### PR TITLE
GUACAMOLE-608: Fix connection write thread may encounter dead loop

### DIFF
--- a/src/guacd/connection.c
+++ b/src/guacd/connection.c
@@ -70,7 +70,7 @@ static int __write_all(int fd, char* buffer, int length) {
     while (length > 0) {
 
         int written = write(fd, buffer, length);
-        if (written < 0 || errno > 0)
+        if (written < 0 || (written == 0 && errno > 0))
             return -1;
 
         length -= written;

--- a/src/guacd/connection.c
+++ b/src/guacd/connection.c
@@ -70,7 +70,7 @@ static int __write_all(int fd, char* buffer, int length) {
     while (length > 0) {
 
         int written = write(fd, buffer, length);
-        if (written < 0)
+        if (written < 0 || errno > 0)
             return -1;
 
         length -= written;


### PR DESCRIPTION
guacd involves a `__write_all` function to write instruction as much as possible. However, system call `write` is possible [return 0 and also set errno](https://linux.die.net/man/2/write), which is not verified in the function.

A possible case is `write` keeps return 0 (nothing writes to buffer). Therefore the daemon process encounters a dead loop. Furthermore, it leads CPU rate up to 99%.

The above phenomenon is observed from server:

```bash
$ top
  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND
15176 root      20   0 1988580  25720   3168 S  99.9  0.3  12176:50 guacd
25414 root      20   0 1726048  23324   3040 S  99.9  0.3  17227:15 guacd
...

$ sudo lsof -i | grep 15176 # no network connection
$ top -H -p 25414
  PID USER      PR  NI    VIRT    RES    SHR S %CPU %MEM     TIME+ COMMAND
25418 root      20   0 1726048  23324   3040 R 99.9  0.3  17230:06 guacd
25414 root      20   0 1726048  23324   3040 S  0.0  0.3   0:00.00 guacd
25420 root      20   0 1726048  23324   3040 S  0.0  0.3   0:06.16 guacd
```

This patch perhaps needs more discussion on when and why this is happening, as well as whether should we record the failure to log, for instance:

```c
int written = write(fd, buffer, length);
if (written < 0)
    return -1;
if (written == 0 && errno > 0) {
    guacd_log(GUAC_LOG_ERROR, "Unable to write buffer to file descriptor: %s", strerror(errno));
    return -1;
}
```