### PR TITLE
GUACAMOLE-481: Add Turkish Q keymap for RDP

### DIFF
--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -258,7 +258,8 @@ rdp_keymaps =                   \
     $(srcdir)/keymaps/it_it_qwerty.keymap \
     $(srcdir)/keymaps/ja_jp_qwerty.keymap \
     $(srcdir)/keymaps/pt_br_qwerty.keymap \
-    $(srcdir)/keymaps/sv_se_qwerty.keymap
+    $(srcdir)/keymaps/sv_se_qwerty.keymap \
+    $(srcdir)/keymaps/tr_tr_qwerty.keymap
 
 _generated_keymaps.c: $(rdp_keymaps)
 	$(srcdir)/keymaps/generate.pl $(rdp_keymaps)

--- a/src/protocols/rdp/keymaps/tr_tr_qwerty.keymap
+++ b/src/protocols/rdp/keymaps/tr_tr_qwerty.keymap
@@ -1,0 +1,78 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+parent  "base"
+name    "tr-tr-qwerty"
+freerdp "KBD_TURKISH_Q"
+
+#
+# Basic keys
+#
+
+map -altgr -shift 0x29 0x02..0x0D      ~ ""1234567890*-"
+map -altgr -shift      0x10..0x1B      ~ "qwertyuıopğü"
+map -altgr -shift      0x1E..0x28 0x2B ~ "asdfghjklşi,"
+map -altgr -shift 0x56 0x2C..0x35      ~ "<zxcvbnmöç."
+
+map -altgr +shift 0x29 0x02..0x03      ~ "é!'"
+map -altgr +shift      0x05..0x0D      ~ "+%&/()=?_"
+map -altgr +shift      0x10..0x1B      ~ "QWERTYUIOPĞÜ"
+map -altgr +shift      0x1E..0x28 0x2B ~ "ASDFGHJKLŞİ;"
+map -altgr +shift 0x56 0x2C..0x35      ~ ">ZXCVBNMÖÇ:"
+
+
+#
+# Keys requiring AltGr
+#
+
+map +altgr -shift 0x29 0x02..0x06      ~ "<>£#$½"
+map +altgr -shift      0x08..0x0D      ~ "{[]}\|"
+
+map +altgr -shift 0x10 ~ "@"
+map +altgr -shift 0x12 ~ "€"
+map +altgr -shift 0x14 ~ "₺"
+map +altgr -shift 0x17 ~ "i"
+
+map +altgr -shift 0x1E ~ "æ"
+map +altgr -shift 0x1F ~ "ß"
+
+map +altgr -shift 0x56 ~ "|"
+
+
+#
+# Keys requiring AltGr & Shift
+#
+
+map +altgr +shift 0x17 ~ "İ"
+
+map +altgr +shift 0x1E ~ "Æ"
+
+#
+# Dead keys
+#
+
+map -altgr +shift 0x04 ~ 0xFE52 # Dead circumflex
+
+map +altgr -shift 0x1A ~ 0xFE57 # Dead diaeresis (umlaut)
+map +altgr -shift 0x1B ~ 0xFE53 # Dead tilde
+
+map +altgr -shift 0x27 ~ 0xFE51 # Dead acute
+map +altgr -shift 0x2B ~ 0xFE50 # Dead grave
+
+# END


### PR DESCRIPTION
I've created tr_tr_qwerty.keymap according to Turkish Q keyboard layout. I have tested this over FreeRDP with a Windows machine, everything seems to be working fine.