### PR TITLE
GUACAMOLE-620: Fix instruction loss when buffer is too short

### DIFF
--- a/src/libguac/parser.c
+++ b/src/libguac/parser.c
@@ -222,7 +222,11 @@ int guac_parser_read(guac_parser* parser, guac_socket* socket, int usec_timeout)
             retval = guac_socket_select(socket, usec_timeout);
             if (retval <= 0)
                 return -1;
-           
+            
+            /* Reset pointers if instruction buf len is less than max instruction len */
+            if (buffer_end - unparsed_end < GUAC_INSTRUCTION_MAX_LENGTH)
+                unparsed_end = unparsed_start = parser->__instructionbuf;
+            
             /* Attempt to fill buffer */
             retval = guac_socket_read(socket, unparsed_end,
                     buffer_end - unparsed_end);

--- a/src/libguac/parser.c
+++ b/src/libguac/parser.c
@@ -167,7 +167,6 @@ int guac_parser_read(guac_parser* parser, guac_socket* socket, int usec_timeout)
 
     char* unparsed_end   = parser->__instructionbuf_unparsed_end;
     char* unparsed_start = parser->__instructionbuf_unparsed_start;
-    char* instr_start    = parser->__instructionbuf_unparsed_start;
     char* buffer_end     = parser->__instructionbuf + sizeof(parser->__instructionbuf);
 
     /* Begin next instruction if previous was ended */
@@ -187,35 +186,9 @@ int guac_parser_read(guac_parser* parser, guac_socket* socket, int usec_timeout)
 
             /* If no space left to read, fail */
             if (unparsed_end == buffer_end) {
-
-                /* Shift backward if possible */
-                if (instr_start != parser->__instructionbuf) {
-
-                    int i;
-
-                    /* Shift buffer */
-                    int offset = instr_start - parser->__instructionbuf;
-                    memmove(parser->__instructionbuf, instr_start,
-                            unparsed_end - instr_start);
-
-                    /* Update tracking pointers */
-                    unparsed_end -= offset;
-                    unparsed_start -= offset;
-                    instr_start = parser->__instructionbuf;
-
-                    /* Update parsed elements, if any */
-                    for (i=0; i < parser->__elementc; i++)
-                        parser->__elementv[i] -= offset;
-
-                }
-
-                /* Otherwise, no memory to read */
-                else {
-                    guac_error = GUAC_STATUS_NO_MEMORY;
-                    guac_error_message = "Instruction too long";
-                    return -1;
-                }
-
+                guac_error = GUAC_STATUS_NO_MEMORY;
+                guac_error_message = "Instruction too long";
+                return -1;
             }
 
             /* No instruction yet? Get more data ... */


### PR DESCRIPTION
`guac_parser_read` moves `unparsed_end` and `unparsed_start` to the middle of `parser->__instructionbuf` after `GUAC_PARSE_COMPLETE` state, and so on. They will be reset only if `unparsed_end == buffer_end`.

This PR fixes an instruction parse error when a provided buffer to `read` call is shorter than the expected instruction data, then the next `guac_parser_append` will read incomplete instruction, which leads a `GUAC_PARSE_ERROR` eventually.

