### PR TITLE
GUACAMOLE-313: Add support for logging mouse cursor information

### DIFF
--- a/src/common/common/cursor.h
+++ b/src/common/common/cursor.h
@@ -103,6 +103,21 @@ typedef struct guac_common_cursor {
     int y;
 
     /**
+     * An integer value representing the current state of each button, where
+     * the Nth bit within the integer is set to 1 if and only if the Nth mouse
+     * button is currently pressed. The lowest-order bit is the left mouse
+     * button, followed by the middle button, right button, and finally the up
+     * and down buttons of the scroll wheel.
+     *
+     * @see GUAC_CLIENT_MOUSE_LEFT
+     * @see GUAC_CLIENT_MOUSE_MIDDLE
+     * @see GUAC_CLIENT_MOUSE_RIGHT
+     * @see GUAC_CLIENT_MOUSE_SCROLL_UP
+     * @see GUAC_CLIENT_MOUSE_SCROLL_DOWN
+     */
+    int button_mask;
+
+    /**
      * The server timestamp representing the point in time when the mousr
      * location was last updated.
      */
@@ -148,12 +163,12 @@ void guac_common_cursor_dup(guac_common_cursor* cursor, guac_user* user,
         guac_socket* socket);
 
 /**
- * Moves the mouse cursor, marking the given user as the most recent user of
- * the mouse. The remote mouse cursor will be hidden for this user and shown
- * for all others.
+ * Updates the current position and button state of the mouse cursor, marking
+ * the given user as the most recent user of the mouse. The remote mouse cursor
+ * will be hidden for this user and shown for all others.
  *
  * @param cursor
- *     The cursor being moved.
+ *     The cursor being updated.
  *
  * @param user
  *     The user that moved the cursor.
@@ -163,9 +178,22 @@ void guac_common_cursor_dup(guac_common_cursor* cursor, guac_user* user,
  *
  * @param y
  *     The new Y coordinate of the cursor.
+ *
+ * @param button_mask
+ *     An integer value representing the current state of each button, where
+ *     the Nth bit within the integer is set to 1 if and only if the Nth mouse
+ *     button is currently pressed. The lowest-order bit is the left mouse
+ *     button, followed by the middle button, right button, and finally the up
+ *     and down buttons of the scroll wheel.
+ *
+ *     @see GUAC_CLIENT_MOUSE_LEFT
+ *     @see GUAC_CLIENT_MOUSE_MIDDLE
+ *     @see GUAC_CLIENT_MOUSE_RIGHT
+ *     @see GUAC_CLIENT_MOUSE_SCROLL_UP
+ *     @see GUAC_CLIENT_MOUSE_SCROLL_DOWN
  */
-void guac_common_cursor_move(guac_common_cursor* cursor, guac_user* user,
-        int x, int y);
+void guac_common_cursor_update(guac_common_cursor* cursor, guac_user* user,
+        int x, int y, int button_mask);
 
 /**
  * Sets the cursor image to the given raw image data. This raw image data must

--- a/src/common/common/cursor.h
+++ b/src/common/common/cursor.h
@@ -102,6 +102,12 @@ typedef struct guac_common_cursor {
      */
     int y;
 
+    /**
+     * The server timestamp representing the point in time when the mousr
+     * location was last updated.
+     */
+    guac_timestamp timestamp;
+
 } guac_common_cursor;
 
 /**

--- a/src/common/common/recording.h
+++ b/src/common/common/recording.h
@@ -43,6 +43,21 @@
 #define GUAC_COMMON_RECORDING_MAX_NAME_LENGTH 2048
 
 /**
+ * An in-progress session recording, attached to a guac_client instance such
+ * that output Guacamole instructions may be dynamically intercepted and
+ * written to a file.
+ */
+typedef struct guac_common_recording {
+
+    /**
+     * The guac_socket which writes directly to the recording file, rather than
+     * to any particular user.
+     */
+    guac_socket* socket;
+
+} guac_common_recording;
+
+/**
  * Replaces the socket of the given client such that all further Guacamole
  * protocol output will be copied into a file within the given path and having
  * the given name. If the create_path flag is non-zero, the given path will be
@@ -68,11 +83,23 @@
  *     exist.
  *
  * @return
- *     Zero if the recording file has been successfully created and a recording
- *     will be written, non-zero otherwise.
+ *     A new guac_common_recording structure representing the in-progress
+ *     recording if the recording file has been successfully created and a
+ *     recording will be written, NULL otherwise.
  */
-int guac_common_recording_create(guac_client* client, const char* path,
-        const char* name, int create_path);
+guac_common_recording* guac_common_recording_create(guac_client* client,
+        const char* path, const char* name, int create_path);
+
+/**
+ * Frees the resources associated with the given in-progress recording. Note
+ * that, due to the manner that recordings are attached to the guac_client, the
+ * underlying guac_socket is not freed. The guac_socket will be automatically
+ * freed when the guac_client is freed.
+ *
+ * @param recording
+ *     The guac_common_recording to free.
+ */
+void guac_common_recording_free(guac_common_recording* recording);
 
 #endif
 

