### PR TITLE
GUACAMOLE-313: Add support for including key events within session recordings.

### DIFF
--- a/src/common/common/recording.h
+++ b/src/common/common/recording.h
@@ -55,6 +55,31 @@ typedef struct guac_common_recording {
      */
     guac_socket* socket;
 
+    /**
+     * Non-zero if output which is broadcast to each connected client
+     * (graphics, streams, etc.) should be included in the session recording,
+     * zero otherwise. Including output is necessary for any recording which
+     * must later be viewable as video.
+     */
+    int include_output;
+
+    /**
+     * Non-zero if changes to mouse state, such as position and buttons pressed
+     * or released, should be included in the session recording, zero
+     * otherwise. Including mouse state is necessary for the mouse cursor to be
+     * rendered in any resulting video.
+     */
+    int include_mouse;
+
+    /**
+     * Non-zero if keys pressed and released should be included in the session
+     * recording, zero otherwise. Including key events within the recording may
+     * be necessary in certain auditing contexts, but should only be done with
+     * caution. Key events can easily contain sensitive information, such as
+     * passwords, credit card numbers, etc.
+     */
+    int include_keys;
+
 } guac_common_recording;
 
 /**
@@ -82,13 +107,33 @@ typedef struct guac_common_recording {
  *     written, or non-zero if the path should be created if it does not yet
  *     exist.
  *
+ * @param include_output
+ *     Non-zero if output which is broadcast to each connected client
+ *     (graphics, streams, etc.) should be included in the session recording,
+ *     zero otherwise. Including output is necessary for any recording which
+ *     must later be viewable as video.
+ *
+ * @param include_mouse
+ *     Non-zero if changes to mouse state, such as position and buttons pressed
+ *     or released, should be included in the session recording, zero
+ *     otherwise. Including mouse state is necessary for the mouse cursor to be
+ *     rendered in any resulting video.
+ *
+ * @param include_keys
+ *     Non-zero if keys pressed and released should be included in the session
+ *     recording, zero otherwise. Including key events within the recording may
+ *     be necessary in certain auditing contexts, but should only be done with
+ *     caution. Key events can easily contain sensitive information, such as
+ *     passwords, credit card numbers, etc.
+ *
  * @return
  *     A new guac_common_recording structure representing the in-progress
  *     recording if the recording file has been successfully created and a
  *     recording will be written, NULL otherwise.
  */
 guac_common_recording* guac_common_recording_create(guac_client* client,
-        const char* path, const char* name, int create_path);
+        const char* path, const char* name, int create_path,
+        int include_output, int include_mouse, int include_keys);
 
 /**
  * Frees the resources associated with the given in-progress recording. Note

--- a/src/common/common/recording.h
+++ b/src/common/common/recording.h
@@ -129,5 +129,22 @@ void guac_common_recording_free(guac_common_recording* recording);
 void guac_common_recording_report_mouse(guac_common_recording* recording,
         int x, int y, int button_mask);
 
+/**
+ * Reports a change in the state of an individual key within the recording.
+ *
+ * @param recording
+ *     The guac_common_recording associated with the key that was pressed or
+ *     released.
+ *
+ * @param keysym
+ *     The X11 keysym of the key that was pressed or released.
+ *
+ * @param pressed
+ *     Non-zero if the key represented by the given keysym is currently
+ *     pressed, zero if it is released.
+ */
+void guac_common_recording_report_key(guac_common_recording* recording,
+        int keysym, int pressed);
+
 #endif
 

--- a/src/common/recording.c
+++ b/src/common/recording.c
@@ -188,3 +188,12 @@ void guac_common_recording_report_mouse(guac_common_recording* recording,
 
 }
 
+void guac_common_recording_report_key(guac_common_recording* recording,
+        int keysym, int pressed) {
+
+    /* Report key state */
+    guac_protocol_send_key(recording->socket, keysym, pressed,
+            guac_timestamp_current());
+
+}
+

