### PR TITLE
GUACAMOLE-573: Correct scrollback buffer bounds checks.

### DIFF
--- a/src/terminal/buffer.c
+++ b/src/terminal/buffer.c
@@ -83,12 +83,10 @@ guac_terminal_buffer_row* guac_terminal_buffer_get_row(guac_terminal_buffer* buf
     guac_terminal_char* first;
     guac_terminal_buffer_row* buffer_row;
 
-    /* Calculate scrollback row index */
-    int index = buffer->top + row;
+    /* Normalize row index into a scrollback buffer index */
+    int index = (buffer->top + row) % buffer->available;
     if (index < 0)
         index += buffer->available;
-    else if (index >= buffer->available)
-        index -= buffer->available;
 
     /* Get row */
     buffer_row = &(buffer->rows[index]);

--- a/src/terminal/select.c
+++ b/src/terminal/select.c
@@ -149,12 +149,6 @@ static int guac_terminal_find_char(guac_terminal* terminal,
 
     int start_column = *column;
 
-    /* If requested row is outside the bounds of the current terminal or
-     * scrollback, assume the character is 1 column wide */
-    if (row >= terminal->term_height
-            || row < terminal->term_height - terminal->buffer->length)
-        return 1;
-
     guac_terminal_buffer_row* buffer_row = guac_terminal_buffer_get_row(terminal->buffer, row, 0);
     if (start_column < buffer_row->length) {
 
@@ -290,12 +284,6 @@ static void guac_terminal_clipboard_append_row(guac_terminal* terminal,
 
     char buffer[1024];
     int i = start;
-
-    /* If requested row is outside the bounds of the current terminal or
-     * scrollback, do nothing */
-    if (row >= terminal->term_height
-            || row < terminal->term_height - terminal->buffer->length)
-        return;
 
     guac_terminal_buffer_row* buffer_row =
         guac_terminal_buffer_get_row(terminal->buffer, row, 0);

--- a/src/terminal/terminal/buffer.h
+++ b/src/terminal/terminal/buffer.h
@@ -70,7 +70,10 @@ typedef struct guac_terminal_buffer {
     guac_terminal_buffer_row* rows;
 
     /**
-     * The row to replace when adding a new row to the buffer.
+     * The index of the first row in the buffer (the row which represents row 0
+     * with respect to the terminal display). This is also the index of the row
+     * to replace when insufficient space remains in the buffer to add a new
+     * row.
      */
     int top;
 


### PR DESCRIPTION
The new bounds checks added for copying text from the scrollback buffer are incorrect for the case where the number of rows in scrollback has not yet reached at least the size of the terminal window. These changes remove those incorrect checks, instead modifying scrollback buffer row retrieval such that it is guaranteed to stay within bounds.