### PR TITLE
GUACAMOLE-565: Add terminal-type parameter for SSH and Telnet.

### DIFF
--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -57,6 +57,7 @@ const char* GUAC_SSH_CLIENT_ARGS[] = {
     "read-only",
     "server-alive-interval",
     "backspace",
+    "terminal-type",
     NULL
 };
 
@@ -217,6 +218,12 @@ enum SSH_ARGS_IDX {
      */
     IDX_BACKSPACE,
 
+    /**
+     * The terminal emulator type that is passed to the remote system (e.g.
+     * "xterm" or "xterm-256color"). "linux" is used if unspecified.
+     */
+    IDX_TERMINAL_TYPE,
+
     SSH_ARGS_COUNT
 };
 
@@ -361,6 +368,11 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
         guac_user_parse_args_int(user, GUAC_SSH_CLIENT_ARGS, argv,
                 IDX_BACKSPACE, 127);
 
+    /* Read terminal emulator type. */
+    settings->terminal_type =
+        guac_user_parse_args_string(user, GUAC_SSH_CLIENT_ARGS, argv,
+                IDX_TERMINAL_TYPE, "linux");
+
     /* Parsing was successful */
     return settings;
 
@@ -395,6 +407,9 @@ void guac_ssh_settings_free(guac_ssh_settings* settings) {
     /* Free screen recording settings */
     free(settings->recording_name);
     free(settings->recording_path);
+
+    /* Free terminal emulator type. */
+    free(settings->terminal_type);
 
     /* Free overall structure */
     free(settings);

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -228,6 +228,11 @@ typedef struct guac_ssh_settings {
      */
     int backspace;
 
+    /**
+     * The terminal emulator type that is passed to the remote system.
+     */
+    char* terminal_type;
+
 } guac_ssh_settings;
 
 /**

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -307,7 +307,8 @@ void* ssh_client_thread(void* data) {
                 "  Backspace may not work as expected.");
 
     /* Request PTY */
-    if (libssh2_channel_request_pty_ex(ssh_client->term_channel, "linux", sizeof("linux")-1,
+    if (libssh2_channel_request_pty_ex(ssh_client->term_channel,
+            settings->terminal_type, strlen(settings->terminal_type),
             ssh_ttymodes, ttymodeBytes, ssh_client->term->term_width,
             ssh_client->term->term_height, 0, 0)) {
         guac_client_abort(client, GUAC_PROTOCOL_STATUS_UPSTREAM_ERROR, "Unable to allocate PTY.");

--- a/src/protocols/telnet/settings.c
+++ b/src/protocols/telnet/settings.c
@@ -51,6 +51,7 @@ const char* GUAC_TELNET_CLIENT_ARGS[] = {
     "create-recording-path",
     "read-only",
     "backspace",
+    "terminal-type",
     NULL
 };
 
@@ -180,6 +181,12 @@ enum TELNET_ARGS_IDX {
      * if not specified.
      */
     IDX_BACKSPACE,
+
+    /**
+     * The terminal emulator type that is passed to the remote system (e.g.
+     * "xterm" or "xterm-256color"). "linux" is used if unspecified.
+     */
+    IDX_TERMINAL_TYPE,
 
     TELNET_ARGS_COUNT
 };
@@ -340,6 +347,11 @@ guac_telnet_settings* guac_telnet_parse_args(guac_user* user,
         guac_user_parse_args_int(user, GUAC_TELNET_CLIENT_ARGS, argv,
                 IDX_BACKSPACE, 127);
 
+    /* Read terminal emulator type. */
+    settings->terminal_type =
+        guac_user_parse_args_string(user, GUAC_TELNET_CLIENT_ARGS, argv,
+                IDX_TERMINAL_TYPE, "linux");
+
     /* Parsing was successful */
     return settings;
 
@@ -378,6 +390,9 @@ void guac_telnet_settings_free(guac_telnet_settings* settings) {
     /* Free screen recording settings */
     free(settings->recording_name);
     free(settings->recording_path);
+
+    /* Free terminal emulator type. */
+    free(settings->terminal_type);
 
     /* Free overall structure */
     free(settings);

--- a/src/protocols/telnet/settings.h
+++ b/src/protocols/telnet/settings.h
@@ -214,6 +214,11 @@ typedef struct guac_telnet_settings {
      */
     int backspace;
 
+    /**
+     * The terminal emulator type that is passed to the remote system.
+     */
+    char* terminal_type;
+
 } guac_telnet_settings;
 
 /**

--- a/src/protocols/telnet/telnet.c
+++ b/src/protocols/telnet/telnet.c
@@ -216,7 +216,7 @@ static void __guac_telnet_event_handler(telnet_t* telnet, telnet_event_t* event,
         /* Terminal type request */
         case TELNET_EV_TTYPE:
             if (event->ttype.cmd == TELNET_TTYPE_SEND)
-                telnet_ttype_is(telnet_client->telnet, "linux");
+                telnet_ttype_is(telnet_client->telnet, settings->terminal_type);
             break;
 
         /* Environment request */


### PR DESCRIPTION
Add a terminal-type parameter for SSH and Telnet connections, to specify the terminal emulator type that is passed to programs. If not specified, the default type of "linux" is used in keep with existing behavior.

Some programs make use of the terminal type to determine some of the terminal's capabilities. For example, tmux seems to only have good 256-color support when the terminal type is something like `screen-256color` instead of `linux`.