### PR TITLE
GUACAMOLE-523: Use client_name for redirect messages

### DIFF
--- a/src/protocols/rdp/guac_rdpdr/rdpdr_messages.c
+++ b/src/protocols/rdp/guac_rdpdr/rdpdr_messages.c
@@ -19,6 +19,7 @@
 
 #include "config.h"
 
+#include "rdp.h"
 #include "rdpdr_messages.h"
 #include "rdpdr_service.h"
 
@@ -161,7 +162,7 @@ void guac_rdpdr_process_server_announce(guac_rdpdrPlugin* rdpdr,
     guac_rdpdr_send_client_announce_reply(rdpdr, major, minor, client_id);
 
     /* Name request */
-    guac_rdpdr_send_client_name_request(rdpdr, "Guacamole RDP");
+    guac_rdpdr_send_client_name_request(rdpdr, ((guac_rdp_client *)rdpdr->client->data)->settings->client_name);
 
 }
 

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -667,7 +667,7 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     /* Client name */
     settings->client_name =
         guac_user_parse_args_string(user, GUAC_RDP_CLIENT_ARGS, argv,
-                IDX_CLIENT_NAME, NULL);
+                IDX_CLIENT_NAME, "Guacamole RDP");
 
     /* Initial program */
     settings->initial_program =


### PR DESCRIPTION
This change passes through the configured client_name in the RDP redirect messages, which tweaks how Windows shows redirected drives (Share on client_name) and printers (client_name: PRN1 in port settings).