### PR TITLE
GUACAMOLE-307: The "size" instruction can also apply to buffers, not just layers.

### DIFF
--- a/src/guacenc/instruction-size.c
+++ b/src/guacenc/instruction-size.c
@@ -38,13 +38,13 @@ int guacenc_handle_size(guacenc_display* display, int argc, char** argv) {
     int width = atoi(argv[1]);
     int height = atoi(argv[2]);
 
-    /* Retrieve requested layer */
-    guacenc_layer* layer = guacenc_display_get_layer(display, index);
-    if (layer == NULL)
+    /* Retrieve requested layer/buffer */
+    guacenc_buffer* buffer = guacenc_display_get_related_buffer(display, index);
+    if (buffer == NULL)
         return 1;
 
-    /* Resize layer */
-    return guacenc_buffer_resize(layer->buffer, width, height);
+    /* Resize layer/buffer */
+    return guacenc_buffer_resize(buffer, width, height);
 
 }
 


### PR DESCRIPTION
When running the guacenc utility against Guacamole session recordings, the following warning is sometimes repeatedly printed while the video is encoded:

    guacenc: WARNING: Layer index out of bounds: -1

This warning is coming from `guacenc_display_get_layer()`, a function used within guacenc to retrieve the layer for a given index, within guacenc's implementation of the "size" instruction. Because the "size" instruction can apply to both buffers and layers, calling `guacenc_display_get_layer()` is incorrect. We should instead use `guacenc_display_get_related_buffer()`, which can deal with both buffers and layers.