### PR TITLE
GUACAMOLE-269: Add basic support for sending TTY mode encoding over SSH

### DIFF
--- a/src/protocols/ssh/Makefile.am
+++ b/src/protocols/ssh/Makefile.am
@@ -29,6 +29,7 @@ libguac_client_ssh_la_SOURCES = \
     settings.c                  \
     sftp.c                      \
     ssh.c                       \
+    ttymode.c                   \
     user.c
 
 noinst_HEADERS =                \

--- a/src/protocols/ssh/Makefile.am
+++ b/src/protocols/ssh/Makefile.am
@@ -38,6 +38,7 @@ noinst_HEADERS =                \
     settings.h                  \
     sftp.h                      \
     ssh.h                       \
+    ttymode.h                   \
     user.h
 
 # Add agent sources if enabled

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -298,8 +298,8 @@ void* ssh_client_thread(void* data) {
     }
 
     /* Request PTY */
-    if (libssh2_channel_request_pty_ex(ssh_client->term_channel, "linux", sizeof("linux")-1, guac_tty_modes,
-            sizeof(guac_tty_modes), ssh_client->term->term_width, ssh_client->term->term_height, 0, 0)) {
+    if (libssh2_channel_request_pty_ex(ssh_client->term_channel, "linux", sizeof("linux")-1, GUAC_SSH_TTY_MODES,
+            sizeof(GUAC_SSH_TTY_MODES), ssh_client->term->term_width, ssh_client->term->term_height, 0, 0)) {
         guac_client_abort(client, GUAC_PROTOCOL_STATUS_UPSTREAM_ERROR, "Unable to allocate PTY.");
         return NULL;
     }

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -26,6 +26,7 @@
 #include "sftp.h"
 #include "ssh.h"
 #include "terminal/terminal.h"
+#include "ttymode.h"
 
 #ifdef ENABLE_SSH_AGENT
 #include "ssh_agent.h"
@@ -297,8 +298,8 @@ void* ssh_client_thread(void* data) {
     }
 
     /* Request PTY */
-    if (libssh2_channel_request_pty_ex(ssh_client->term_channel, "linux", sizeof("linux")-1, NULL, 0,
-            ssh_client->term->term_width, ssh_client->term->term_height, 0, 0)) {
+    if (libssh2_channel_request_pty_ex(ssh_client->term_channel, "linux", sizeof("linux")-1, guac_tty_modes,
+            sizeof(guac_tty_modes), ssh_client->term->term_width, ssh_client->term->term_height, 0, 0)) {
         guac_client_abort(client, GUAC_PROTOCOL_STATUS_UPSTREAM_ERROR, "Unable to allocate PTY.");
         return NULL;
     }

--- a/src/protocols/ssh/ttymode.c
+++ b/src/protocols/ssh/ttymode.c
@@ -17,16 +17,11 @@
  * under the License.
  */
 
-#ifndef GUAC_SSH_TTYMODE_H
-#define GUAC_SSH_TTYMODE_H
-
 #include "config.h"
+#include "ttymode.h"
 
-#define GUAC_SSH_TTY_OP_END 0
-#define GUAC_SSH_TTY_OP_VERASE 3
-
-#define GUAC_SSH_TERM_DEFAULT_BACKSPACE 127
-
-extern const char GUAC_SSH_TTY_MODES[6];
-
-#endif
+const char GUAC_SSH_TTY_MODES[6] = {
+    GUAC_SSH_TTY_OP_VERASE,
+    0, 0, 0, GUAC_SSH_TERM_DEFAULT_BACKSPACE,
+    GUAC_SSH_TTY_OP_END
+};

--- a/src/protocols/ssh/ttymode.h
+++ b/src/protocols/ssh/ttymode.h
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_SSH_TTYMODE_H
+#define GUAC_SSH_TTYMODE_H
+
+#include "config.h"
+
+#define TTY_OP_END 0
+#define TTY_OP_VERASE 3
+
+#define GUAC_SSH_TERM_DEFAULT_BACKSPACE 127
+
+char guac_tty_modes[] = {
+    TTY_OP_VERASE,
+    0, 0, 0, GUAC_SSH_TERM_DEFAULT_BACKSPACE,
+    TTY_OP_END
+};
+
+#endif

--- a/src/protocols/ssh/ttymode.h
+++ b/src/protocols/ssh/ttymode.h
@@ -22,11 +22,31 @@
 
 #include "config.h"
 
+/**
+ * The SSH TTY mode encoding opcode that terminates
+ * the list of TTY modes.
+ */
 #define GUAC_SSH_TTY_OP_END 0
+
+/**
+ * The SSH tty mode encoding opcode that configures
+ * the TTY erase code to configure the server
+ * backspace key.
+ */
 #define GUAC_SSH_TTY_OP_VERASE 3
 
+/**
+ * The default ASCII code to send for the backspace
+ * key that will be sent to the SSH server.
+ */
 #define GUAC_SSH_TERM_DEFAULT_BACKSPACE 127
 
+/**
+ * The array of TTY mode encoding data to send to the
+ * SSH server.  These consist of pairs of byte codes
+ * and uint32 (4-byte) values, with a 0 to terminate
+ * the list.
+ */
 extern const char GUAC_SSH_TTY_MODES[6];
 
 #endif


### PR DESCRIPTION
This is a very basic change that takes care of the problem described in GUACAMOLE-269, specifically in SSH, where the remote system does not correctly register the TTY erase character.  It adds the necessary data structure for passing this through, and the changes to the `libssh2_channel_request_pty_ex()` function to pass the structure through.

I tried to do this in a way that allows it to be extended easily in the future.  Not sure if this is a sane approach or not - it does take care of the issue raised in -269 for the SSH protocol, but I welcome any comments or suggestions on other approaches.