### PR TITLE
GUACAMOLE-448: Add support for configuring bitmap caching.

### DIFF
--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -72,6 +72,8 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
     "enable-full-window-drag",
     "enable-desktop-composition",
     "enable-menu-animations",
+    "disable-bitmap-caching",
+    "disable-offscreen-caching",
     "preconnection-id",
     "preconnection-blob",
 
@@ -304,6 +306,18 @@ enum RDP_ARGS_IDX {
      * not be animated.
      */
     IDX_ENABLE_MENU_ANIMATIONS,
+
+    /**
+     * "true" if bitmap caching should be disabled, "false" if bitmap caching
+     * should remain enabled.
+     */
+    IDX_DISABLE_BITMAP_CACHING,
+
+    /**
+     * "true" if the offscreen caching should be disabled, false if offscren
+     * caching should remain enabled.
+     */
+    IDX_DISABLE_OFFSCREEN_CACHING,
 
     /**
      * The preconnection ID to send within the preconnection PDU when
@@ -671,6 +685,14 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     settings->menu_animations_enabled =
         guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
                 IDX_ENABLE_MENU_ANIMATIONS, 0);
+
+    settings->disable_bitmap_caching =
+        guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_DISABLE_BITMAP_CACHING, 0);
+
+    settings->disable_offscreen_caching =
+        guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_DISABLE_OFFSCREEN_CACHING, 0);
 
     /* Session color depth */
     settings->color_depth = 
@@ -1305,7 +1327,9 @@ void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp) {
 
     /* Order support */
 #ifdef LEGACY_RDPSETTINGS
-    bitmap_cache = rdp_settings->bitmap_cache;
+    rdp_settings->bitmap_cache = !guac_settings->disable_bitmap_caching;
+    bitmap_cache = !guac_settings->disable_bitmap_caching;
+    rdp_settings->offscreen_bitmap_cache = !guac_settings->disable_offscreen_caching;
     rdp_settings->os_major_type = OSMAJORTYPE_UNSPECIFIED;
     rdp_settings->os_minor_type = OSMINORTYPE_UNSPECIFIED;
     rdp_settings->desktop_resize = TRUE;
@@ -1334,7 +1358,9 @@ void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp) {
     rdp_settings->order_support[NEG_ELLIPSE_SC_INDEX] = FALSE;
     rdp_settings->order_support[NEG_ELLIPSE_CB_INDEX] = FALSE;
 #else
-    bitmap_cache = rdp_settings->BitmapCacheEnabled;
+    rdp_settings->BitmapCacheEnabled = !guac_settings->disable_bitmap_caching;
+    bitmap_cache = !guac_settings->disable_bitmap_caching;
+    rdp_settings->OffscreenSupportLevel = !guac_settings->disable_offscreen_caching;
     rdp_settings->OsMajorType = OSMAJORTYPE_UNSPECIFIED;
     rdp_settings->OsMinorType = OSMINORTYPE_UNSPECIFIED;
     rdp_settings->DesktopResize = TRUE;

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -74,6 +74,7 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
     "enable-menu-animations",
     "disable-bitmap-caching",
     "disable-offscreen-caching",
+    "disable-glyph-caching",
     "preconnection-id",
     "preconnection-blob",
 
@@ -318,6 +319,12 @@ enum RDP_ARGS_IDX {
      * caching should remain enabled.
      */
     IDX_DISABLE_OFFSCREEN_CACHING,
+
+    /**
+     * "true" if glyph caching should be disabled, false if glyph caching should
+     * remain enabled.
+     */
+    IDX_DISABLE_GLYPH_CACHING,
 
     /**
      * The preconnection ID to send within the preconnection PDU when
@@ -694,6 +701,10 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
         guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
                 IDX_DISABLE_OFFSCREEN_CACHING, 0);
 
+    settings->disable_glyph_caching =
+        guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_DISABLE_GLYPH_CACHING, 0);
+
     /* Session color depth */
     settings->color_depth = 
         guac_user_parse_args_int(user, GUAC_RDP_CLIENT_ARGS, argv,
@@ -1063,7 +1074,7 @@ static char* guac_rdp_strdup(const char* str) {
 
 void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp) {
 
-    BOOL bitmap_cache;
+    BOOL bitmap_cache = !guac_settings->disable_bitmap_caching;
     rdpSettings* rdp_settings = rdp->settings;
 
     /* Authentication */
@@ -1327,9 +1338,9 @@ void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp) {
 
     /* Order support */
 #ifdef LEGACY_RDPSETTINGS
-    rdp_settings->bitmap_cache = !guac_settings->disable_bitmap_caching;
-    bitmap_cache = !guac_settings->disable_bitmap_caching;
+    rdp_settings->bitmap_cache = bitmap_cache;
     rdp_settings->offscreen_bitmap_cache = !guac_settings->disable_offscreen_caching;
+    rdp_settings->glyph_cache = !guac_settings->disable_glyph_caching;
     rdp_settings->os_major_type = OSMAJORTYPE_UNSPECIFIED;
     rdp_settings->os_minor_type = OSMINORTYPE_UNSPECIFIED;
     rdp_settings->desktop_resize = TRUE;
@@ -1358,9 +1369,9 @@ void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp) {
     rdp_settings->order_support[NEG_ELLIPSE_SC_INDEX] = FALSE;
     rdp_settings->order_support[NEG_ELLIPSE_CB_INDEX] = FALSE;
 #else
-    rdp_settings->BitmapCacheEnabled = !guac_settings->disable_bitmap_caching;
-    bitmap_cache = !guac_settings->disable_bitmap_caching;
+    rdp_settings->BitmapCacheEnabled = bitmap_cache;
     rdp_settings->OffscreenSupportLevel = !guac_settings->disable_offscreen_caching;
+    rdp_settings->GlyphSupportLevel = !guac_settings->disable_glyph_caching ? GLYPH_SUPPORT_FULL : GLYPH_SUPPORT_NONE;
     rdp_settings->OsMajorType = OSMAJORTYPE_UNSPECIFIED;
     rdp_settings->OsMinorType = OSMINORTYPE_UNSPECIFIED;
     rdp_settings->DesktopResize = TRUE;

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -300,6 +300,18 @@ typedef struct guac_rdp_settings {
     int menu_animations_enabled;
 
     /**
+     * Whether bitmap caching should be disabled.  By default it is
+     * enabled - this allows users to explicitly disable it.
+     */
+    int disable_bitmap_caching;
+
+    /**
+     * Whether offscreen caching should be disabled.  By default it is
+     * enabled - this allows users to explicitly disable it.
+     */
+    int disable_offscreen_caching;
+
+    /**
      * The preconnection ID to send within the preconnection PDU when
      * initiating an RDP connection, if any. If no preconnection ID is
      * specified, this will be -1.

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -312,6 +312,12 @@ typedef struct guac_rdp_settings {
     int disable_offscreen_caching;
 
     /**
+     * Whether glyph caching should be disabled.  By default it is enabled
+     * - this allows users to explicitly disable it.
+     */
+    int disable_glyph_caching;
+
+    /**
      * The preconnection ID to send within the preconnection PDU when
      * initiating an RDP connection, if any. If no preconnection ID is
      * specified, this will be -1.


### PR DESCRIPTION
This change adds support for disabling bitmap caching and offscreen caching, which are enabled by FreeRDP by default.