--- a/src/common/recording.c
+++ b/src/common/recording.c
@@ -136,7 +136,8 @@ static int guac_common_recording_open(const char* path,
 }
 
 guac_common_recording* guac_common_recording_create(guac_client* client,
-        const char* path, const char* name, int create_path) {
+        const char* path, const char* name, int create_path,
+        int include_output, int include_mouse, int include_keys) {
 
     char filename[GUAC_COMMON_RECORDING_MAX_NAME_LENGTH];
 
@@ -162,9 +163,14 @@ guac_common_recording* guac_common_recording_create(guac_client* client,
     /* Create recording structure with reference to underlying socket */
     guac_common_recording* recording = malloc(sizeof(guac_common_recording));
     recording->socket = guac_socket_open(fd);
+    recording->include_output = include_output;
+    recording->include_mouse = include_mouse;
+    recording->include_keys = include_keys;
 
-    /* Replace client socket with wrapped recording socket */
-    client->socket = guac_socket_tee(client->socket, recording->socket);
+    /* Replace client socket with wrapped recording socket only if including
+     * output within the recording */
+    if (include_output)
+        client->socket = guac_socket_tee(client->socket, recording->socket);
 
     /* Recording creation succeeded */
     guac_client_log(client, GUAC_LOG_INFO,
@@ -176,24 +182,34 @@ guac_common_recording* guac_common_recording_create(guac_client* client,
 }
 
 void guac_common_recording_free(guac_common_recording* recording) {
+
+    /* If not including broadcast output, the output socket is not associated
+     * with the client, and must be freed manually */
+    if (!recording->include_output)
+        guac_socket_free(recording->socket);
+
+    /* Free recording itself */
     free(recording);
+
 }
 
 void guac_common_recording_report_mouse(guac_common_recording* recording,
         int x, int y, int button_mask) {
 
-    /* Report mouse location */
-    guac_protocol_send_mouse(recording->socket, x, y, button_mask,
-            guac_timestamp_current());
+    /* Report mouse location only if recording should contain mouse events */
+    if (recording->include_mouse)
+        guac_protocol_send_mouse(recording->socket, x, y, button_mask,
+                guac_timestamp_current());
 
 }
 
 void guac_common_recording_report_key(guac_common_recording* recording,
         int keysym, int pressed) {
 
-    /* Report key state */
-    guac_protocol_send_key(recording->socket, keysym, pressed,
-            guac_timestamp_current());
+    /* Report key state only if recording should contain key events */
+    if (recording->include_keys)
+        guac_protocol_send_key(recording->socket, keysym, pressed,
+                guac_timestamp_current());
 
 }
 

--- a/src/libguac/guacamole/protocol.h
+++ b/src/libguac/guacamole/protocol.h
@@ -107,6 +107,32 @@ int guac_protocol_send_error(guac_socket* socket, const char* error,
         guac_protocol_status status);
 
 /**
+ * Sends a key instruction over the given guac_socket connection.
+ *
+ * If an error occurs sending the instruction, a non-zero value is
+ * returned, and guac_error is set appropriately.
+ *
+ * @param socket
+ *     The guac_socket connection to use.
+ *
+ * @param keysym
+ *     The X11 keysym of the key that was pressed or released.
+ *
+ * @param pressed
+ *     Non-zero if the key represented by the given keysym is currently
+ *     pressed, zero if it is released.
+ *
+ * @param timestamp
+ *     The server timestamp (in milliseconds) at the point in time this key
+ *     event was acknowledged.
+ *
+ * @return
+ *     Zero on success, non-zero on error.
+ */
+int guac_protocol_send_key(guac_socket* socket, int keysym, int pressed,
+        guac_timestamp timestamp);
+
+/**
  * Sends a log instruction over the given guac_socket connection. This is
  * mainly useful in debugging.
  *

--- a/src/libguac/protocol.c
+++ b/src/libguac/protocol.c
@@ -615,6 +615,24 @@ int guac_protocol_send_identity(guac_socket* socket, const guac_layer* layer) {
 
 }
 
+int guac_protocol_send_key(guac_socket* socket, int keysym, int pressed,
+        guac_timestamp timestamp) {
+
+    int ret_val;
+
+    guac_socket_instruction_begin(socket);
+    ret_val =
+           guac_socket_write_string(socket, "3.key,")
+        || __guac_socket_write_length_int(socket, keysym)
+        || guac_socket_write_string(socket, pressed ? ",1.1," : ",1.0,")
+        || __guac_socket_write_length_int(socket, timestamp)
+        || guac_socket_write_string(socket, ";");
+
+    guac_socket_instruction_end(socket);
+    return ret_val;
+
+}
+
 int guac_protocol_send_lfill(guac_socket* socket,
         guac_composite_mode mode, const guac_layer* layer,
         const guac_layer* srcl) {

--- a/src/protocols/rdp/input.c
+++ b/src/protocols/rdp/input.c
@@ -128,6 +128,11 @@ int guac_rdp_user_key_handler(guac_user* user, int keysym, int pressed) {
     guac_client* client = user->client;
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
 
+    /* Report key state within recording */
+    if (rdp_client->recording != NULL)
+        guac_common_recording_report_key(rdp_client->recording,
+                keysym, pressed);
+
     /* Skip if keyboard not yet ready */
     if (rdp_client->keyboard == NULL)
         return 0;

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -671,7 +671,10 @@ static int guac_rdp_handle_connection(guac_client* client) {
         rdp_client->recording = guac_common_recording_create(client,
                 settings->recording_path,
                 settings->recording_name,
-                settings->create_recording_path);
+                settings->create_recording_path,
+                !settings->recording_exclude_output,
+                !settings->recording_exclude_mouse,
+                settings->recording_include_keys);
     }
 
     /* Create display */

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -90,6 +90,9 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
 
     "recording-path",
     "recording-name",
+    "recording-exclude-output",
+    "recording-exclude-mouse",
+    "recording-include-keys",
     "create-recording-path",
     "resize-method",
     "enable-audio-input",
@@ -394,6 +397,32 @@ enum RDP_ARGS_IDX {
      * the given path.
      */
     IDX_RECORDING_NAME,
+
+    /**
+     * Whether output which is broadcast to each connected client (graphics,
+     * streams, etc.) should NOT be included in the session recording. Output
+     * is included by default, as it is necessary for any recording which must
+     * later be viewable as video.
+     */
+    IDX_RECORDING_EXCLUDE_OUTPUT,
+
+    /**
+     * Whether changes to mouse state, such as position and buttons pressed or
+     * released, should NOT be included in the session recording. Mouse state
+     * is included by default, as it is necessary for the mouse cursor to be
+     * rendered in any resulting video.
+     */
+    IDX_RECORDING_EXCLUDE_MOUSE,
+
+    /**
+     * Whether keys pressed and released should be included in the session
+     * recording. Key events are NOT included by default within the recording,
+     * as doing so has privacy and security implications.  Including key events
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Key events can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_KEYS,
 
     /**
      * Whether the specified screen recording path should automatically be
@@ -811,6 +840,21 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     settings->recording_name =
         guac_user_parse_args_string(user, GUAC_RDP_CLIENT_ARGS, argv,
                 IDX_RECORDING_NAME, GUAC_RDP_DEFAULT_RECORDING_NAME);
+
+    /* Parse output exclusion flag */
+    settings->recording_exclude_output =
+        guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_RECORDING_EXCLUDE_OUTPUT, 0);
+
+    /* Parse mouse exclusion flag */
+    settings->recording_exclude_mouse =
+        guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_RECORDING_EXCLUDE_MOUSE, 0);
+
+    /* Parse key event inclusion flag */
+    settings->recording_include_keys =
+        guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_KEYS, 0);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -393,6 +393,32 @@ typedef struct guac_rdp_settings {
     int create_recording_path;
 
     /**
+     * Non-zero if output which is broadcast to each connected client
+     * (graphics, streams, etc.) should NOT be included in the session
+     * recording, zero otherwise. Output is included by default, as it is
+     * necessary for any recording which must later be viewable as video.
+     */
+    int recording_exclude_output;
+
+    /**
+     * Non-zero if changes to mouse state, such as position and buttons pressed
+     * or released, should NOT be included in the session recording, zero
+     * otherwise. Mouse state is included by default, as it is necessary for
+     * the mouse cursor to be rendered in any resulting video.
+     */
+    int recording_exclude_mouse;
+
+    /**
+     * Non-zero if keys pressed and released should be included in the session
+     * recording, zero otherwise. Key events are NOT included by default within
+     * the recording, as doing so has privacy and security implications.
+     * Including key events may be necessary in certain auditing contexts, but
+     * should only be done with caution. Key events can easily contain
+     * sensitive information, such as passwords, credit card numbers, etc.
+     */
+    int recording_include_keys;
+
+    /**
      * The method to apply when the user's display changes size.
      */
     guac_rdp_resize_method resize_method;

--- a/src/protocols/ssh/input.c
+++ b/src/protocols/ssh/input.c
@@ -56,6 +56,11 @@ int guac_ssh_user_key_handler(guac_user* user, int keysym, int pressed) {
     guac_ssh_client* ssh_client = (guac_ssh_client*) client->data;
     guac_terminal* term = ssh_client->term;
 
+    /* Report key state within recording */
+    if (ssh_client->recording != NULL)
+        guac_common_recording_report_key(ssh_client->recording,
+                keysym, pressed);
+
     /* Skip if terminal not yet ready */
     if (term == NULL)
         return 0;

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -50,6 +50,9 @@ const char* GUAC_SSH_CLIENT_ARGS[] = {
     "create-typescript-path",
     "recording-path",
     "recording-name",
+    "recording-exclude-output",
+    "recording-exclude-mouse",
+    "recording-include-keys",
     "create-recording-path",
     "read-only",
     "server-alive-interval",
@@ -160,6 +163,32 @@ enum SSH_ARGS_IDX {
      * the given path.
      */
     IDX_RECORDING_NAME,
+
+    /**
+     * Whether output which is broadcast to each connected client (graphics,
+     * streams, etc.) should NOT be included in the session recording. Output
+     * is included by default, as it is necessary for any recording which must
+     * later be viewable as video.
+     */
+    IDX_RECORDING_EXCLUDE_OUTPUT,
+
+    /**
+     * Whether changes to mouse state, such as position and buttons pressed or
+     * released, should NOT be included in the session recording. Mouse state
+     * is included by default, as it is necessary for the mouse cursor to be
+     * rendered in any resulting video.
+     */
+    IDX_RECORDING_EXCLUDE_MOUSE,
+
+    /**
+     * Whether keys pressed and released should be included in the session
+     * recording. Key events are NOT included by default within the recording,
+     * as doing so has privacy and security implications.  Including key events
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Key events can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_KEYS,
 
     /**
      * Whether the specified screen recording path should automatically be
@@ -293,6 +322,21 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
     settings->recording_name =
         guac_user_parse_args_string(user, GUAC_SSH_CLIENT_ARGS, argv,
                 IDX_RECORDING_NAME, GUAC_SSH_DEFAULT_RECORDING_NAME);
+
+    /* Parse output exclusion flag */
+    settings->recording_exclude_output =
+        guac_user_parse_args_boolean(user, GUAC_SSH_CLIENT_ARGS, argv,
+                IDX_RECORDING_EXCLUDE_OUTPUT, false);
+
+    /* Parse mouse exclusion flag */
+    settings->recording_exclude_mouse =
+        guac_user_parse_args_boolean(user, GUAC_SSH_CLIENT_ARGS, argv,
+                IDX_RECORDING_EXCLUDE_MOUSE, false);
+
+    /* Parse key event inclusion flag */
+    settings->recording_include_keys =
+        guac_user_parse_args_boolean(user, GUAC_SSH_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_KEYS, false);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -193,6 +193,32 @@ typedef struct guac_ssh_settings {
     bool create_recording_path;
 
     /**
+     * Whether output which is broadcast to each connected client (graphics,
+     * streams, etc.) should NOT be included in the session recording. Output
+     * is included by default, as it is necessary for any recording which must
+     * later be viewable as video.
+     */
+    bool recording_exclude_output;
+
+    /**
+     * Whether changes to mouse state, such as position and buttons pressed or
+     * released, should NOT be included in the session recording. Mouse state
+     * is included by default, as it is necessary for the mouse cursor to be
+     * rendered in any resulting video.
+     */
+    bool recording_exclude_mouse;
+
+    /**
+     * Whether keys pressed and released should be included in the session
+     * recording. Key events are NOT included by default within the recording,
+     * as doing so has privacy and security implications.  Including key events
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Key events can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    bool recording_include_keys;
+
+    /**
      * The number of seconds between sending server alive messages.
      */
     int server_alive_interval;

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -196,7 +196,10 @@ void* ssh_client_thread(void* data) {
         ssh_client->recording = guac_common_recording_create(client,
                 settings->recording_path,
                 settings->recording_name,
-                settings->create_recording_path);
+                settings->create_recording_path,
+                !settings->recording_exclude_output,
+                !settings->recording_exclude_mouse,
+                settings->recording_include_keys);
     }
 
     /* Create terminal */

--- a/src/protocols/telnet/input.c
+++ b/src/protocols/telnet/input.c
@@ -63,6 +63,11 @@ int guac_telnet_user_key_handler(guac_user* user, int keysym, int pressed) {
     guac_telnet_settings* settings = telnet_client->settings;
     guac_terminal* term = telnet_client->term;
 
+    /* Report key state within recording */
+    if (telnet_client->recording != NULL)
+        guac_common_recording_report_key(telnet_client->recording,
+                keysym, pressed);
+
     /* Skip if terminal not yet ready */
     if (term == NULL)
         return 0;

--- a/src/protocols/telnet/settings.c
+++ b/src/protocols/telnet/settings.c
@@ -45,6 +45,9 @@ const char* GUAC_TELNET_CLIENT_ARGS[] = {
     "create-typescript-path",
     "recording-path",
     "recording-name",
+    "recording-exclude-output",
+    "recording-exclude-mouse",
+    "recording-include-keys",
     "create-recording-path",
     "read-only",
     NULL
@@ -132,6 +135,32 @@ enum TELNET_ARGS_IDX {
      * the given path.
      */
     IDX_RECORDING_NAME,
+
+    /**
+     * Whether output which is broadcast to each connected client (graphics,
+     * streams, etc.) should NOT be included in the session recording. Output
+     * is included by default, as it is necessary for any recording which must
+     * later be viewable as video.
+     */
+    IDX_RECORDING_EXCLUDE_OUTPUT,
+
+    /**
+     * Whether changes to mouse state, such as position and buttons pressed or
+     * released, should NOT be included in the session recording. Mouse state
+     * is included by default, as it is necessary for the mouse cursor to be
+     * rendered in any resulting video.
+     */
+    IDX_RECORDING_EXCLUDE_MOUSE,
+
+    /**
+     * Whether keys pressed and released should be included in the session
+     * recording. Key events are NOT included by default within the recording,
+     * as doing so has privacy and security implications.  Including key events
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Key events can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_KEYS,
 
     /**
      * Whether the specified screen recording path should automatically be
@@ -278,6 +307,21 @@ guac_telnet_settings* guac_telnet_parse_args(guac_user* user,
     settings->recording_name =
         guac_user_parse_args_string(user, GUAC_TELNET_CLIENT_ARGS, argv,
                 IDX_RECORDING_NAME, GUAC_TELNET_DEFAULT_RECORDING_NAME);
+
+    /* Parse output exclusion flag */
+    settings->recording_exclude_output =
+        guac_user_parse_args_boolean(user, GUAC_TELNET_CLIENT_ARGS, argv,
+                IDX_RECORDING_EXCLUDE_OUTPUT, false);
+
+    /* Parse mouse exclusion flag */
+    settings->recording_exclude_mouse =
+        guac_user_parse_args_boolean(user, GUAC_TELNET_CLIENT_ARGS, argv,
+                IDX_RECORDING_EXCLUDE_MOUSE, false);
+
+    /* Parse key event inclusion flag */
+    settings->recording_include_keys =
+        guac_user_parse_args_boolean(user, GUAC_TELNET_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_KEYS, false);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/telnet/settings.h
+++ b/src/protocols/telnet/settings.h
@@ -181,6 +181,32 @@ typedef struct guac_telnet_settings {
      */
     bool create_recording_path;
 
+    /**
+     * Whether output which is broadcast to each connected client (graphics,
+     * streams, etc.) should NOT be included in the session recording. Output
+     * is included by default, as it is necessary for any recording which must
+     * later be viewable as video.
+     */
+    bool recording_exclude_output;
+
+    /**
+     * Whether changes to mouse state, such as position and buttons pressed or
+     * released, should NOT be included in the session recording. Mouse state
+     * is included by default, as it is necessary for the mouse cursor to be
+     * rendered in any resulting video.
+     */
+    bool recording_exclude_mouse;
+
+    /**
+     * Whether keys pressed and released should be included in the session
+     * recording. Key events are NOT included by default within the recording,
+     * as doing so has privacy and security implications.  Including key events
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Key events can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    bool recording_include_keys;
+
 } guac_telnet_settings;
 
 /**

--- a/src/protocols/telnet/telnet.c
+++ b/src/protocols/telnet/telnet.c
@@ -470,7 +470,10 @@ void* guac_telnet_client_thread(void* data) {
         telnet_client->recording = guac_common_recording_create(client,
                 settings->recording_path,
                 settings->recording_name,
-                settings->create_recording_path);
+                settings->create_recording_path,
+                !settings->recording_exclude_output,
+                !settings->recording_exclude_mouse,
+                settings->recording_include_keys);
     }
 
     /* Create terminal */

--- a/src/protocols/vnc/input.c
+++ b/src/protocols/vnc/input.c
@@ -52,6 +52,11 @@ int guac_vnc_user_key_handler(guac_user* user, int keysym, int pressed) {
     guac_vnc_client* vnc_client = (guac_vnc_client*) user->client->data;
     rfbClient* rfb_client = vnc_client->rfb_client;
 
+    /* Report key state within recording */
+    if (vnc_client->recording != NULL)
+        guac_common_recording_report_key(vnc_client->recording,
+                keysym, pressed);
+
     /* Send VNC event only if finished connecting */
     if (rfb_client != NULL)
         SendKeyEvent(rfb_client, keysym, pressed);

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -72,6 +72,9 @@ const char* GUAC_VNC_CLIENT_ARGS[] = {
 
     "recording-path",
     "recording-name",
+    "recording-exclude-output",
+    "recording-exclude-mouse",
+    "recording-include-keys",
     "create-recording-path",
 
     NULL
@@ -258,6 +261,32 @@ enum VNC_ARGS_IDX {
     IDX_RECORDING_NAME,
 
     /**
+     * Whether output which is broadcast to each connected client (graphics,
+     * streams, etc.) should NOT be included in the session recording. Output
+     * is included by default, as it is necessary for any recording which must
+     * later be viewable as video.
+     */
+    IDX_RECORDING_EXCLUDE_OUTPUT,
+
+    /**
+     * Whether changes to mouse state, such as position and buttons pressed or
+     * released, should NOT be included in the session recording. Mouse state
+     * is included by default, as it is necessary for the mouse cursor to be
+     * rendered in any resulting video.
+     */
+    IDX_RECORDING_EXCLUDE_MOUSE,
+
+    /**
+     * Whether keys pressed and released should be included in the session
+     * recording. Key events are NOT included by default within the recording,
+     * as doing so has privacy and security implications.  Including key events
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Key events can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_KEYS,
+
+    /**
      * Whether the specified screen recording path should automatically be
      * created if it does not yet exist.
      */
@@ -432,6 +461,21 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
     settings->recording_name =
         guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_RECORDING_NAME, GUAC_VNC_DEFAULT_RECORDING_NAME);
+
+    /* Parse output exclusion flag */
+    settings->recording_exclude_output =
+        guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_RECORDING_EXCLUDE_OUTPUT, false);
+
+    /* Parse mouse exclusion flag */
+    settings->recording_exclude_mouse =
+        guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_RECORDING_EXCLUDE_MOUSE, false);
+
+    /* Parse key event inclusion flag */
+    settings->recording_include_keys =
+        guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_KEYS, false);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -206,6 +206,32 @@ typedef struct guac_vnc_settings {
      */
     bool create_recording_path;
 
+    /**
+     * Whether output which is broadcast to each connected client (graphics,
+     * streams, etc.) should NOT be included in the session recording. Output
+     * is included by default, as it is necessary for any recording which must
+     * later be viewable as video.
+     */
+    bool recording_exclude_output;
+
+    /**
+     * Whether changes to mouse state, such as position and buttons pressed or
+     * released, should NOT be included in the session recording. Mouse state
+     * is included by default, as it is necessary for the mouse cursor to be
+     * rendered in any resulting video.
+     */
+    bool recording_exclude_mouse;
+
+    /**
+     * Whether keys pressed and released should be included in the session
+     * recording. Key events are NOT included by default within the recording,
+     * as doing so has privacy and security implications.  Including key events
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Key events can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    bool recording_include_keys;
+
 } guac_vnc_settings;
 
 /**

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -306,7 +306,10 @@ void* guac_vnc_client_thread(void* data) {
         vnc_client->recording = guac_common_recording_create(client,
                 settings->recording_path,
                 settings->recording_name,
-                settings->create_recording_path);
+                settings->create_recording_path,
+                !settings->recording_exclude_output,
+                !settings->recording_exclude_mouse,
+                settings->recording_include_keys);
     }
 
     /* Send name */


### PR DESCRIPTION
This change adds a set of flags which control the contents of session recordings, allowing key events to be included if the associated flag is explicitly set. Due to clear privacy concerns, key events are *not* included by default.

Parts of session recordings which *are* included by default, like graphical updates and mouse events, can also now be explicitly disabled if desired.