### PR TITLE
GUACAMOLE-629: Add support for updating connection parameters of in-progress connections.

### DIFF
--- a/src/libguac/guacamole/user-fntypes.h
+++ b/src/libguac/guacamole/user-fntypes.h
@@ -238,6 +238,36 @@ typedef int guac_user_pipe_handler(guac_user* user, guac_stream* stream,
         char* mimetype, char* name);
 
 /**
+ * Handler for Guacamole argument value (argv) streams received from a user.
+ * Argument value streams are real-time revisions to the connection parameters
+ * of an in-progress connection. Each such argument value stream begins when
+ * the user sends a "argv" instruction. To handle received data along this
+ * stream, implementations of this handler must assign blob and end handlers to
+ * the given stream object.
+ *
+ * @param user
+ *     The user that opened the argument value stream.
+ *
+ * @param stream
+ *     The stream object allocated by libguac to represent the argument value
+ *     stream opened by the user.
+ *
+ * @param mimetype
+ *     The mimetype of the data that will be sent along the stream.
+ *
+ * @param name
+ *     The name of the connection parameter being updated. It is up to the
+ *     implementation of this handler to decide whether and how to update a
+ *     connection parameter.
+ *
+ * @return
+ *     Zero if the opening of the argument value stream has been handled
+ *     successfully, or non-zero if an error occurs.
+ */
+typedef int guac_user_argv_handler(guac_user* user, guac_stream* stream,
+        char* mimetype, char* name);
+
+/**
  * Handler for Guacamole stream blobs. Each blob originates from a "blob"
  * instruction which was associated with a previously-created stream.
  *

--- a/src/libguac/guacamole/user.h
+++ b/src/libguac/guacamole/user.h
@@ -475,6 +475,27 @@ struct guac_user {
      */
     guac_user_audio_handler* audio_handler;
 
+    /**
+     * Handler for argv events (updates to the connection parameters of an
+     * in-progress connection) sent by the Guacamole web-client.
+     *
+     * The handler takes a guac_stream which contains the stream index and
+     * will persist through the duration of the transfer, the mimetype of
+     * the data being transferred, and the argument (connection parameter)
+     * name.
+     *
+     * Example:
+     * @code
+     *     int argv_handler(guac_user* user, guac_stream* stream,
+     *             char* mimetype, char* name);
+     *
+     *     int guac_user_init(guac_user* user, int argc, char** argv) {
+     *         user->argv_handler = argv_handler;
+     *     }
+     * @endcode
+     */
+    guac_user_argv_handler* argv_handler;
+
 };
 
 /**

--- a/src/libguac/user-handlers.c
+++ b/src/libguac/user-handlers.c
@@ -49,6 +49,7 @@ __guac_instruction_handler_mapping __guac_instruction_handler_map[] = {
    {"get",        __guac_handle_get},
    {"put",        __guac_handle_put},
    {"audio",      __guac_handle_audio},
+   {"argv",       __guac_handle_argv},
    {NULL,         NULL}
 };
 
@@ -379,6 +380,30 @@ int __guac_handle_pipe(guac_user* user, int argc, char** argv) {
     /* Otherwise, abort */
     guac_protocol_send_ack(user->socket, stream,
             "Named pipes unsupported", GUAC_PROTOCOL_STATUS_UNSUPPORTED);
+    return 0;
+}
+
+int __guac_handle_argv(guac_user* user, int argc, char** argv) {
+
+    /* Pull corresponding stream */
+    int stream_index = atoi(argv[0]);
+    guac_stream* stream = __init_input_stream(user, stream_index);
+    if (stream == NULL)
+        return 0;
+
+    /* If supported, call handler */
+    if (user->argv_handler)
+        return user->argv_handler(
+            user,
+            stream,
+            argv[1], /* mimetype */
+            argv[2]  /* name */
+        );
+
+    /* Otherwise, abort */
+    guac_protocol_send_ack(user->socket, stream,
+            "Reconfiguring in-progress connections unsupported",
+            GUAC_PROTOCOL_STATUS_UNSUPPORTED);
     return 0;
 }
 

--- a/src/libguac/user-handlers.h
+++ b/src/libguac/user-handlers.h
@@ -121,6 +121,13 @@ __guac_instruction_handler __guac_handle_file;
 __guac_instruction_handler __guac_handle_pipe;
 
 /**
+ * Internal initial handler for the argv instruction. When a argv instruction
+ * is received, this handler will be called. The client's argv handler will
+ * be invoked if defined.
+ */
+__guac_instruction_handler __guac_handle_argv;
+
+/**
  * Internal initial handler for the ack instruction. When a ack instruction
  * is received, this handler will be called. The client's ack handler will
  * be invoked if defined.


### PR DESCRIPTION
This is the non-handshake portion of changes which allow connection parameters to be sent via streams, rather than as elements of a single, handshake-only instruction. The expected flow is as follows:

1. While the connection is underway, the connected client may begin to stream an update to a connection parameter using an `argv` instruction. It is expected that not all parameters may be updated in this manner, that some updates will be refused for security reasons, and even that instruction filtering within the webapp may intercept the inbound stream and apply additional constraints.
2. If the underlying protocol supports updating that particular parameter, this will be indicated with a successful `ack`. If the parameter cannot be updated, either due to lack of support or the parameter being privileged, an unsuccessful `ack` indicating will be sent indicating why.
3. It is up to the underlying protocol support to implement actually applying the new parameter to the in-progress connection, including whether the data of that parameter is handled as a true stream or is internally buffered.

Note that these changes are just the base framework changes to libguac. This new `argv` instruction is not currently used by any supported protocol, though I do have pending changes which leverage this for updating the `color-scheme` parameter of SSH/telnet.