### PR TITLE
GUACAMOLE-407: Refactor guacd Docker image to use "debian:stable" base.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@
 #
 
 
-# Use CentOS as base for the build
-ARG CENTOS_VERSION=centos7
-FROM centos:${CENTOS_VERSION} AS builder
+# Use Ubuntu as base for the build
+ARG UBUNTU_VERSION=xenial
+FROM ubuntu:${UBUNTU_VERSION} AS builder
 
 # Base directory for installed build artifacts.
 # Due to limitations of the Docker image build process, this value is
@@ -37,29 +37,28 @@ ARG BUILD_DIR=/tmp/guacd-docker-BUILD
 ARG BUILD_DEPENDENCIES="              \
         autoconf                      \
         automake                      \
-        cairo-devel                   \
-        freerdp-devel                 \
         gcc                           \
-        libjpeg-turbo-devel           \
-        libssh2-devel                 \
+        libcairo2-dev                 \
+        libfreerdp-dev                \
+        libjpeg-turbo8-dev            \
+        libossp-uuid-dev              \
+        libpango1.0-dev               \
+        libpulse-dev                  \
+        libssh2-1-dev                 \
+        libssl-dev                    \
+        libtelnet-dev                 \
         libtool                       \
-        libtelnet-devel               \
-        libvorbis-devel               \
-        libvncserver-devel            \
-        libwebp-devel                 \
-        make                          \
-        pango-devel                   \
-        pulseaudio-libs-devel         \
-        uuid-devel"
+        libvncserver-dev              \
+        libwebp-dev                   \
+        make"
 
 # Build time environment
 ENV LC_ALL=en_US.UTF-8
 
 # Bring build environment up to date and install build dependencies