--- a/src/common/common/recording.h
+++ b/src/common/common/recording.h
@@ -102,7 +102,7 @@ guac_common_recording* guac_common_recording_create(guac_client* client,
 void guac_common_recording_free(guac_common_recording* recording);
 
 /**
- * Reports the current mouse position within the recording.
+ * Reports the current mouse position and button state within the recording.
  *
  * @param recording
  *     The guac_common_recording associated with the mouse that has moved.
@@ -112,9 +112,22 @@ void guac_common_recording_free(guac_common_recording* recording);
  *
  * @param y
  *     The new Y coordinate of the mouse cursor, in pixels.
+ *
+ * @param button_mask
+ *     An integer value representing the current state of each button, where
+ *     the Nth bit within the integer is set to 1 if and only if the Nth mouse
+ *     button is currently pressed. The lowest-order bit is the left mouse
+ *     button, followed by the middle button, right button, and finally the up
+ *     and down buttons of the scroll wheel.
+ *
+ *     @see GUAC_CLIENT_MOUSE_LEFT
+ *     @see GUAC_CLIENT_MOUSE_MIDDLE
+ *     @see GUAC_CLIENT_MOUSE_RIGHT
+ *     @see GUAC_CLIENT_MOUSE_SCROLL_UP
+ *     @see GUAC_CLIENT_MOUSE_SCROLL_DOWN
  */
 void guac_common_recording_report_mouse(guac_common_recording* recording,
-        int x, int y);
+        int x, int y, int button_mask);
 
 #endif
 

