### PR TITLE
GUACAMOLE-470: Support named colors in color-scheme configuration.

### DIFF
--- a/src/terminal/named-colors.c
+++ b/src/terminal/named-colors.c
@@ -761,8 +761,13 @@ static int guac_terminal_named_color_search(const void* a, const void* b) {
         /* Skip any spaces in key (name will never have spaces) */
         while (*key && isspace(*key)) key++;
 
+        /* Treat semi-colon as string terminator, to support parsing color
+           names within a larger string (e.g. within the terminal color-scheme
+           configuration string). */
+        const int keyChar = (*key == ';') ? '\0' : tolower(*key);
+
         /* Compare, ignoring case (name is already known to be lowercase) */
-        int difference = tolower(*key) - *name;
+        int difference = keyChar - *name;
         if (difference)
             return difference;
 


### PR DESCRIPTION
Named colors don't currently work inside the color-scheme configuration, because `guac_terminal_named_color_search` expects the name string to be null-terminated, whereas we work with non-null-terminated strings when parsing the color scheme.

To make named colors work, we can either copy the name string to a separate null-terminated buffer, or we can make `guac_terminal_named_color_search` support non-null-terminated strings. This patch implements the latter option, and makes `guac_terminal_named_color_search` treat semi-colons as string terminators.