### PR TITLE
GUACAMOLE-466: using "-" in place of an input file name with guacenc …

### DIFF
--- a/src/guacenc/encode.c
+++ b/src/guacenc/encode.c
@@ -84,38 +84,44 @@ static int guacenc_read_instructions(guacenc_display* display,
 int guacenc_encode(const char* path, const char* out_path, const char* codec,
         int width, int height, int bitrate, bool force) {
 
-    /* Open input file */
-    int fd = open(path, O_RDONLY);
-    if (fd < 0) {
-        guacenc_log(GUAC_LOG_ERROR, "%s: %s", path, strerror(errno));
-        return 1;
+    int fd;
+    if (strcmp(path, "-") != 0) {
+        /* Open input file */
+        fd = open(path, O_RDONLY);
+        if (fd < 0) {
+            guacenc_log(GUAC_LOG_ERROR, "%s: %s", path, strerror(errno));
+            return 1;
+        }
+
+        /* Lock entire input file for reading by the current process */
+        struct flock file_lock = {
+                .l_type   = F_RDLCK,
+                .l_whence = SEEK_SET,
+                .l_start  = 0,
+                .l_len    = 0,
+                .l_pid    = getpid()
+        };
+
+        /* Abort if file cannot be locked for reading */
+        if (!force && fcntl(fd, F_SETLK, &file_lock) == -1) {
+
+            /* Warn if lock cannot be acquired */
+            if (errno == EACCES || errno == EAGAIN)
+                guacenc_log(GUAC_LOG_WARNING, "Refusing to encode in-progress "
+                        "recording \"%s\" (specify the -f option to override "
+                        "this behavior).", path);
+
+            /* Log an error if locking fails in an unexpected way */
+            else
+                guacenc_log(GUAC_LOG_ERROR, "Cannot lock \"%s\" for reading: %s",
+                        path, strerror(errno));
+
+            close(fd);
+            return 1;
+        }
     }
-
-    /* Lock entire input file for reading by the current process */
-    struct flock file_lock = {
-        .l_type   = F_RDLCK,
-        .l_whence = SEEK_SET,
-        .l_start  = 0,
-        .l_len    = 0,
-        .l_pid    = getpid()
-    };
-
-    /* Abort if file cannot be locked for reading */
-    if (!force && fcntl(fd, F_SETLK, &file_lock) == -1) {
-
-        /* Warn if lock cannot be acquired */
-        if (errno == EACCES || errno == EAGAIN)
-            guacenc_log(GUAC_LOG_WARNING, "Refusing to encode in-progress "
-                    "recording \"%s\" (specify the -f option to override "
-                    "this behavior).", path);
-
-        /* Log an error if locking fails in an unexpected way */
-        else
-            guacenc_log(GUAC_LOG_ERROR, "Cannot lock \"%s\" for reading: %s",
-                    path, strerror(errno));
-
-        close(fd);
-        return 1;
+    else {
+        fd = STDIN_FILENO;
     }
 
     /* Allocate display for encoding process */

--- a/src/guacenc/guacenc.c
+++ b/src/guacenc/guacenc.c
@@ -101,7 +101,8 @@ int main(int argc, char* argv[]) {
 
         /* Generate output filename */
         char out_path[4096];
-        int len = snprintf(out_path, sizeof(out_path), "%s.m4v", path);
+        int len = snprintf(out_path, sizeof(out_path), "%s.m4v",
+                strcmp(path, "-") != 0 ? path : GUACENC_DEFAULT_FILENAME);
 
         /* Do not write if filename exceeds maximum length */
         if (len >= sizeof(out_path)) {

--- a/src/guacenc/guacenc.h
+++ b/src/guacenc/guacenc.h
@@ -45,6 +45,11 @@
 #define GUACENC_DEFAULT_BITRATE 2000000
 
 /**
+ * The default file name guacenc will use if stdin is used as input
+ */
+#define GUACENC_DEFAULT_FILENAME "output"
+
+/**
  * The default log level below which no messages should be logged.
  */
 #define GUACENC_DEFAULT_LOG_LEVEL GUAC_LOG_INFO


### PR DESCRIPTION
…will cause guacenc to read data from stdin

This is a really small patch that allows guacenc to read data from stdin rather than just from a file. It follows a common Linux practice of reserving the single "-" character to represent stdin if it's used in place of a filename. It also sets a default output filename "output" in the case that stdin is used instead of a file. For encodes that read from a file, the original filename with a ".m4v" is still used as the output filename.