--- a/src/common/common/recording.h
+++ b/src/common/common/recording.h
@@ -101,5 +101,20 @@ guac_common_recording* guac_common_recording_create(guac_client* client,
  */
 void guac_common_recording_free(guac_common_recording* recording);
 
+/**
+ * Reports the current mouse position within the recording.
+ *
+ * @param recording
+ *     The guac_common_recording associated with the mouse that has moved.
+ *
+ * @param x
+ *     The new X coordinate of the mouse cursor, in pixels.
+ *
+ * @param y
+ *     The new Y coordinate of the mouse cursor, in pixels.
+ */
+void guac_common_recording_report_mouse(guac_common_recording* recording,
+        int x, int y);
+
 #endif
 

--- a/src/common/recording.c
+++ b/src/common/recording.c
@@ -22,6 +22,7 @@
 #include <guacamole/client.h>
 #include <guacamole/protocol.h>
 #include <guacamole/socket.h>
+#include <guacamole/timestamp.h>
 
 #ifdef __MINGW32__
 #include <direct.h>
@@ -182,7 +183,8 @@ void guac_common_recording_report_mouse(guac_common_recording* recording,
         int x, int y) {
 
     /* Report mouse location */
-    guac_protocol_send_mouse(recording->socket, x, y);
+    guac_protocol_send_mouse(recording->socket, x, y,
+            guac_timestamp_current());
 
 }
 

--- a/src/common/recording.c
+++ b/src/common/recording.c
@@ -180,10 +180,10 @@ void guac_common_recording_free(guac_common_recording* recording) {
 }
 
 void guac_common_recording_report_mouse(guac_common_recording* recording,
-        int x, int y) {
+        int x, int y, int button_mask) {
 
     /* Report mouse location */
-    guac_protocol_send_mouse(recording->socket, x, y,
+    guac_protocol_send_mouse(recording->socket, x, y, button_mask,
             guac_timestamp_current());
 
 }

--- a/src/common/recording.c
+++ b/src/common/recording.c
@@ -20,6 +20,7 @@
 #include "common/recording.h"
 
 #include <guacamole/client.h>
+#include <guacamole/protocol.h>
 #include <guacamole/socket.h>
 
 #ifdef __MINGW32__
@@ -175,5 +176,13 @@ guac_common_recording* guac_common_recording_create(guac_client* client,
 
 void guac_common_recording_free(guac_common_recording* recording) {
     free(recording);
+}
+
+void guac_common_recording_report_mouse(guac_common_recording* recording,
+        int x, int y) {
+
+    /* Report mouse location */
+    guac_protocol_send_mouse(recording->socket, x, y);
+
 }
 

--- a/src/guacenc/Makefile.am
+++ b/src/guacenc/Makefile.am
@@ -26,6 +26,7 @@ man_MANS =        \
 
 noinst_HEADERS =    \
     buffer.h        \
+    cursor.h        \
     display.h       \
     encode.h        \
     ffmpeg-compat.h \
@@ -41,6 +42,7 @@ noinst_HEADERS =    \
 
 guacenc_SOURCES =           \
     buffer.c                \
+    cursor.c                \
     display.c               \
     display-buffers.c       \
     display-image-streams.c \

--- a/src/guacenc/Makefile.am
+++ b/src/guacenc/Makefile.am
@@ -61,6 +61,7 @@ guacenc_SOURCES =           \
     instruction-dispose.c   \
     instruction-end.c       \
     instruction-img.c       \
+    instruction-mouse.c     \
     instruction-move.c      \
     instruction-rect.c      \
     instruction-shade.c     \

--- a/src/guacenc/cursor.c
+++ b/src/guacenc/cursor.c
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+#include "buffer.h"
+#include "cursor.h"
+
+#include <stdlib.h>
+
+guacenc_cursor* guacenc_cursor_alloc() {
+
+    /* Allocate new cursor */
+    guacenc_cursor* cursor = (guacenc_cursor*) calloc(1,
+            sizeof(guacenc_cursor));
+    if (cursor == NULL)
+        return NULL;
+
+    /* Allocate associated buffer (image) */
+    cursor->buffer = guacenc_buffer_alloc();
+    if (cursor->buffer == NULL) {
+        free(cursor);
+        return NULL;
+    }
+
+    return cursor;
+
+}
+
+void guacenc_cursor_free(guacenc_cursor* cursor) {
+
+    /* Ignore NULL cursors */
+    if (cursor == NULL)
+        return;
+
+    /* Free underlying buffer */
+    guacenc_buffer_free(cursor->buffer);
+
+    free(cursor);
+
+}
+

--- a/src/guacenc/cursor.c
+++ b/src/guacenc/cursor.c
@@ -26,8 +26,7 @@
 guacenc_cursor* guacenc_cursor_alloc() {
 
     /* Allocate new cursor */
-    guacenc_cursor* cursor = (guacenc_cursor*) calloc(1,
-            sizeof(guacenc_cursor));
+    guacenc_cursor* cursor = (guacenc_cursor*) malloc(sizeof(guacenc_cursor));
     if (cursor == NULL)
         return NULL;
 
@@ -37,6 +36,9 @@ guacenc_cursor* guacenc_cursor_alloc() {
         free(cursor);
         return NULL;
     }
+
+    /* Do not initially render cursor, unless it moves */
+    cursor->x = cursor->y = -1;
 
     return cursor;
 

--- a/src/guacenc/cursor.h
+++ b/src/guacenc/cursor.h
@@ -33,12 +33,16 @@
 typedef struct guacenc_cursor {
 
     /**
-     * The current X coordinate of the mouse cursor, in pixels.
+     * The current X coordinate of the mouse cursor, in pixels. Valid values
+     * are non-negative. Negative values indicate that the cursor should not
+     * be rendered.
      */
     int x;
 
     /**
-     * The current Y coordinate of the mouse cursor, in pixels.
+     * The current Y coordinate of the mouse cursor, in pixels. Valid values
+     * are non-negative. Negative values indicate that the cursor should not
+     * be rendered.
      */
     int y;
 

--- a/src/guacenc/cursor.h
+++ b/src/guacenc/cursor.h
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUACENC_CURSOR_H
+#define GUACENC_CURSOR_H
+
+#include "config.h"
+#include "buffer.h"
+
+#include <guacamole/protocol.h>
+#include <guacamole/timestamp.h>
+
+/**
+ * A mouse cursor, having a current location, hostspot, and associated cursor
+ * image.
+ */
+typedef struct guacenc_cursor {
+
+    /**
+     * The current X coordinate of the mouse cursor, in pixels.
+     */
+    int x;
+
+    /**
+     * The current Y coordinate of the mouse cursor, in pixels.
+     */
+    int y;
+
+    /**
+     * The X coordinate of the mouse cursor hotspot within the cursor image,
+     * in pixels.
+     */
+    int hotspot_x;
+
+    /**
+     * The Y coordinate of the mouse cursor hotspot within the cursor image,
+     * in pixels.
+     */
+    int hotspot_y;
+
+    /**
+     * The current mouse cursor image.
+     */
+    guacenc_buffer* buffer;
+
+} guacenc_cursor;
+
+/**
+ * Allocates and initializes a new cursor object.
+ *
+ * @return
+ *     A newly-allocated and initialized guacenc_cursor, or NULL if allocation
+ *     fails.
+ */
+guacenc_cursor* guacenc_cursor_alloc();
+
+/**
+ * Frees all memory associated with the given cursor object. If the cursor
+ * provided is NULL, this function has no effect.
+ *
+ * @param cursor
+ *     The cursor to free, which may be NULL.
+ */
+void guacenc_cursor_free(guacenc_cursor* cursor);
+
+#endif
+

--- a/src/guacenc/display-flatten.c
+++ b/src/guacenc/display-flatten.c
@@ -93,6 +93,10 @@ static int guacenc_display_render_cursor(guacenc_display* display) {
 
     guacenc_cursor* cursor = display->cursor;
 
+    /* Do not render cursor if coordinates are negative */
+    if (cursor->x < 0 || cursor->y < 0)
+        return 0;
+
     /* Retrieve default layer (guaranteed to not be NULL) */
     guacenc_layer* def_layer = guacenc_display_get_layer(display, 0);
     assert(def_layer != NULL);

--- a/src/guacenc/display-flatten.c
+++ b/src/guacenc/display-flatten.c
@@ -20,9 +20,12 @@
 #include "config.h"
 #include "display.h"
 #include "layer.h"
+#include "log.h"
 
 #include <cairo/cairo.h>
+#include <guacamole/client.h>
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -72,6 +75,46 @@ static int guacenc_display_layer_comparator(const void* a, const void* b) {
 
     /* Order sibling layers according to descending Z */
     return layer_b->z - layer_a->z;
+
+}
+
+/**
+ * Renders the mouse cursor on top of the frame buffer of the default layer of
+ * the given display.
+ *
+ * @param display
+ *     The display whose mouse cursor should be rendered to the frame buffer
+ *     of its default layer.
+ *
+ * @return
+ *     Zero if rendering succeeds, non-zero otherwise.
+ */
+static int guacenc_display_render_cursor(guacenc_display* display) {
+
+    guacenc_cursor* cursor = display->cursor;
+
+    /* Retrieve default layer (guaranteed to not be NULL) */
+    guacenc_layer* def_layer = guacenc_display_get_layer(display, 0);
+    assert(def_layer != NULL);
+
+    /* Get source and destination buffers */
+    guacenc_buffer* src = cursor->buffer;
+    guacenc_buffer* dst = def_layer->frame;
+
+    /* Render cursor to layer */
+    if (src->width > 0 && src->height > 0) {
+        cairo_set_source_surface(dst->cairo, src->surface,
+                cursor->x - cursor->hotspot_x,
+                cursor->y - cursor->hotspot_y);
+        cairo_rectangle(dst->cairo,
+                cursor->x - cursor->hotspot_x,
+                cursor->y - cursor->hotspot_y,
+                src->width, src->height);
+        cairo_fill(dst->cairo);
+    }
+
+    /* Always succeeds */
+    return 0;
 
 }
 
@@ -151,7 +194,8 @@ int guacenc_display_flatten(guacenc_display* display) {
 
     }
 
-    return 0;
+    /* Render cursor on top of everything else */
+    return guacenc_display_render_cursor(display);
 
 }
 

--- a/src/guacenc/display.c
+++ b/src/guacenc/display.c
@@ -18,6 +18,7 @@
  */
 
 #include "config.h"
+#include "cursor.h"
 #include "display.h"
 #include "video.h"
 
@@ -97,6 +98,9 @@ guacenc_display* guacenc_display_alloc(const char* path, const char* codec,
     /* Associate display with video output */
     display->output = video;
 
+    /* Allocate special-purpose cursor layer */
+    display->cursor = guacenc_cursor_alloc();
+
     return display;
 
 }
@@ -123,6 +127,9 @@ int guacenc_display_free(guacenc_display* display) {
     /* Free all streams */
     for (i = 0; i < GUACENC_DISPLAY_MAX_STREAMS; i++)
         guacenc_image_stream_free(display->image_streams[i]);
+
+    /* Free cursor */
+    guacenc_cursor_free(display->cursor);
 
     free(display);
     return retval;

--- a/src/guacenc/display.h
+++ b/src/guacenc/display.h
@@ -22,10 +22,12 @@
 
 #include "config.h"
 #include "buffer.h"
+#include "cursor.h"
 #include "image-stream.h"
 #include "layer.h"
 #include "video.h"
 
+#include <cairo/cairo.h>
 #include <guacamole/protocol.h>
 #include <guacamole/timestamp.h>
 
@@ -51,6 +53,11 @@
  * The current state of the Guacamole video encoder's internal display.
  */
 typedef struct guacenc_display {
+
+    /**
+     * The current mouse cursor state.
+     */
+    guacenc_cursor* cursor;
 
     /**
      * All currently-allocated buffers. The index of the buffer corresponds to

--- a/src/guacenc/instruction-mouse.c
+++ b/src/guacenc/instruction-mouse.c
@@ -45,11 +45,11 @@ int guacenc_handle_mouse(guacenc_display* display, int argc, char** argv) {
     cursor->y = y;
 
     /* If no timestamp provided, nothing further to do */
-    if (argc < 3)
+    if (argc < 4)
         return 0;
 
     /* Leverage timestamp to render frame */
-    guac_timestamp timestamp = guacenc_parse_timestamp(argv[2]);
+    guac_timestamp timestamp = guacenc_parse_timestamp(argv[3]);
     return guacenc_display_sync(display, timestamp);
 
 }

--- a/src/guacenc/instruction-mouse.c
+++ b/src/guacenc/instruction-mouse.c
@@ -21,6 +21,7 @@
 #include "cursor.h"
 #include "display.h"
 #include "log.h"
+#include "parse.h"
 
 #include <guacamole/client.h>
 
@@ -43,7 +44,13 @@ int guacenc_handle_mouse(guacenc_display* display, int argc, char** argv) {
     cursor->x = x;
     cursor->y = y;
 
-    return 0;
+    /* If no timestamp provided, nothing further to do */
+    if (argc < 3)
+        return 0;
+
+    /* Leverage timestamp to render frame */
+    guac_timestamp timestamp = guacenc_parse_timestamp(argv[2]);
+    return guacenc_display_sync(display, timestamp);
 
 }
 

--- a/src/guacenc/instruction-mouse.c
+++ b/src/guacenc/instruction-mouse.c
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+#include "cursor.h"
+#include "display.h"
+#include "log.h"
+
+#include <guacamole/client.h>
+
+#include <stdlib.h>
+
+int guacenc_handle_mouse(guacenc_display* display, int argc, char** argv) {
+
+    /* Verify argument count */
+    if (argc < 2) {
+        guacenc_log(GUAC_LOG_WARNING, "\"mouse\" instruction incomplete");
+        return 1;
+    }
+
+    /* Parse arguments */
+    int x = atoi(argv[0]);
+    int y = atoi(argv[1]);
+
+    /* Update cursor properties */
+    guacenc_cursor* cursor = display->cursor;
+    cursor->x = x;
+    cursor->y = y;
+
+    return 0;
+
+}
+

--- a/src/guacenc/instruction-sync.c
+++ b/src/guacenc/instruction-sync.c
@@ -20,46 +20,13 @@
 #include "config.h"
 #include "display.h"
 #include "log.h"
+#include "parse.h"
 
 #include <guacamole/client.h>
 #include <guacamole/timestamp.h>
 
 #include <inttypes.h>
 #include <stdlib.h>
-
-/**
- * Parses a guac_timestamp from the given string. The string is assumed to
- * consist solely of decimal digits with an optional leading minus sign. If the
- * given string contains other characters, the behavior of this function is
- * undefined.
- *
- * @param str
- *     The string to parse, which must contain only decimal digits and an
- *     optional leading minus sign.
- *
- * @return
- *     A guac_timestamp having the same value as the provided string.
- */
-static guac_timestamp guacenc_parse_timestamp(const char* str) {
-
-    int sign = 1;
-    int64_t num = 0;
-
-    for (; *str != '\0'; str++) {
-
-        /* Flip sign for each '-' encountered */
-        if (*str == '-')
-            sign = -sign;
-
-        /* If not '-', assume the character is a digit */
-        else
-            num = num * 10 + (*str - '0');
-
-    }
-
-    return (guac_timestamp) (num * sign);
-
-}
 
 int guacenc_handle_sync(guacenc_display* display, int argc, char** argv) {
 

--- a/src/guacenc/instructions.c
+++ b/src/guacenc/instructions.c
@@ -30,6 +30,7 @@ guacenc_instruction_handler_mapping guacenc_instruction_handler_map[] = {
     {"blob",     guacenc_handle_blob},
     {"img",      guacenc_handle_img},
     {"end",      guacenc_handle_end},
+    {"mouse",    guacenc_handle_mouse},
     {"sync",     guacenc_handle_sync},
     {"cursor",   guacenc_handle_cursor},
     {"copy",     guacenc_handle_copy},

--- a/src/guacenc/instructions.h
+++ b/src/guacenc/instructions.h
@@ -115,6 +115,11 @@ guacenc_instruction_handler guacenc_handle_img;
 guacenc_instruction_handler guacenc_handle_end;
 
 /**
+ * Handler for the Guacamole "mouse" instruction.
+ */
+guacenc_instruction_handler guacenc_handle_mouse;
+
+/**
  * Handler for the Guacamole "sync" instruction.
  */
 guacenc_instruction_handler guacenc_handle_sync;

--- a/src/guacenc/parse.c
+++ b/src/guacenc/parse.c
@@ -19,6 +19,8 @@
 
 #include "config.h"
 
+#include <guacamole/timestamp.h>
+
 #include <errno.h>
 #include <limits.h>
 #include <string.h>
@@ -64,6 +66,27 @@ int guacenc_parse_dimensions(char* arg, int* width, int* height) {
     *height = h;
 
     return 0;
+
+}
+
+guac_timestamp guacenc_parse_timestamp(const char* str) {
+
+    int sign = 1;
+    int64_t num = 0;
+
+    for (; *str != '\0'; str++) {
+
+        /* Flip sign for each '-' encountered */
+        if (*str == '-')
+            sign = -sign;
+
+        /* If not '-', assume the character is a digit */
+        else
+            num = num * 10 + (*str - '0');
+
+    }
+
+    return (guac_timestamp) (num * sign);
 
 }
 

--- a/src/guacenc/parse.h
+++ b/src/guacenc/parse.h
@@ -22,6 +22,8 @@
 
 #include "config.h"
 
+#include <guacamole/timestamp.h>
+
 /**
  * Parses a string into a single integer. Only positive integers are accepted.
  * The input string may be modified during parsing. A value will be stored in
@@ -62,6 +64,21 @@ int guacenc_parse_int(char* arg, int* i);
  *     invalid.
  */
 int guacenc_parse_dimensions(char* arg, int* width, int* height);
+
+/**
+ * Parses a guac_timestamp from the given string. The string is assumed to
+ * consist solely of decimal digits with an optional leading minus sign. If the
+ * given string contains other characters, the behavior of this function is
+ * undefined.
+ *
+ * @param str
+ *     The string to parse, which must contain only decimal digits and an
+ *     optional leading minus sign.
+ *
+ * @return
+ *     A guac_timestamp having the same value as the provided string.
+ */
+guac_timestamp guacenc_parse_timestamp(const char* str);
 
 #endif
 

--- a/src/libguac/guacamole/protocol.h
+++ b/src/libguac/guacamole/protocol.h
@@ -159,10 +159,15 @@ int vguac_protocol_send_log(guac_socket* socket, const char* format,
  * @param y
  *     The Y coordinate of the current mouse position.
  *
+ * @param timestamp
+ *     The server timestamp (in milliseconds) at the point in time this mouse
+ *     position was acknowledged.
+ *
  * @return
  *     Zero on success, non-zero on error.
  */
-int guac_protocol_send_mouse(guac_socket* socket, int x, int y);
+int guac_protocol_send_mouse(guac_socket* socket, int x, int y,
+        guac_timestamp timestamp);
 
 /**
  * Sends a nest instruction over the given guac_socket connection.

--- a/src/libguac/guacamole/protocol.h
+++ b/src/libguac/guacamole/protocol.h
@@ -159,6 +159,19 @@ int vguac_protocol_send_log(guac_socket* socket, const char* format,
  * @param y
  *     The Y coordinate of the current mouse position.
  *
+ * @param button_mask
+ *     An integer value representing the current state of each button, where
+ *     the Nth bit within the integer is set to 1 if and only if the Nth mouse
+ *     button is currently pressed. The lowest-order bit is the left mouse
+ *     button, followed by the middle button, right button, and finally the up
+ *     and down buttons of the scroll wheel.
+ *
+ *     @see GUAC_CLIENT_MOUSE_LEFT
+ *     @see GUAC_CLIENT_MOUSE_MIDDLE
+ *     @see GUAC_CLIENT_MOUSE_RIGHT
+ *     @see GUAC_CLIENT_MOUSE_SCROLL_UP
+ *     @see GUAC_CLIENT_MOUSE_SCROLL_DOWN
+ *
  * @param timestamp
  *     The server timestamp (in milliseconds) at the point in time this mouse
  *     position was acknowledged.
@@ -167,7 +180,7 @@ int vguac_protocol_send_log(guac_socket* socket, const char* format,
  *     Zero on success, non-zero on error.
  */
 int guac_protocol_send_mouse(guac_socket* socket, int x, int y,
-        guac_timestamp timestamp);
+        int button_mask, guac_timestamp timestamp);
 
 /**
  * Sends a nest instruction over the given guac_socket connection.

--- a/src/libguac/protocol.c
+++ b/src/libguac/protocol.c
@@ -685,7 +685,7 @@ int guac_protocol_send_lstroke(guac_socket* socket,
 }
 
 int guac_protocol_send_mouse(guac_socket* socket, int x, int y,
-        guac_timestamp timestamp) {
+        int button_mask, guac_timestamp timestamp) {
 
     int ret_val;
 
@@ -695,6 +695,8 @@ int guac_protocol_send_mouse(guac_socket* socket, int x, int y,
         || __guac_socket_write_length_int(socket, x)
         || guac_socket_write_string(socket, ",")
         || __guac_socket_write_length_int(socket, y)
+        || guac_socket_write_string(socket, ",")
+        || __guac_socket_write_length_int(socket, button_mask)
         || guac_socket_write_string(socket, ",")
         || __guac_socket_write_length_int(socket, timestamp)
         || guac_socket_write_string(socket, ";");

--- a/src/libguac/protocol.c
+++ b/src/libguac/protocol.c
@@ -684,7 +684,8 @@ int guac_protocol_send_lstroke(guac_socket* socket,
 
 }
 
-int guac_protocol_send_mouse(guac_socket* socket, int x, int y) {
+int guac_protocol_send_mouse(guac_socket* socket, int x, int y,
+        guac_timestamp timestamp) {
 
     int ret_val;
 
@@ -694,6 +695,8 @@ int guac_protocol_send_mouse(guac_socket* socket, int x, int y) {
         || __guac_socket_write_length_int(socket, x)
         || guac_socket_write_string(socket, ",")
         || __guac_socket_write_length_int(socket, y)
+        || guac_socket_write_string(socket, ",")
+        || __guac_socket_write_length_int(socket, timestamp)
         || guac_socket_write_string(socket, ";");
 
     guac_socket_instruction_end(socket);

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include "audio_input.h"
+#include "common/recording.h"
 #include "client.h"
 #include "rdp.h"
 #include "rdp_disp.h"
@@ -121,6 +122,10 @@ int guac_rdp_client_free_handler(guac_client* client) {
 
     guac_common_ssh_uninit();
 #endif
+
+    /* Clean up recording, if in progress */
+    if (rdp_client->recording != NULL)
+        guac_common_recording_free(rdp_client->recording);
 
     /* Clean up audio stream, if allocated */
     if (rdp_client->audio != NULL)

--- a/src/protocols/rdp/input.c
+++ b/src/protocols/rdp/input.c
@@ -47,12 +47,12 @@ int guac_rdp_user_mouse_handler(guac_user* user, int x, int y, int mask) {
         return 0;
     }
 
-    /* Store current mouse location */
-    guac_common_cursor_move(rdp_client->display->cursor, user, x, y);
+    /* Store current mouse location/state */
+    guac_common_cursor_update(rdp_client->display->cursor, user, x, y, mask);
 
     /* Report mouse position within recording */
     if (rdp_client->recording != NULL)
-        guac_common_recording_report_mouse(rdp_client->recording, x, y);
+        guac_common_recording_report_mouse(rdp_client->recording, x, y, mask);
 
     /* If button mask unchanged, just send move event */
     if (mask == rdp_client->mouse_button_mask)

--- a/src/protocols/rdp/input.c
+++ b/src/protocols/rdp/input.c
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include "client.h"
+#include "common/recording.h"
 #include "input.h"
 #include "keyboard.h"
 #include "rdp.h"
@@ -48,6 +49,10 @@ int guac_rdp_user_mouse_handler(guac_user* user, int x, int y, int mask) {
 
     /* Store current mouse location */
     guac_common_cursor_move(rdp_client->display->cursor, user, x, y);
+
+    /* Report mouse position within recording */
+    if (rdp_client->recording != NULL)
+        guac_common_recording_report_mouse(rdp_client->recording, x, y);
 
     /* If button mask unchanged, just send move event */
     if (mask == rdp_client->mouse_button_mask)

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -668,7 +668,7 @@ static int guac_rdp_handle_connection(guac_client* client) {
 
     /* Set up screen recording, if requested */
     if (settings->recording_path != NULL) {
-        guac_common_recording_create(client,
+        rdp_client->recording = guac_common_recording_create(client,
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path);

--- a/src/protocols/rdp/rdp.h
+++ b/src/protocols/rdp/rdp.h
@@ -26,6 +26,7 @@
 #include "common/clipboard.h"
 #include "common/display.h"
 #include "common/list.h"
+#include "common/recording.h"
 #include "common/surface.h"
 #include "keyboard.h"
 #include "rdp_disp.h"
@@ -142,6 +143,12 @@ typedef struct guac_rdp_client {
      */
     guac_common_ssh_sftp_filesystem* sftp_filesystem;
 #endif
+
+    /**
+     * The in-progress session recording, or NULL if no recording is in
+     * progress.
+     */
+    guac_common_recording* recording;
 
     /**
      * Display size update module.

--- a/src/protocols/ssh/client.c
+++ b/src/protocols/ssh/client.c
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include "client.h"
+#include "common/recording.h"
 #include "common-ssh/sftp.h"
 #include "ssh.h"
 #include "terminal/terminal.h"
@@ -87,6 +88,10 @@ int guac_ssh_client_free_handler(guac_client* client) {
         guac_common_ssh_destroy_sftp_filesystem(ssh_client->sftp_filesystem);
         guac_common_ssh_destroy_session(ssh_client->sftp_session);
     }
+
+    /* Clean up recording, if in progress */
+    if (ssh_client->recording != NULL)
+        guac_common_recording_free(ssh_client->recording);
 
     /* Free interactive SSH session */
     if (ssh_client->session != NULL)

--- a/src/protocols/ssh/input.c
+++ b/src/protocols/ssh/input.c
@@ -43,7 +43,7 @@ int guac_ssh_user_mouse_handler(guac_user* user, int x, int y, int mask) {
 
     /* Report mouse position within recording */
     if (ssh_client->recording != NULL)
-        guac_common_recording_report_mouse(ssh_client->recording, x, y);
+        guac_common_recording_report_mouse(ssh_client->recording, x, y, mask);
 
     /* Send mouse event */
     guac_terminal_send_mouse(term, user, x, y, mask);

--- a/src/protocols/ssh/input.c
+++ b/src/protocols/ssh/input.c
@@ -21,6 +21,7 @@
 
 #include "common/cursor.h"
 #include "common/display.h"
+#include "common/recording.h"
 #include "ssh.h"
 #include "terminal/terminal.h"
 
@@ -39,6 +40,10 @@ int guac_ssh_user_mouse_handler(guac_user* user, int x, int y, int mask) {
     /* Skip if terminal not yet ready */
     if (term == NULL)
         return 0;
+
+    /* Report mouse position within recording */
+    if (ssh_client->recording != NULL)
+        guac_common_recording_report_mouse(ssh_client->recording, x, y);
 
     /* Send mouse event */
     guac_terminal_send_mouse(term, user, x, y, mask);

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -193,7 +193,7 @@ void* ssh_client_thread(void* data) {
 
     /* Set up screen recording, if requested */
     if (settings->recording_path != NULL) {
-        guac_common_recording_create(client,
+        ssh_client->recording = guac_common_recording_create(client,
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path);

--- a/src/protocols/ssh/ssh.h
+++ b/src/protocols/ssh/ssh.h
@@ -22,6 +22,7 @@
 
 #include "config.h"
 
+#include "common/recording.h"
 #include "common-ssh/sftp.h"
 #include "common-ssh/ssh.h"
 #include "common-ssh/user.h"
@@ -93,6 +94,12 @@ typedef struct guac_ssh_client {
      */
     guac_terminal* term;
    
+    /**
+     * The in-progress session recording, or NULL if no recording is in
+     * progress.
+     */
+    guac_common_recording* recording;
+
 } guac_ssh_client ;
 
 /**

--- a/src/protocols/telnet/client.c
+++ b/src/protocols/telnet/client.c
@@ -19,6 +19,7 @@
 
 #include "config.h"
 #include "client.h"
+#include "common/recording.h"
 #include "settings.h"
 #include "telnet.h"
 #include "terminal/terminal.h"
@@ -70,6 +71,10 @@ int guac_telnet_client_free_handler(guac_client* client) {
     /* Close telnet connection */
     if (telnet_client->socket_fd != -1)
         close(telnet_client->socket_fd);
+
+    /* Clean up recording, if in progress */
+    if (telnet_client->recording != NULL)
+        guac_common_recording_free(telnet_client->recording);
 
     /* Kill terminal */
     guac_terminal_free(telnet_client->term);

--- a/src/protocols/telnet/input.c
+++ b/src/protocols/telnet/input.c
@@ -45,7 +45,8 @@ int guac_telnet_user_mouse_handler(guac_user* user, int x, int y, int mask) {
 
     /* Report mouse position within recording */
     if (telnet_client->recording != NULL)
-        guac_common_recording_report_mouse(telnet_client->recording, x, y);
+        guac_common_recording_report_mouse(telnet_client->recording, x, y,
+                mask);
 
     /* Send mouse if not searching for password or username */
     if (settings->password_regex == NULL && settings->username_regex == NULL)

--- a/src/protocols/telnet/input.c
+++ b/src/protocols/telnet/input.c
@@ -18,6 +18,7 @@
  */
 
 #include "config.h"
+#include "common/recording.h"
 #include "input.h"
 #include "terminal/terminal.h"
 #include "telnet.h"
@@ -41,6 +42,10 @@ int guac_telnet_user_mouse_handler(guac_user* user, int x, int y, int mask) {
     /* Skip if terminal not yet ready */
     if (term == NULL)
         return 0;
+
+    /* Report mouse position within recording */
+    if (telnet_client->recording != NULL)
+        guac_common_recording_report_mouse(telnet_client->recording, x, y);
 
     /* Send mouse if not searching for password or username */
     if (settings->password_regex == NULL && settings->username_regex == NULL)

--- a/src/protocols/telnet/telnet.c
+++ b/src/protocols/telnet/telnet.c
@@ -467,7 +467,7 @@ void* guac_telnet_client_thread(void* data) {
 
     /* Set up screen recording, if requested */
     if (settings->recording_path != NULL) {
-        guac_common_recording_create(client,
+        telnet_client->recording = guac_common_recording_create(client,
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path);

--- a/src/protocols/telnet/telnet.h
+++ b/src/protocols/telnet/telnet.h
@@ -21,6 +21,7 @@
 #define GUAC_TELNET_H
 
 #include "config.h"
+#include "common/recording.h"
 #include "settings.h"
 #include "terminal/terminal.h"
 
@@ -69,7 +70,13 @@ typedef struct guac_telnet_client {
      * The terminal which will render all output from the telnet client.
      */
     guac_terminal* term;
-   
+
+    /**
+     * The in-progress session recording, or NULL if no recording is in
+     * progress.
+     */
+    guac_common_recording* recording;
+
 } guac_telnet_client;
 
 /**

--- a/src/protocols/vnc/client.c
+++ b/src/protocols/vnc/client.c
@@ -19,6 +19,7 @@
 
 #include "config.h"
 
+#include "common/recording.h"
 #include "client.h"
 #include "user.h"
 #include "vnc.h"
@@ -101,6 +102,10 @@ int guac_vnc_client_free_handler(guac_client* client) {
 
     guac_common_ssh_uninit();
 #endif
+
+    /* Clean up recording, if in progress */
+    if (vnc_client->recording != NULL)
+        guac_common_recording_free(vnc_client->recording);
 
     /* Free clipboard */
     if (vnc_client->clipboard != NULL)

--- a/src/protocols/vnc/input.c
+++ b/src/protocols/vnc/input.c
@@ -33,12 +33,12 @@ int guac_vnc_user_mouse_handler(guac_user* user, int x, int y, int mask) {
     guac_vnc_client* vnc_client = (guac_vnc_client*) client->data;
     rfbClient* rfb_client = vnc_client->rfb_client;
 
-    /* Store current mouse location */
-    guac_common_cursor_move(vnc_client->display->cursor, user, x, y);
+    /* Store current mouse location/state */
+    guac_common_cursor_update(vnc_client->display->cursor, user, x, y, mask);
 
     /* Report mouse position within recording */
     if (vnc_client->recording != NULL)
-        guac_common_recording_report_mouse(vnc_client->recording, x, y);
+        guac_common_recording_report_mouse(vnc_client->recording, x, y, mask);
 
     /* Send VNC event only if finished connecting */
     if (rfb_client != NULL)

--- a/src/protocols/vnc/input.c
+++ b/src/protocols/vnc/input.c
@@ -21,6 +21,7 @@
 
 #include "common/cursor.h"
 #include "common/display.h"
+#include "common/recording.h"
 #include "vnc.h"
 
 #include <guacamole/user.h>
@@ -34,6 +35,10 @@ int guac_vnc_user_mouse_handler(guac_user* user, int x, int y, int mask) {
 
     /* Store current mouse location */
     guac_common_cursor_move(vnc_client->display->cursor, user, x, y);
+
+    /* Report mouse position within recording */
+    if (vnc_client->recording != NULL)
+        guac_common_recording_report_mouse(vnc_client->recording, x, y);
 
     /* Send VNC event only if finished connecting */
     if (rfb_client != NULL)

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -303,7 +303,7 @@ void* guac_vnc_client_thread(void* data) {
 
     /* Set up screen recording, if requested */
     if (settings->recording_path != NULL) {
-        guac_common_recording_create(client,
+        vnc_client->recording = guac_common_recording_create(client,
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path);

--- a/src/protocols/vnc/vnc.h
+++ b/src/protocols/vnc/vnc.h
@@ -25,6 +25,7 @@
 #include "common/clipboard.h"
 #include "common/display.h"
 #include "common/iconv.h"
+#include "common/recording.h"
 #include "common/surface.h"
 #include "settings.h"
 
@@ -109,6 +110,12 @@ typedef struct guac_vnc_client {
      */
     guac_common_ssh_sftp_filesystem* sftp_filesystem;
 #endif
+
+    /**
+     * The in-progress session recording, or NULL if no recording is in
+     * progress.
+     */
+    guac_common_recording* recording;
 
     /**
      * Clipboard encoding-specific reader.

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -1670,8 +1670,8 @@ static int __guac_terminal_send_mouse(guac_terminal* term, guac_user* user,
     int released_mask =  term->mouse_mask & ~mask;
     int pressed_mask  = ~term->mouse_mask &  mask;
 
-    /* Store current mouse location */
-    guac_common_cursor_move(term->cursor, user, x, y);
+    /* Store current mouse location/state */
+    guac_common_cursor_update(term->cursor, user, x, y, mask);
 
     /* Notify scrollbar, do not handle anything handled by scrollbar */
     if (guac_terminal_scrollbar_handle_mouse(term->scrollbar, x, y, mask)) {


### PR DESCRIPTION
This change adds low-level support for logging mouse cursor position and state within session recordings (built upon protocol-level support for doing the same), and leverages that support to include the mouse cursor within video produced by guacenc.

As this requires that the session recording object track the current state of the shared mouse, the `guac_common_recording_create()` function now returns a `guac_common_recording` structure (rather than an `int`) which the caller must eventually free via `guac_common_recording_free()`.

For the sake of accurate recordings, a timestamp is now included in the "mouse" instruction sent from server to client, as an acknowledgement of the server time at which the mouse had the reported state. The mouse button state is also included for completeness.