### PR TITLE
GUACAMOLE-597: Add optional flags to OSC for controlling redirected terminal output.

### DIFF
--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -1961,7 +1961,8 @@ int guac_terminal_next_tab(guac_terminal* term, int column) {
     return tabstop;
 }
 
-void guac_terminal_pipe_stream_open(guac_terminal* term, const char* name) {
+void guac_terminal_pipe_stream_open(guac_terminal* term, const char* name,
+        int flags) {
 
     guac_client* client = term->client;
     guac_socket* socket = client->socket;
@@ -1972,13 +1973,14 @@ void guac_terminal_pipe_stream_open(guac_terminal* term, const char* name) {
     /* Allocate and assign new pipe stream */
     term->pipe_stream = guac_client_alloc_stream(client);
     term->pipe_buffer_length = 0;
+    term->pipe_stream_flags = flags;
 
     /* Open new pipe stream */
     guac_protocol_send_pipe(socket, term->pipe_stream, "text/plain", name);
 
     /* Log redirect at debug level */
-    guac_client_log(client, GUAC_LOG_DEBUG,
-            "Terminal output now redirected to pipe '%s'.", name);
+    guac_client_log(client, GUAC_LOG_DEBUG, "Terminal output now directed to "
+            "pipe \"%s\" (flags=%i).", name, flags);
 
 }
 

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -1551,6 +1551,10 @@ void guac_terminal_flush(guac_terminal* terminal) {
     if (terminal->typescript != NULL)
         guac_terminal_typescript_flush(terminal->typescript);
 
+    /* Flush pipe stream if automatic flushing is enabled */
+    if (terminal->pipe_stream_flags & GUAC_TERMINAL_PIPE_AUTOFLUSH)
+        guac_terminal_pipe_stream_flush(terminal);
+
     /* Flush display state */
     guac_terminal_select_redraw(terminal);
     guac_terminal_commit_cursor(terminal);

--- a/src/terminal/terminal/terminal.h
+++ b/src/terminal/terminal/terminal.h
@@ -98,6 +98,13 @@
  */
 #define GUAC_TERMINAL_SCHEME_NUMBERED "color"
 
+/**
+ * Flag which specifies that terminal output should be sent to both the current
+ * pipe stream and the user's display. By default, terminal output will be sent
+ * only to the open pipe.
+ */
+#define GUAC_TERMINAL_PIPE_INTERPRET_OUTPUT 1
+
 typedef struct guac_terminal guac_terminal;
 
 /**
@@ -219,6 +226,8 @@ struct guac_terminal {
      * Bitwise OR of all flags which apply to the currently-open pipe stream.
      * If no pipe stream is open, this value has no meaning, and its contents
      * are undefined.
+     *
+     * @see GUAC_TERMINAL_PIPE_INTERPRET_OUTPUT
      */
     int pipe_stream_flags;
 
@@ -931,6 +940,8 @@ int guac_terminal_next_tab(guac_terminal* term, int column);
  * @param flags
  *     A bitwise OR of all integer flags which should apply to the new pipe
  *     stream.
+ *
+ *     @see GUAC_TERMINAL_PIPE_INTERPRET_OUTPUT
  */
 void guac_terminal_pipe_stream_open(guac_terminal* term, const char* name,
         int flags);

--- a/src/terminal/terminal/terminal.h
+++ b/src/terminal/terminal/terminal.h
@@ -216,6 +216,13 @@ struct guac_terminal {
     guac_stream* pipe_stream;
 
     /**
+     * Bitwise OR of all flags which apply to the currently-open pipe stream.
+     * If no pipe stream is open, this value has no meaning, and its contents
+     * are undefined.
+     */
+    int pipe_stream_flags;
+
+    /**
      * Buffer of data pending write to the pipe_stream. Data within this buffer
      * will be flushed to the pipe_stream when either (1) the buffer is full
      * and another character needs to be written or (2) the pipe_stream is
@@ -920,8 +927,13 @@ int guac_terminal_next_tab(guac_terminal* term, int column);
  *
  * @param name
  *     The name of the pipe stream to open.
+ *
+ * @param flags
+ *     A bitwise OR of all integer flags which should apply to the new pipe
+ *     stream.
  */
-void guac_terminal_pipe_stream_open(guac_terminal* term, const char* name);
+void guac_terminal_pipe_stream_open(guac_terminal* term, const char* name,
+        int flags);
 
 /**
  * Writes a single byte of data to the pipe stream currently open and

--- a/src/terminal/terminal/terminal.h
+++ b/src/terminal/terminal/terminal.h
@@ -105,6 +105,14 @@
  */
 #define GUAC_TERMINAL_PIPE_INTERPRET_OUTPUT 1
 
+/**
+ * Flag which forces the open pipe stream to be flushed automatically, whenever
+ * a new frame would be rendered, with only minimal buffering performed between
+ * frames. By default, the contents of the pipe stream will be flushed only
+ * when the buffer is full or the pipe stream is being closed.
+ */
+#define GUAC_TERMINAL_PIPE_AUTOFLUSH 2
+
 typedef struct guac_terminal guac_terminal;
 
 /**
@@ -228,6 +236,7 @@ struct guac_terminal {
      * are undefined.
      *
      * @see GUAC_TERMINAL_PIPE_INTERPRET_OUTPUT
+     * @see GUAC_TERMINAL_PIPE_AUTOFLUSH
      */
     int pipe_stream_flags;
 
@@ -942,6 +951,7 @@ int guac_terminal_next_tab(guac_terminal* term, int column);
  *     stream.
  *
  *     @see GUAC_TERMINAL_PIPE_INTERPRET_OUTPUT
+ *     @see GUAC_TERMINAL_PIPE_AUTOFLUSH
  */
 void guac_terminal_pipe_stream_open(guac_terminal* term, const char* name,
         int flags);

--- a/src/terminal/terminal_handlers.c
+++ b/src/terminal/terminal_handlers.c
@@ -1141,27 +1141,44 @@ int guac_terminal_download(guac_terminal* term, unsigned char c) {
 
 int guac_terminal_open_pipe_stream(guac_terminal* term, unsigned char c) {
 
-    static char stream_name[2048];
+    static char param[2048];
     static int length = 0;
+    static int flags = 0;
 
     /* Open pipe on ECMA-48 ST (String Terminator) */
     if (c == 0x9C || c == 0x5C || c == 0x07) {
 
-        /* End stream name string */
-        stream_name[length++] = '\0';
+        /* End parameter string */
+        param[length++] = '\0';
         length = 0;
 
-        /* Open new pipe stream */
-        guac_terminal_pipe_stream_open(term, stream_name);
+        /* Open new pipe stream using final parameter as name */
+        guac_terminal_pipe_stream_open(term, param, flags);
 
         /* Return to echo mode */
         term->char_handler = guac_terminal_echo;
 
+        /* Reset tracked flags for sake of any future pipe streams */
+        flags = 0;
+
     }
 
-    /* Otherwise, store character within stream name */
-    else if (length < sizeof(stream_name)-1)
-        stream_name[length++] = c;
+    /* Interpret all parameters prior to the final parameter as integer
+     * flags which should affect the pipe stream when opened */
+    else if (c == ';') {
+
+        /* End parameter string */
+        param[length++] = '\0';
+        length = 0;
+
+        /* Parse parameter string as integer flags */
+        flags |= atoi(param);
+
+    }
+
+    /* Otherwise, store character within parameter */
+    else if (length < sizeof(param)-1)
+        param[length++] = c;
 
     return 0;
 

--- a/src/terminal/terminal_handlers.c
+++ b/src/terminal/terminal_handlers.c
@@ -135,8 +135,14 @@ int guac_terminal_echo(guac_terminal* term, unsigned char c) {
 
     /* Echo to pipe stream if open and not starting an ESC sequence */
     if (term->pipe_stream != NULL && c != 0x1B) {
+
         guac_terminal_pipe_stream_write(term, c);
-        return 0;
+
+        /* Do not render output while pipe is open unless explicitly requested
+         * via flags */
+        if (!(term->pipe_stream_flags & GUAC_TERMINAL_PIPE_INTERPRET_OUTPUT))
+            return 0;
+
     }
 
     /* If using non-Unicode mapping, just map straight bytes */


### PR DESCRIPTION
As described on [GUACAMOLE-597](https://issues.apache.org/jira/browse/GUACAMOLE-597), these changes add an optional "flags" parameter to the existing OSC that redirects terminal output to a pipe stream. In addition to the old sequence, the following sequence may now be used:

`ESC` `]` `482202` `;` `FLAGS` `;` `NAME` `ST`

where `FLAGS` is the bitwise OR of any or all of the following flags:

Value | Description
----- | -----------
1     | Send output to both the pipe stream *and* the user's display. By default, output will be sent to only the pipe stream for as long as the pipe stream is open.
2     | Automatically flush the pipe stream when a frame would be rendered, only buffering data between frames. By default, data sent to the pipe stream is buffered until the buffer is full (roughly 6KB) or until the pipe stream is closed.