### PR TITLE
GUACAMOLE-574: Allow input for SSH/telnet to come from "STDIN" pipe.

### DIFF
--- a/src/protocols/ssh/Makefile.am
+++ b/src/protocols/ssh/Makefile.am
@@ -26,6 +26,7 @@ libguac_client_ssh_la_SOURCES = \
     client.c                    \
     clipboard.c                 \
     input.c                     \
+    pipe.c                      \
     settings.c                  \
     sftp.c                      \
     ssh.c                       \
@@ -36,6 +37,7 @@ noinst_HEADERS =                \
     client.h                    \
     clipboard.h                 \
     input.h                     \
+    pipe.h                      \
     settings.h                  \
     sftp.h                      \
     ssh.h                       \

--- a/src/protocols/ssh/pipe.c
+++ b/src/protocols/ssh/pipe.c
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+#include "pipe.h"
+#include "ssh.h"
+#include "terminal/terminal.h"
+
+#include <guacamole/protocol.h>
+#include <guacamole/socket.h>
+#include <guacamole/user.h>
+
+#include <string.h>
+
+int guac_ssh_pipe_handler(guac_user* user, guac_stream* stream,
+        char* mimetype, char* name) {
+
+    guac_client* client = user->client;
+    guac_ssh_client* ssh_client = (guac_ssh_client*) client->data;
+
+    /* Redirect STDIN if pipe has required name */
+    if (strcmp(name, GUAC_SSH_STDIN_PIPE_NAME) == 0) {
+        guac_terminal_send_stream(ssh_client->term, user, stream);
+        return 0;
+    }
+
+    /* No other inbound pipe streams are supported */
+    guac_protocol_send_ack(user->socket, stream, "No such input stream.",
+            GUAC_PROTOCOL_STATUS_RESOURCE_NOT_FOUND);
+    guac_socket_flush(user->socket);
+    return 0;
+
+}
+

--- a/src/protocols/ssh/pipe.h
+++ b/src/protocols/ssh/pipe.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#ifndef GUAC_SSH_PIPE_H
+#define GUAC_SSH_PIPE_H
+
+#include "config.h"
+
+#include <guacamole/user.h>
+
+/**
+ * The name reserved for the inbound pipe stream which forces the terminal
+ * emulator's STDIN to be received from the pipe.
+ */
+#define GUAC_SSH_STDIN_PIPE_NAME "STDIN"
+
+/**
+ * Handles an incoming stream from a Guacamole "pipe" instruction. If the pipe
+ * is named "STDIN", the the contents of the pipe stream are redirected to
+ * STDIN of the terminal emulator for as long as the pipe is open.
+ */
+guac_user_pipe_handler guac_ssh_pipe_handler;
+
+#endif
+

--- a/src/protocols/ssh/user.c
+++ b/src/protocols/ssh/user.c
@@ -23,6 +23,7 @@
 #include "common/display.h"
 #include "input.h"
 #include "user.h"
+#include "pipe.h"
 #include "sftp.h"
 #include "ssh.h"
 #include "settings.h"
