### PR TITLE
GUACAMOLE-422: Add support for timezone redirection

### DIFF
--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -719,7 +719,7 @@ static int guac_rdp_handle_connection(guac_client* client) {
     guac_common_cursor_set_pointer(rdp_client->display->cursor);
 
     /* Push desired settings to FreeRDP */
-    guac_rdp_push_settings(settings, rdp_inst);
+    guac_rdp_push_settings(client, settings, rdp_inst);
 
     /* Connect to RDP server */
     if (!freerdp_connect(rdp_inst)) {

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -1281,15 +1281,8 @@ void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp) {
 #endif
 
     /* Device redirection */
-    if (guac_settings->timezone) {
-
-        /* Set the TZ env variable */
-        if (setenv("TZ", guac_settings->timezone, 1)) {
-            guac_user_log(user, GUAC_LOG_WARNING, "Could not set TZ "
-                "variable.  Received error %i", errno);
-        }
-
-    }
+    if (guac_settings->timezone)
+        setenv("TZ", guac_settings->timezone, 1)
 
 #ifdef LEGACY_RDPSETTINGS
 #ifdef HAVE_RDPSETTINGS_DEVICEREDIRECTION

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -1280,8 +1280,15 @@ void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp) {
 #endif
 
     /* Device redirection */
-    if (guac_settings->timezone)
-        setenv("TZ", guac_settings->timezone, 1);
+    if (guac_settings->timezone) {
+
+        /* Set the TZ env variable */
+        if (setenv("TZ", guac_settings->timezone, 1)) {
+            guac_user_log(user, GUAC_LOG_WARNING, "Could not set TZ "
+                "variable.  Received error %i", errno);
+        }
+
+    }
 
 #ifdef LEGACY_RDPSETTINGS
 #ifdef HAVE_RDPSETTINGS_DEVICEREDIRECTION

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -1169,7 +1169,8 @@ static char* guac_rdp_strdup(const char* str) {
 
 }
 
-void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp) {
+void guac_rdp_push_settings(guac_client* client,
+        guac_rdp_settings* guac_settings, freerdp* rdp) {
 
     BOOL bitmap_cache = !guac_settings->disable_bitmap_caching;
     rdpSettings* rdp_settings = rdp->settings;
@@ -1280,10 +1281,15 @@ void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp) {
 #endif
 #endif
 
-    /* Device redirection */
-    if (guac_settings->timezone)
-        setenv("TZ", guac_settings->timezone, 1)
+    /* Timezone redirection */
+    if (guac_settings->timezone) {
+        if(setenv("TZ", guac_settings->timezone, 1)) {
+            guac_client_log(client, GUAC_LOG_WARNING,
+                "Unable to set TZ variable, error %i", errno);
+        }
+    }
 
+    /* Device redirection */
 #ifdef LEGACY_RDPSETTINGS
 #ifdef HAVE_RDPSETTINGS_DEVICEREDIRECTION
     rdp_settings->device_redirection =  guac_settings->audio_enabled

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -79,6 +79,7 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
     "disable-glyph-caching",
     "preconnection-id",
     "preconnection-blob",
+    "timezone",
 
 #ifdef ENABLE_COMMON_SSH
     "enable-sftp",
@@ -355,6 +356,11 @@ enum RDP_ARGS_IDX {
      * destination VM.
      */
     IDX_PRECONNECTION_BLOB,
+
+    /**
+     * The timezone to pass through to the RDP connection.
+     */
+    IDX_TIMEZONE,
 
 #ifdef ENABLE_COMMON_SSH
     /**
@@ -840,6 +846,11 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     if (settings->server_layout == NULL)
         settings->server_layout = guac_rdp_keymap_find(GUAC_DEFAULT_KEYMAP);
 
+    /* Timezone if provied by client */
+    settings->timezone =
+        guac_user_parse_args_string(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_TIMEZONE, NULL);
+
 #ifdef ENABLE_COMMON_SSH
     /* SFTP enable/disable */
     settings->enable_sftp =
@@ -1013,6 +1024,7 @@ void guac_rdp_settings_free(guac_rdp_settings* settings) {
     free(settings->remote_app);
     free(settings->remote_app_args);
     free(settings->remote_app_dir);
+    free(settings->timezone);
     free(settings->username);
     free(settings->printer_name);
 
@@ -1265,6 +1277,9 @@ void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp) {
 #endif
 
     /* Device redirection */
+    if (guac_settings->timezone)
+        setenv("TZ", guac_settings->timezone, 1);
+
 #ifdef LEGACY_RDPSETTINGS
 #ifdef HAVE_RDPSETTINGS_DEVICEREDIRECTION
     rdp_settings->device_redirection =  guac_settings->audio_enabled

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -35,6 +35,7 @@
 #include "compat/winpr-wtypes.h"
 #endif
 
+#include <errno.h>
 #include <stddef.h>
 #include <string.h>
 

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -358,7 +358,10 @@ enum RDP_ARGS_IDX {
     IDX_PRECONNECTION_BLOB,
 
     /**
-     * The timezone to pass through to the RDP connection.
+     * The timezone to pass through to the RDP connection, in IANA format, which
+     * will be translated into Windows formats.  See the following page for
+     * information and list of valid values:
+     * https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
      */
     IDX_TIMEZONE,
 

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -1286,7 +1286,7 @@ void guac_rdp_push_settings(guac_client* client,
         if (setenv("TZ", guac_settings->timezone, 1)) {
             guac_client_log(client, GUAC_LOG_WARNING,
                 "Unable to forward timezone: TZ environment variable "
-                "could not be set: %s", sterror(errno));
+                "could not be set: %s", strerror(errno));
         }
     }
 

--- a/src/protocols/rdp/rdp_settings.c
+++ b/src/protocols/rdp/rdp_settings.c
@@ -1283,9 +1283,10 @@ void guac_rdp_push_settings(guac_client* client,
 
     /* Timezone redirection */
     if (guac_settings->timezone) {
-        if(setenv("TZ", guac_settings->timezone, 1)) {
+        if (setenv("TZ", guac_settings->timezone, 1)) {
             guac_client_log(client, GUAC_LOG_WARNING,
-                "Unable to set TZ variable, error %i", errno);
+                "Unable to forward timezone: TZ environment variable "
+                "could not be set: %s", sterror(errno));
         }
     }
 

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -552,13 +552,17 @@ extern const char* GUAC_RDP_CLIENT_ARGS[];
 /**
  * Save all given settings to the given freerdp instance.
  *
+ * @param client
+ *     The guac_client object providing the settings.
+ *
  * @param guac_settings
  *     The guac_rdp_settings object to save.
  *
  * @param rdp
  *     The RDP instance to save settings to.
  */
-void guac_rdp_push_settings(guac_rdp_settings* guac_settings, freerdp* rdp);
+void guac_rdp_push_settings(guac_client* client,
+        guac_rdp_settings* guac_settings, freerdp* rdp);
 
 /**
  * Returns the width of the RDP session display.

--- a/src/protocols/rdp/rdp_settings.h
+++ b/src/protocols/rdp/rdp_settings.h
@@ -341,6 +341,11 @@ typedef struct guac_rdp_settings {
      */
     char* preconnection_blob;
 
+    /**
+     * The timezone to pass through to the RDP connection.
+     */
+    char* timezone;
+
 #ifdef ENABLE_COMMON_SSH
     /**
      * Whether SFTP should be enabled for the VNC connection.

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -61,6 +61,7 @@ const char* GUAC_SSH_CLIENT_ARGS[] = {
     "terminal-type",
     "scrollback",
     "locale",
+    "timezone",
     NULL
 };
 
@@ -246,6 +247,15 @@ enum SSH_ARGS_IDX {
      * variable to be set.
      */
     IDX_LOCALE,
+     
+    /**
+     * The timezone that is passed from the client system to the
+     * remote server, or null if not specified.  If set, and allowed
+     * by the remote SSH server, the TZ environment variable will be
+     * set on the remote session, causing the session to be localized
+     * to the specified timezone.
+     */
+    IDX_TIMEZONE,
 
     SSH_ARGS_COUNT
 };
@@ -410,6 +420,11 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
         guac_user_parse_args_string(user, GUAC_SSH_CLIENT_ARGS, argv,
                 IDX_LOCALE, NULL);
 
+    /* Read the client timezone. */
+    settings->timezone =
+        guac_user_parse_args_string(user, GUAC_SSH_CLIENT_ARGS, argv,
+                IDX_TIMEZONE, NULL);
+
     /* Parsing was successful */
     return settings;
 
@@ -451,6 +466,9 @@ void guac_ssh_settings_free(guac_ssh_settings* settings) {
 
     /* Free locale */
     free(settings->locale);
+
+    /* Free the client timezone. */
+    free(settings->timezone);
 
     /* Free overall structure */
     free(settings);

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -249,11 +249,12 @@ enum SSH_ARGS_IDX {
     IDX_LOCALE,
      
     /**
-     * The timezone that is passed from the client system to the
-     * remote server, or null if not specified.  If set, and allowed
-     * by the remote SSH server, the TZ environment variable will be
-     * set on the remote session, causing the session to be localized
-     * to the specified timezone.
+     * The timezone that is to be passed to the remote system, via the
+     * TZ environment variable.  By default, no timezone is forwarded
+     * and the timezone of the remote system will be used.  This
+     * setting will only work if the SSH server allows the TZ variable
+     * to be set.  Timezones should be in standard IANA format, see:
+     * https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
      */
     IDX_TIMEZONE,
 

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -253,6 +253,7 @@ typedef struct guac_ssh_settings {
      * environment variable.
      */
     char* locale;
+
     /** 
      * The client timezone to pass to the remote system.
      */

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -253,6 +253,10 @@ typedef struct guac_ssh_settings {
      * environment variable.
      */
     char* locale;
+    /** 
+     * The client timezone to pass to the remote system.
+     */
+    char* timezone;
 
 } guac_ssh_settings;
 

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -256,6 +256,10 @@ void* ssh_client_thread(void* data) {
         return NULL;
     }
 
+    /* Set the client timezone */
+    if (settings->timezone != NULL)
+        libssh2_channel_setenv(ssh_client->term_channel, "TZ", settings->timezone);
+
 #ifdef ENABLE_SSH_AGENT
     /* Start SSH agent forwarding, if enabled */
     if (ssh_client->enable_agent) {

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -257,8 +257,15 @@ void* ssh_client_thread(void* data) {
     }
 
     /* Set the client timezone */
-    if (settings->timezone != NULL)
-        libssh2_channel_setenv(ssh_client->term_channel, "TZ", settings->timezone);
+    if (settings->timezone != NULL) {
+        if (libssh2_channel_setenv(ssh_client->term_channel, "TZ",
+                    settings->timezone)) {
+            guac_client_log(client, GUAC_LOG_WARNING,
+                    "Unable to set the timzeone: SSH server "
+                    "refused to set \"TZ\" variable.");
+        }
+    }
+
 
 #ifdef ENABLE_SSH_AGENT
     /* Start SSH agent forwarding, if enabled */

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -261,7 +261,7 @@ void* ssh_client_thread(void* data) {
         if (libssh2_channel_setenv(ssh_client->term_channel, "TZ",
                     settings->timezone)) {
             guac_client_log(client, GUAC_LOG_WARNING,
-                    "Unable to set the timzeone: SSH server "
+                    "Unable to set the timezone: SSH server "
                     "refused to set \"TZ\" variable.");
         }
     }


### PR DESCRIPTION
These are the server-side changes necessary to support timezone redirection for RDP and SSH.  I originally attempted to implement for Telnet, as well; however, I quickly found that at least the default Linux telnet server implementation completely ignores arbitrary environment variables and only pays attention to specific ones (USER, REMOTEHOST, DISPLAY, etc.).