### PR TITLE
GUACAMOLE-482: Allow encoding to proceed despite invalid instructions.

### DIFF
--- a/src/guacenc/encode.c
+++ b/src/guacenc/encode.c
@@ -65,8 +65,8 @@ static int guacenc_read_instructions(guacenc_display* display,
     while (!guac_parser_read(parser, socket, -1)) {
         if (guacenc_handle_instruction(display, parser->opcode,
                 parser->argc, parser->argv)) {
-            guac_parser_free(parser);
-            return 1;
+            guacenc_log(GUAC_LOG_DEBUG, "Handling of \"%s\" instruction "
+                    "failed.", parser->opcode);
         }
     }
 


### PR DESCRIPTION
guacenc should not fail the encoding process in cases where `Guacamole.Client` would not drop the connection, such as when a "blob" instruction is received for an unsupported stream.

This difference in behavior is a regression introduced by commit 19b5050, and is causing encoding failures if a session recording contains data from an audio stream. Session recordings do not currently include the initial "audio" instruction beginning such streams, thus any related "blob" instructions always appear invalid to guacenc.

This change logs instruction failures rather than aborting the entire encoding process.