### PR TITLE
GUACAMOLE-445: Make Printer Name Configurable

### DIFF
--- a/src/protocols/rdp/guac_rdpdr/rdpdr_messages.c
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_messages.c
@@ -22,9 +22,11 @@
 #include "rdp.h"
 #include "rdpdr_messages.h"
 #include "rdpdr_service.h"
+#include "unicode.h"
 
 #include <freerdp/utils/svc_plugin.h>
 #include <guacamole/client.h>
+#include <guacamole/unicode.h>
 
 #ifdef ENABLE_WINPR
 #include <winpr/stream.h>
@@ -122,20 +124,29 @@ static void guac_rdpdr_send_client_capability(guac_rdpdrPlugin* rdpdr) {
 
 static void guac_rdpdr_send_client_device_list_announce_request(guac_rdpdrPlugin* rdpdr) {
 
-    int i;
-    wStream* output_stream = Stream_New(NULL, 256);
+    /* Calculate number of bytes needed for the stream */
+    int streamBytes = 16;
+    for (int i=0; i < rdpdr->devices_registered; i++)
+        streamBytes += rdpdr->devices[i].device_announce_len;
+
+    /* Allocate the stream */
+    wStream* output_stream = Stream_New(NULL, streamBytes);
 
     /* Write header */
     Stream_Write_UINT16(output_stream, RDPDR_CTYP_CORE);
     Stream_Write_UINT16(output_stream, PAKID_CORE_DEVICELIST_ANNOUNCE);
 
-    /* List devices */
+    /* Get the stream for each of the devices. */
     Stream_Write_UINT32(output_stream, rdpdr->devices_registered);
-    for (i=0; i<rdpdr->devices_registered; i++) {
-        guac_rdpdr_device* device = &(rdpdr->devices[i]);
-        device->announce_handler(device, output_stream, i);
+    for (int i=0; i<rdpdr->devices_registered; i++) {
+        
+        Stream_Write(output_stream,
+                Stream_Buffer(rdpdr->devices[i].device_announce),
+                rdpdr->devices[i].device_announce_len);
+
         guac_client_log(rdpdr->client, GUAC_LOG_INFO, "Registered device %i (%s)",
-                device->device_id, device->device_name);
+                rdpdr->devices[i].device_id, rdpdr->devices[i].device_name);
+        
     }
 
     svc_plugin_send((rdpSvcPlugin*) rdpdr, output_stream);

--- a/src/protocols/rdp/guac_rdpdr/rdpdr_messages.c
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_messages.c
@@ -273,4 +273,3 @@ void guac_rdpdr_process_prn_cache_data(guac_rdpdrPlugin* rdpdr, wStream* input_s
 void guac_rdpdr_process_prn_using_xps(guac_rdpdrPlugin* rdpdr, wStream* input_stream) {
     guac_client_log(rdpdr->client, GUAC_LOG_INFO, "Printer unexpectedly switched to XPS mode");
 }
-

--- a/src/protocols/rdp/guac_rdpdr/rdpdr_messages.h
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_messages.h
@@ -77,12 +77,6 @@
 #define GUAC_PRINTER_DRIVER_LENGTH 50
 
 /**
- * Name of the printer itself.
- */
-#define GUAC_PRINTER_NAME          "G\0u\0a\0c\0a\0m\0o\0l\0e\0\0\0"
-#define GUAC_PRINTER_NAME_LENGTH   20
-
-/**
  * Name of the filesystem.
  */
 #define GUAC_FILESYSTEM_NAME          "G\0u\0a\0c\0a\0m\0o\0l\0e\0\0\0"

--- a/src/protocols/rdp/guac_rdpdr/rdpdr_printer.h
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_printer.h
@@ -35,7 +35,7 @@
  * Registers a new printer device within the RDPDR plugin. This must be done
  * before RDPDR connection finishes.
  */
-void guac_rdpdr_register_printer(guac_rdpdrPlugin* rdpdr);
+void guac_rdpdr_register_printer(guac_rdpdrPlugin* rdpdr, char* printer_name);
 
 #endif
 

--- a/src/protocols/rdp/guac_rdpdr/rdpdr_printer.h
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_printer.h
@@ -34,6 +34,13 @@
 /**
  * Registers a new printer device within the RDPDR plugin. This must be done
  * before RDPDR connection finishes.
+ * 
+ * @param rdpdr
+ *     The RDP device redirection plugin where the device is registered.
+ * 
+ * @param printer_name
+ *     The name of the printer that will be registered with the RDP
+ *     connection and passed through to the server.
  */
 void guac_rdpdr_register_printer(guac_rdpdrPlugin* rdpdr, char* printer_name);
 

--- a/src/protocols/rdp/guac_rdpdr/rdpdr_service.c
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_service.c
@@ -96,7 +96,7 @@ void guac_rdpdr_process_connect(rdpSvcPlugin* plugin) {
 
     /* Register printer if enabled */
     if (rdp_client->settings->printing_enabled)
-        guac_rdpdr_register_printer(rdpdr);
+        guac_rdpdr_register_printer(rdpdr, rdp_client->settings->printer_name);
 
     /* Register drive if enabled */
     if (rdp_client->settings->drive_enabled)

--- a/src/protocols/rdp/guac_rdpdr/rdpdr_service.h
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_service.h
@@ -74,15 +74,30 @@ struct guac_rdpdr_device {
     int device_id;
 
     /**
-     * An arbitrary device name, used for logging purposes only.
+     * Device name, used for logging and for passthrough to the
+     * server.
      */
     const char* device_name;
 
     /**
-     * Handler which will be called when the RDPDR plugin is forming the client
-     * device announce list.
+     * The type of RDPDR device that this represents.
      */
-    guac_rdpdr_device_announce_handler* announce_handler;
+    uint32_t device_type;
+
+    /**
+     * The DOS name of the device.  Max 8 bytes, including terminator.
+     */
+    const char *dos_name;
+    
+    /**
+     * The stream that stores the RDPDR device announcement for this device.
+     */
+    wStream* device_announce;
+    
+    /**
+     * The length of the device_announce wStream.
+     */
+    int device_announce_len;
 
     /**
      * Handler which should be called for every I/O request received.
@@ -90,7 +105,7 @@ struct guac_rdpdr_device {
     guac_rdpdr_device_iorequest_handler* iorequest_handler;
 
     /**
-     * Handlel which should be called when the device is being free'd.
+     * Handler which should be called when the device is being freed.
      */
     guac_rdpdr_device_free_handler* free_handler;
 
@@ -154,7 +169,7 @@ void guac_rdpdr_process_terminate(rdpSvcPlugin* plugin);
 void guac_rdpdr_process_event(rdpSvcPlugin* plugin, wMessage* event);
 
 /**
- * Creates a new stream which contains the ommon DR_DEVICE_IOCOMPLETION header
+ * Creates a new stream which contains the common DR_DEVICE_IOCOMPLETION header
  * used for virtually all responses.
  */
 wStream* guac_rdpdr_new_io_completion(guac_rdpdr_device* device,

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -52,6 +52,7 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
     "color-depth",
     "disable-audio",
     "enable-printing",
+    "printer-name",
     "enable-drive",
     "drive-path",
     "create-drive-path",
@@ -185,6 +186,11 @@ enum RDP_ARGS_IDX {
      * "true" if printing should be enabled, "false" or blank otherwise.
      */
     IDX_ENABLE_PRINTING,
+
+    /**
+     * The name of the printer that will be passed through to the RDP server.
+     */
+    IDX_PRINTER_NAME,
 
     /**
      * "true" if the virtual drive should be enabled, "false" or blank
@@ -787,6 +793,11 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     settings->printing_enabled =
         guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
                 IDX_ENABLE_PRINTING, 0);
+
+    /* Name of redirected printer */
+    settings->printer_name =
+        guac_user_parse_args_string(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_PRINTER_NAME, "Guacamole Printer");
 
     /* Drive enable/disable */
     settings->drive_enabled =

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -990,6 +990,7 @@ void guac_rdp_settings_free(guac_rdp_settings* settings) {
     free(settings->remote_app_args);
     free(settings->remote_app_dir);
     free(settings->username);
+    free(settings->printer_name);
 
     /* Free channel name array */
     if (settings->svc_names != NULL) {

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -178,6 +178,11 @@ typedef struct guac_rdp_settings {
     int printing_enabled;
 
     /**
+     * Name of the redirected printer.
+     */
+    char* printer_name;
+
+    /**
      * Whether the virtual drive is enabled.
      */
     int drive_enabled;


### PR DESCRIPTION
This adds the parameters and changes to rdpdr to make the printer name configurable in the RDP session.

I'm not sure if we had totally settled in the JIRA issue on whether or not this change was actually going to happen, but I went ahead and did it.  I can close the PR if we decide against it.