### PR TITLE
GUACAMOLE-446: Allow redirected drive name to be configured

### DIFF
--- a/src/protocols/rdp/guac_rdpdr/rdpdr_fs_service.c
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_fs_service.c
@@ -119,7 +119,7 @@ static void guac_rdpdr_device_fs_free_handler(guac_rdpdr_device* device) {
     
 }
 
-void guac_rdpdr_register_fs(guac_rdpdrPlugin* rdpdr) {
+void guac_rdpdr_register_fs(guac_rdpdrPlugin* rdpdr, char* drive_name) {
 
     guac_client* client = rdpdr->client;
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
@@ -131,7 +131,7 @@ void guac_rdpdr_register_fs(guac_rdpdrPlugin* rdpdr) {
     /* Init device */
     device->rdpdr       = rdpdr;
     device->device_id   = id;
-    device->device_name = "Guacamole Filesystem";
+    device->device_name = drive_name;
     int device_name_len = guac_utf8_strlen(device->device_name);
     device->device_type = RDPDR_DTYP_FILESYSTEM;
     device->dos_name = "GUACFS\0\0";

--- a/src/protocols/rdp/guac_rdpdr/rdpdr_fs_service.h
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_fs_service.h
@@ -41,8 +41,14 @@
 /**
  * Registers a new filesystem device within the RDPDR plugin. This must be done
  * before RDPDR connection finishes.
+ * 
+ * @param rdpdr
+ *     The RDP device redirection plugin with which to register the device.
+ * 
+ * @param drive_name
+ *     The name of the redirected drive to display in the RDP connection.
  */
-void guac_rdpdr_register_fs(guac_rdpdrPlugin* rdpdr);
+void guac_rdpdr_register_fs(guac_rdpdrPlugin* rdpdr, char* drive_name);
 
 #endif
 

--- a/src/protocols/rdp/guac_rdpdr/rdpdr_messages.h
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_messages.h
@@ -77,12 +77,6 @@
 #define GUAC_PRINTER_DRIVER_LENGTH 50
 
 /**
- * Name of the filesystem.
- */
-#define GUAC_FILESYSTEM_NAME          "G\0u\0a\0c\0a\0m\0o\0l\0e\0\0\0"
-#define GUAC_FILESYSTEM_NAME_LENGTH   20
-
-/**
  * Label of the filesystem.
  */
 #define GUAC_FILESYSTEM_LABEL          "G\0U\0A\0C\0F\0I\0L\0E\0"

--- a/src/protocols/rdp/guac_rdpdr/rdpdr_service.c
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_service.c
@@ -100,7 +100,7 @@ void guac_rdpdr_process_connect(rdpSvcPlugin* plugin) {
 
     /* Register drive if enabled */
     if (rdp_client->settings->drive_enabled)
-        guac_rdpdr_register_fs(rdpdr);
+        guac_rdpdr_register_fs(rdpdr, rdp_client->settings->drive_name);
 
     /* Log that printing, etc. has been loaded */
     guac_client_log(client, GUAC_LOG_INFO, "guacdr connected.");

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -54,6 +54,7 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
     "enable-printing",
     "printer-name",
     "enable-drive",
+    "drive-name",
     "drive-path",
     "create-drive-path",
     "console",
@@ -198,6 +199,12 @@ enum RDP_ARGS_IDX {
      * otherwise.
      */
     IDX_ENABLE_DRIVE,
+    
+    /**
+     * The name of the virtual driver that will be passed through to the
+     * RDP connection.
+     */
+    IDX_DRIVE_NAME,
 
     /**
      * The local system path which will be used to persist the
@@ -809,6 +816,11 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     settings->drive_enabled =
         guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
                 IDX_ENABLE_DRIVE, 0);
+    
+    /* Name of the drive being passed through */
+    settings->drive_name =
+        guac_user_parse_args_string(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_DRIVE_NAME, 0);
 
     settings->drive_path =
         guac_user_parse_args_string(user, GUAC_RDP_CLIENT_ARGS, argv,
@@ -990,6 +1002,7 @@ void guac_rdp_settings_free(guac_rdp_settings* settings) {
     /* Free settings strings */
     free(settings->client_name);
     free(settings->domain);
+    free(settings->drive_name);
     free(settings->drive_path);
     free(settings->hostname);
     free(settings->initial_program);

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -820,7 +820,7 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     /* Name of the drive being passed through */
     settings->drive_name =
         guac_user_parse_args_string(user, GUAC_RDP_CLIENT_ARGS, argv,
-                IDX_DRIVE_NAME, 0);
+                IDX_DRIVE_NAME, "Guacamole Filesystem");
 
     settings->drive_path =
         guac_user_parse_args_string(user, GUAC_RDP_CLIENT_ARGS, argv,

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -186,6 +186,11 @@ typedef struct guac_rdp_settings {
      * Whether the virtual drive is enabled.
      */
     int drive_enabled;
+    
+    /**
+     * The name of the virtual drive to pass through to the RDP connection.
+     */
+    char* drive_name;
 
     /**
      * The local system path which will be used to persist the


### PR DESCRIPTION
Allows for the name of the redirected drive to be configured when pushing a filesystem through via RDP.

Note that this change not only allows for the name to be configured, but also *removes UTF-16 encoding* of the drive name as it appears that Windows does not expect the filesystem name to be UTF-16 encoded.