-RUN yum -y update                        && \
-    yum -y install epel-release          && \
-    yum -y install $BUILD_DEPENDENCIES   && \
-    yum clean all
+RUN apt-get update                         && \
+    apt-get install -y $BUILD_DEPENDENCIES && \
+    rm -rf /var/lib/apt/lists/*
 
 # Add configuration scripts
 COPY src/guacd-docker/bin /opt/guacd/bin/
@@ -70,8 +69,8 @@ COPY . "$BUILD_DIR"
 # Build guacamole-server from local source
 RUN /opt/guacd/bin/build-guacd.sh "$BUILD_DIR" "$PREFIX_DIR"
 
-# Use same CentOS as the base for the runtime image
-FROM centos:${CENTOS_VERSION}
+# Use same Ubuntu as the base for the runtime image
+FROM ubuntu:${UBUNTU_VERSION}
 
 # Base directory for installed build artifacts.
 # Due to limitations of the Docker image build process, this value is
@@ -85,36 +84,74 @@ ENV LC_ALL=en_US.UTF-8
 ENV GUACD_LOG_LEVEL=info
 
 ARG RUNTIME_DEPENDENCIES="            \
-        cairo                         \
-        dejavu-sans-mono-fonts        \
-        freerdp                       \
-        freerdp-plugins               \
         ghostscript                   \
-        libjpeg-turbo                 \
-        libssh2                       \
-        liberation-mono-fonts         \
-        libtelnet                     \
-        libvorbis                     \
-        libvncserver                  \
-        libwebp                       \
-        pango                         \
-        pulseaudio-libs               \
-        terminus-fonts                \
-        uuid"
+        libcairo2                     \
+        fonts-liberation              \
+        fonts-dejavu                  \
+        libfreerdp-cache1.1           \
+        libfreerdp-client1.1          \
+        libfreerdp-codec1.1           \
+        libfreerdp-common1.1.0        \
+        libfreerdp-core1.1            \
+        libfreerdp-crypto1.1          \
+        libfreerdp-gdi1.1             \
+        libfreerdp-locale1.1          \
+        libfreerdp-plugins-standard   \
+        libfreerdp-primitives1.1      \
+        libfreerdp-rail1.1            \
+        libfreerdp-utils1.1           \
+        libjpeg-turbo8                \
+        libossp-uuid16                \
+        libpango1.0                   \
+        libpulse0                     \
+        libssh2-1                     \
+        libssl1.0.0                   \
+        libtelnet2                    \
+        libvncclient1                 \
+        libwebp5                      \
+        libwinpr-asn1-0.1             \
+        libwinpr-bcrypt0.1            \
+        libwinpr-credentials0.1       \
+        libwinpr-credui0.1            \
+        libwinpr-crt0.1               \
+        libwinpr-crypto0.1            \
+        libwinpr-dsparse0.1           \
+        libwinpr-environment0.1       \
+        libwinpr-error0.1             \
+        libwinpr-file0.1              \
+        libwinpr-handle0.1            \
+        libwinpr-heap0.1              \
+        libwinpr-input0.1             \
+        libwinpr-interlocked0.1       \
+        libwinpr-io0.1                \
+        libwinpr-library0.1           \
+        libwinpr-path0.1              \
+        libwinpr-pipe0.1              \
+        libwinpr-pool0.1              \
+        libwinpr-registry0.1          \
+        libwinpr-rpc0.1               \
+        libwinpr-sspi0.1              \
+        libwinpr-sspicli0.1           \
+        libwinpr-synch0.1             \
+        libwinpr-sysinfo0.1           \
+        libwinpr-thread0.1            \
+        libwinpr-timezone0.1          \
+        libwinpr-utils0.1             \
+        libwinpr-winhttp0.1           \
+        libwinpr-winsock0.1           \
+        xfonts-terminus"
 
 # Bring runtime environment up to date and install runtime dependencies
-RUN yum -y update                          && \
-    yum -y install epel-release            && \
-    yum -y install $RUNTIME_DEPENDENCIES   && \
-    yum clean all                          && \
-    rm -rf /var/cache/yum
+RUN apt-get update                           && \
+    apt-get install -y $RUNTIME_DEPENDENCIES && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy build artifacts into this stage
 COPY --from=builder ${PREFIX_DIR} ${PREFIX_DIR}
 
 # Link FreeRDP plugins into proper path
 RUN FREERDP_DIR=$(dirname \
-        $(rpm -ql freerdp-libs | grep 'libfreerdp.*\.so' | head -n1)) && \
+        $(dpkg-query -L libfreerdp | grep 'libfreerdp.*\.so' | head -n1)) && \
     FREERDP_PLUGIN_DIR="${FREERDP_DIR}/freerdp" && \
     mkdir -p "$FREERDP_PLUGIN_DIR" && \
     ln -s "$PREFIX_DIR"/lib/freerdp/*.so "$FREERDP_PLUGIN_DIR"

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ ARG PREFIX_DIR=/usr/local/guacamole
 
 # Runtime environment
 ENV LC_ALL=en_US.UTF-8
+ENV LD_LIBRARY_PATH=${PREFIX_DIR}/lib
 ENV GUACD_LOG_LEVEL=info
 
 ARG RUNTIME_DEPENDENCIES="            \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@
 #
 
 
-# Use Ubuntu as base for the build
-ARG UBUNTU_VERSION=artful
-FROM ubuntu:${UBUNTU_VERSION} AS builder
+# Use Debian as base for the build
+ARG DEBIAN_VERSION=stable
+FROM debian:${DEBIAN_VERSION} AS builder
 
 # Base directory for installed build artifacts.
 # Due to limitations of the Docker image build process, this value is
@@ -40,7 +40,7 @@ ARG BUILD_DEPENDENCIES="              \
         gcc                           \
         libcairo2-dev                 \
         libfreerdp-dev                \
-        libjpeg-turbo8-dev            \
+        libjpeg62-turbo-dev           \
         libossp-uuid-dev              \
         libpango1.0-dev               \
         libpulse-dev                  \
@@ -76,8 +76,8 @@ RUN ${PREFIX_DIR}/bin/list-dependencies.sh    \
         ${PREFIX_DIR}/lib/freerdp/guac*.so    \
         > ${PREFIX_DIR}/DEPENDENCIES
 
-# Use same Ubuntu as the base for the runtime image
-FROM ubuntu:${UBUNTU_VERSION}
+# Use same Debian as the base for the runtime image
+FROM debian:${DEBIAN_VERSION}
 
 # Base directory for installed build artifacts.
 # Due to limitations of the Docker image build process, this value is

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,11 +94,9 @@ ARG RUNTIME_DEPENDENCIES="            \
         libfreerdp-common1.1.0        \
         libfreerdp-core1.1            \
         libfreerdp-crypto1.1          \
-        libfreerdp-gdi1.1             \
         libfreerdp-locale1.1          \
-        libfreerdp-plugins-standard   \
         libfreerdp-primitives1.1      \
-        libfreerdp-rail1.1            \
+        libfreerdp-plugins-standard   \
         libfreerdp-utils1.1           \
         libjpeg-turbo8                \
         libossp-uuid16                \
@@ -109,36 +107,24 @@ ARG RUNTIME_DEPENDENCIES="            \
         libtelnet2                    \
         libvncclient1                 \
         libwebp5                      \
-        libwinpr-asn1-0.1             \
-        libwinpr-bcrypt0.1            \
-        libwinpr-credentials0.1       \
-        libwinpr-credui0.1            \
         libwinpr-crt0.1               \
-        libwinpr-crypto0.1            \
         libwinpr-dsparse0.1           \
         libwinpr-environment0.1       \
-        libwinpr-error0.1             \
         libwinpr-file0.1              \
         libwinpr-handle0.1            \
         libwinpr-heap0.1              \
         libwinpr-input0.1             \
         libwinpr-interlocked0.1       \
-        libwinpr-io0.1                \
         libwinpr-library0.1           \
         libwinpr-path0.1              \
-        libwinpr-pipe0.1              \
         libwinpr-pool0.1              \
         libwinpr-registry0.1          \
         libwinpr-rpc0.1               \
         libwinpr-sspi0.1              \
-        libwinpr-sspicli0.1           \
         libwinpr-synch0.1             \
         libwinpr-sysinfo0.1           \
         libwinpr-thread0.1            \
-        libwinpr-timezone0.1          \
         libwinpr-utils0.1             \
-        libwinpr-winhttp0.1           \
-        libwinpr-winsock0.1           \
         xfonts-terminus"
 
 # Bring runtime environment up to date and install runtime dependencies
@@ -151,7 +137,7 @@ COPY --from=builder ${PREFIX_DIR} ${PREFIX_DIR}
 
 # Link FreeRDP plugins into proper path
 RUN FREERDP_DIR=$(dirname \
-        $(dpkg-query -L libfreerdp | grep 'libfreerdp.*\.so' | head -n1)) && \
+        $(dpkg-query -L libfreerdp-client1.1 | grep 'libfreerdp.*\.so' | head -n1)) && \
     FREERDP_PLUGIN_DIR="${FREERDP_DIR}/freerdp" && \
     mkdir -p "$FREERDP_PLUGIN_DIR" && \
     ln -s "$PREFIX_DIR"/lib/freerdp/*.so "$FREERDP_PLUGIN_DIR"

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ FROM debian:${DEBIAN_VERSION}
 ARG PREFIX_DIR=/usr/local/guacamole
 
 # Runtime environment
-ENV LC_ALL=en_US.UTF-8
+ENV LC_ALL=C.UTF-8
 ENV LD_LIBRARY_PATH=${PREFIX_DIR}/lib
 ENV GUACD_LOG_LEVEL=info
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,6 @@ ARG BUILD_DEPENDENCIES="              \
         libwebp-dev                   \
         make"
 
-# Build time environment
-ENV LC_ALL=en_US.UTF-8
-
 # Bring build environment up to date and install build dependencies
 RUN apt-get update                         && \
     apt-get install -y $BUILD_DEPENDENCIES && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 
 
 # Use Ubuntu as base for the build
-ARG UBUNTU_VERSION=xenial
+ARG UBUNTU_VERSION=artful
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 
 # Base directory for installed build artifacts.

--- a/src/guacd-docker/bin/build-guacd.sh
+++ b/src/guacd-docker/bin/build-guacd.sh
@@ -43,7 +43,7 @@ PREFIX_DIR="$2"
 
 cd "$BUILD_DIR"
 autoreconf -fi
-./configure --prefix="$PREFIX_DIR"
+./configure --prefix="$PREFIX_DIR" --disable-guaclog
 make
 make install
 ldconfig

--- a/src/guacd-docker/bin/link-freerdp-plugins.sh
+++ b/src/guacd-docker/bin/link-freerdp-plugins.sh
@@ -1,0 +1,86 @@
+#!/bin/sh -e
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+##
+## @fn link-freerdp-plugins.sh
+##
+## Automatically creates any required symbolic links for the proper loading of
+## the given FreeRDP plugins. If a given plugin is already in the correct
+## directory, no link is created for that plugin.
+##
+## @param ...
+##     The FreeRDP plugins to add links for.
+##
+
+##
+## Given the full path to a FreeRDP plugin, locates the base directory of the
+## associated FreeRDP installation (where the FreeRDP library .so files are
+## located), printing the result to STDOUT. If the directory cannot be
+## determined, an error is printed.
+##
+## @param PLUGIN_FILE
+##     The full path to the FreeRDP plugin to check.
+##
+where_is_freerdp() {
+
+    PLUGIN_FILE="$1"
+
+    # Determine the location of all libfreerdp* libraries explicitly linked
+    # to given file
+    PATHS="$(ldd "$PLUGIN_FILE"              \
+                 | awk '/=>/{print $(NF-1)}' \
+                 | grep 'libfreerdp'         \
+                 | xargs -r dirname          \
+                 | xargs -r realpath         \
+                 | sort -u)"
+
+    # Verify that exactly one location was found
+    if [ "$(echo "$PATHS" | wc -l)" != 1 ]; then
+        echo "$1: Unable to locate FreeRDP install location." >&2
+        return 1
+    fi
+
+    echo "$PATHS"
+
+}
+
+#
+# Create symbolic links as necessary to include all given plugins within the
+# search path of FreeRDP
+#
+
+while [ -n "$1" ]; do
+
+    # Determine correct install location for FreeRDP plugins
+    FREERDP_DIR="$(where_is_freerdp "$1")"
+    FREERDP_PLUGIN_DIR="${FREERDP_DIR}/freerdp"
+
+    # Add symbolic link if necessary
+    if [ ! -e "$FREERDP_PLUGIN_DIR/$(basename "$1")" ]; then
+        mkdir -p "$FREERDP_PLUGIN_DIR"
+        ln -s "$1" "$FREERDP_PLUGIN_DIR"
+    else
+        echo "$1: Already in correct directory." >&2
+    fi
+
+    shift
+
+done
+

--- a/src/guacd-docker/bin/list-dependencies.sh
+++ b/src/guacd-docker/bin/list-dependencies.sh
@@ -1,0 +1,48 @@
+#!/bin/sh -e
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+##
+## @fn list-dependencies.sh
+##
+## Lists the Debian/Ubuntu package names for all library dependencies of the
+## given binaries. Each package is only listed once, even if multiple binaries
+## provided by the same package are given.
+##
+## @param ...
+##     The full paths to all binaries being checked.
+##
+
+while [ -n "$1" ]; do
+
+    # For all non-Guacamole library dependencies
+    ldd "$1" | grep -v 'libguac' | awk '/=>/{print $(NF-1)}' \
+        | while read LIBRARY; do
+
+        # Determine the Debian package which is associated with that
+        # library, if any
+        dpkg-query -S "$LIBRARY" 2> /dev/null || true
+
+    done
+
+    # Next binary
+    shift
+
+done | cut -f1 -d: | sort -u
+


### PR DESCRIPTION
These changes migrate from a CentOS-based image to a Debian-based one, updating dependencies accordingly.

Part of the idea behind this migration is to allow the Docker image to be easily rebuilt to take advantage of upstream updates, thus rather than hard-code runtime dependencies, the image now dynamically determines the packages required by listing the packages which provide the libraries that end up linked.