### PR TITLE
GUACAMOLE-533: Wait at most 5 seconds for connection processes to terminate following disconnect.

### DIFF
--- a/src/guacd/proc.h
+++ b/src/guacd/proc.h
@@ -41,6 +41,14 @@
 #define GUACD_USEC_TIMEOUT (GUACD_TIMEOUT*1000)
 
 /**
+ * The number of seconds to wait for any particular guac_client instance
+ * to be freed following disconnect. If the free operation does not complete
+ * within this period of time, the associated process will be forcibly
+ * terminated.
+ */
+#define GUACD_CLIENT_FREE_TIMEOUT 5
+
+/**
  * Process information of the internal remote desktop client.
  */
 typedef struct guacd_proc {


### PR DESCRIPTION
This change refactors guacd such that `guac_client_free()` is invoked in a dedicated thread, while guacd waits for the free/disconnect operation to signal completion. If free/disconnect does not complete in a timely manner, guacd takes control, forcibly kills the connection process, and logs a warning.

In addition, even if the `guac_client` is freed successfully and within a reasonable time, guacd now verifies that all child processes of that connection have also terminated. If any child processes remain, they are forcibly terminated by guacd, and a warning is logged.