@@ -82,6 +83,9 @@ int guac_ssh_user_join_handler(guac_user* user, int argc, char** argv) {
         user->key_handler       = guac_ssh_user_key_handler;
         user->mouse_handler     = guac_ssh_user_mouse_handler;
         user->clipboard_handler = guac_ssh_clipboard_handler;
+
+        /* STDIN redirection */
+        user->pipe_handler = guac_ssh_pipe_handler;
 
         /* Display size change events */
         user->size_handler = guac_ssh_user_size_handler;

--- a/src/protocols/telnet/Makefile.am
+++ b/src/protocols/telnet/Makefile.am
@@ -26,6 +26,7 @@ libguac_client_telnet_la_SOURCES = \
     client.c                       \
     clipboard.c                    \
     input.c                        \
+    pipe.c                         \
     settings.c                     \
     telnet.c                       \
     user.c
@@ -34,6 +35,7 @@ noinst_HEADERS = \
     client.h     \
     clipboard.h  \
     input.h      \
+    pipe.h       \
     settings.h   \
     telnet.h     \
     user.h

--- a/src/protocols/telnet/pipe.c
+++ b/src/protocols/telnet/pipe.c
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+#include "pipe.h"
+#include "telnet.h"
+#include "terminal/terminal.h"
+
+#include <guacamole/protocol.h>
+#include <guacamole/socket.h>
+#include <guacamole/user.h>
+
+#include <string.h>
+
+int guac_telnet_pipe_handler(guac_user* user, guac_stream* stream,
+        char* mimetype, char* name) {
+
+    guac_client* client = user->client;
+    guac_telnet_client* telnet_client = (guac_telnet_client*) client->data;
+
+    /* Redirect STDIN if pipe has required name */
+    if (strcmp(name, GUAC_TELNET_STDIN_PIPE_NAME) == 0) {
+        guac_terminal_send_stream(telnet_client->term, user, stream);
+        return 0;
+    }
+
+    /* No other inbound pipe streams are supported */
+    guac_protocol_send_ack(user->socket, stream, "No such input stream.",
+            GUAC_PROTOCOL_STATUS_RESOURCE_NOT_FOUND);
+    guac_socket_flush(user->socket);
+    return 0;
+
+}
+

--- a/src/protocols/telnet/pipe.h
+++ b/src/protocols/telnet/pipe.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#ifndef GUAC_TELNET_PIPE_H
+#define GUAC_TELNET_PIPE_H
+
+#include "config.h"
+
+#include <guacamole/user.h>
+
+/**
+ * The name reserved for the inbound pipe stream which forces the terminal
+ * emulator's STDIN to be received from the pipe.
+ */
+#define GUAC_TELNET_STDIN_PIPE_NAME "STDIN"
+
+/**
+ * Handles an incoming stream from a Guacamole "pipe" instruction. If the pipe
+ * is named "STDIN", the the contents of the pipe stream are redirected to
+ * STDIN of the terminal emulator for as long as the pipe is open.
+ */
+guac_user_pipe_handler guac_telnet_pipe_handler;
+
+#endif
+

--- a/src/protocols/telnet/user.c
+++ b/src/protocols/telnet/user.c
@@ -21,6 +21,7 @@
 
 #include "clipboard.h"
 #include "input.h"
+#include "pipe.h"
 #include "settings.h"
 #include "telnet.h"
 #include "terminal/terminal.h"
@@ -81,6 +82,9 @@ int guac_telnet_user_join_handler(guac_user* user, int argc, char** argv) {
         user->key_handler       = guac_telnet_user_key_handler;
         user->mouse_handler     = guac_telnet_user_mouse_handler;
         user->clipboard_handler = guac_telnet_clipboard_handler;
+
+        /* STDIN redirection */
+        user->pipe_handler = guac_telnet_pipe_handler;
 
         /* Display size change events */
         user->size_handler = guac_telnet_user_size_handler;

--- a/src/terminal/Makefile.am
+++ b/src/terminal/Makefile.am
@@ -48,6 +48,7 @@ libguac_terminal_la_SOURCES =   \
     select.c                    \
     terminal.c                  \
     terminal_handlers.c         \
+    terminal-stdin-stream.c     \
     typescript.c                \
     xparsecolor.c
 

--- a/src/terminal/terminal-stdin-stream.c
+++ b/src/terminal/terminal-stdin-stream.c
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+#include "terminal/common.h"
+#include "terminal/terminal.h"
+
+#include <guacamole/protocol.h>
+#include <guacamole/socket.h>
+#include <guacamole/user.h>
+
+/**
+ * Handler for "blob" instructions which writes the data of received
+ * blobs to STDIN of the terminal associated with the stream.
+ *
+ * @see guac_user_blob_handler
+ */
+static int guac_terminal_input_stream_blob_handler(guac_user* user,
+        guac_stream* stream, void* data, int length) {
+
+    guac_terminal* term = (guac_terminal*) stream->data;
+
+    /* Attempt to write received data */
+    guac_terminal_lock(term);
+    int result = guac_terminal_write_all(term->stdin_pipe_fd[1], data, length);
+    guac_terminal_unlock(term);
+
+    /* Acknowledge receipt of data and result of write attempt */
+    if (result <= 0) {
+
+        guac_user_log(user, GUAC_LOG_DEBUG,
+                "Attempt to write to STDIN via an inbound stream failed.");
+
+        guac_protocol_send_ack(user->socket, stream,
+                "Attempt to write to STDIN failed.",
+                GUAC_PROTOCOL_STATUS_SUCCESS);
+
+    }
+    else {
+
+        guac_user_log(user, GUAC_LOG_DEBUG,
+                "%i bytes successfully written to STDIN from an inbound stream.",
+                length);
+
+        guac_protocol_send_ack(user->socket, stream,
+                "Data written to STDIN.",
+                GUAC_PROTOCOL_STATUS_SUCCESS);
+
+    }
+
+    guac_socket_flush(user->socket);
+    return 0;
+
+}
+
+/**
+ * Handler for "end" instructions which disassociates the given
+ * stream from the terminal, allowing user input to resume.
+ *
+ * @see guac_user_end_handler
+ */
+static int guac_terminal_input_stream_end_handler(guac_user* user,
+        guac_stream* stream) {
+
+    guac_terminal* term = (guac_terminal*) stream->data;
+
+    /* Reset input stream, unblocking user input */
+    guac_terminal_lock(term);
+    term->input_stream = NULL;
+    guac_terminal_unlock(term);
+
+    guac_user_log(user, GUAC_LOG_DEBUG, "Inbound stream closed. User input "
+            "will now resume affecting STDIN.");
+
+    return 0;
+
+}
+
+/**
+ * Internal implementation of guac_terminal_send_stream() which assumes
+ * that the guac_terminal has already been locked through a call to
+ * guac_terminal_lock(). The semantics of all parameters and the return
+ * value are identical to guac_terminal_send_stream().
+ *
+ * @see guac_terminal_send_stream()
+ */
+static int __guac_terminal_send_stream(guac_terminal* term, guac_user* user,
+        guac_stream* stream) {
+
+    /* If a stream is already being used for STDIN, deny creation of
+     * further streams */
+    if (term->input_stream != NULL) {
+
+        guac_user_log(user, GUAC_LOG_DEBUG, "Attempt to direct the contents "
+                "of an inbound stream to STDIN denied. STDIN is already "
+                "being read from an inbound stream.");
+
+        guac_protocol_send_ack(user->socket, stream,
+                "STDIN is already being read from a stream.",
+                GUAC_PROTOCOL_STATUS_RESOURCE_CONFLICT);
+
+        guac_socket_flush(user->socket);
+        return 1;
+
+    }
+
+    guac_user_log(user, GUAC_LOG_DEBUG, "Now reading STDIN from inbound "
+            "stream. User input will no longer affect STDIN until the "
+            "stream is closed.");
+
+    stream->blob_handler = guac_terminal_input_stream_blob_handler;
+    stream->end_handler = guac_terminal_input_stream_end_handler;
+    stream->data = term;
+
+    /* Block user input until stream is ended */
+    term->input_stream = stream;
+
+    /* Acknowledge redirection from stream */
+    guac_protocol_send_ack(user->socket, stream,
+            "Now reading STDIN from stream.",
+            GUAC_PROTOCOL_STATUS_SUCCESS);
+
+    guac_socket_flush(user->socket);
+    return 0;
+
+}
+
+int guac_terminal_send_stream(guac_terminal* term, guac_user* user,
+        guac_stream* stream) {
+
+    int result;
+
+    guac_terminal_lock(term);
+    result = __guac_terminal_send_stream(term, user, stream);
+    guac_terminal_unlock(term);
+
+    return result;
+
+}
+


### PR DESCRIPTION
This change adds support to SSH and telnet for reading user input from a pipe stream named "STDIN". When the client side opens this pipe stream, user input through keyboard, clipboard, etc. is blocked, and data from the pipe stream is sent directly over the SSH/telnet connection. User input is unblocked once the "STDIN" pipe is closed.