### PR TITLE
GUACAMOLE-623: Include Kubernetes plugin in dist directories.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,19 +20,20 @@
 ACLOCAL_AMFLAGS = -I m4
 
 # Subprojects
-DIST_SUBDIRS =           \
-    src/libguac          \
-    src/common           \
-    src/common-ssh       \
-    src/terminal         \
-    src/guacd            \
-    src/guacenc          \
-    src/guaclog          \
-    src/pulse            \
-    src/protocols/rdp    \
-    src/protocols/ssh    \
-    src/protocols/telnet \
-    src/protocols/vnc    \
+DIST_SUBDIRS =               \
+    src/libguac              \
+    src/common               \
+    src/common-ssh           \
+    src/terminal             \
+    src/guacd                \
+    src/guacenc              \
+    src/guaclog              \
+    src/pulse                \
+    src/protocols/kubernetes \
+    src/protocols/rdp        \
+    src/protocols/ssh        \
+    src/protocols/telnet     \
+    src/protocols/vnc        \
     tests
 
 SUBDIRS =        \


### PR DESCRIPTION
The `src/protocols/kubernetes` directory needs to be present in `DIST_SUBDIRS` for the source of the Kubernetes plugin to be included in the .tar.gz file built by `make dist`.

The "guacamole-server-master" build in Jenkins verifies that the .tar.gz built by `make dist`, so this is [currently failing](https://builds.apache.org/view/E-G/view/Guacamole/job/guacamole-server-master/67/console):

```
...
configure: creating ./config.status
config.status: creating Makefile
config.status: creating doc/Doxyfile
config.status: creating tests/Makefile
config.status: creating src/common/Makefile
config.status: creating src/common-ssh/Makefile
config.status: creating src/terminal/Makefile
config.status: creating src/libguac/Makefile
config.status: creating src/guacd/Makefile
config.status: creating src/guacd/man/guacd.8
config.status: creating src/guacd/man/guacd.conf.5
config.status: creating src/guacenc/Makefile
config.status: creating src/guacenc/man/guacenc.1
config.status: creating src/guaclog/Makefile
config.status: creating src/guaclog/man/guaclog.1
config.status: creating src/pulse/Makefile
config.status: error: cannot find input file: `src/protocols/kubernetes/Makefile.in'
The command '/bin/sh -c /bin/bash -e -x /build/build.sh' returned a non-zero code: 1
+ docker rmi --force guac-jenkins-guacamole-server-master-67
Error response from daemon: No such image: guac-jenkins-guacamole-server-master-67:latest
+ true
Build step 'Execute shell' marked build as failure
Sending e-mails to: dev@guacamole.apache.org
Finished: FAILURE
```