### PR TITLE
GUACAMOLE-623: Fix build against older libwebsockets.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1224,6 +1224,14 @@ then
                    [Whether LCCSCF_USE_SSL is defined])],,
         [#include <libwebsockets.h>])
 
+    # Older versions of libwebsockets do not define a dummy callback which
+    # must be invoked after the main event callback is invoked; the main event
+    # callback must instead manually return zero
+    AC_CHECK_DECL([lws_callback_http_dummy],
+        [AC_DEFINE([HAVE_LWS_CALLBACK_HTTP_DUMMY],,
+                   [Whether lws_callback_http_dummy() is defined])],,
+        [#include <libwebsockets.h>])
+
 fi
 
 AM_CONDITIONAL([ENABLE_WEBSOCKETS],

--- a/configure.ac
+++ b/configure.ac
@@ -1198,14 +1198,32 @@ then
                  have_libwebsockets=no])
 fi
 
-# Check for client-specific closed event, which must be used in favor of the
-# generic closed event if libwebsockets is recent enough to provide this
 if test "x$with_websockets" != "xno"
 then
+
+    # Check for client-specific closed event, which must be used in favor of
+    # the generic closed event if libwebsockets is recent enough to provide
+    # this
     AC_CHECK_DECL([LWS_CALLBACK_CLIENT_CLOSED],
         [AC_DEFINE([HAVE_LWS_CALLBACK_CLIENT_CLOSED],,
                    [Whether LWS_CALLBACK_CLIENT_CLOSED is defined])],,
         [#include <libwebsockets.h>])
+
+    # Older versions of libwebsockets may not define a flag for requesting
+    # global initialization of OpenSSL, instead performing that initialization
+    # by default
+    AC_CHECK_DECL([LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT],
+        [AC_DEFINE([HAVE_LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT],,
+                   [Whether LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT is defined])],,
+        [#include <libwebsockets.h>])
+
+    # Older versions of libwebsockets do not define special macros for SSL
+    # connection flags, instead relying on documented integer values
+    AC_CHECK_DECL([LCCSCF_USE_SSL],
+        [AC_DEFINE([HAVE_LCCSCF_USE_SSL],,
+                   [Whether LCCSCF_USE_SSL is defined])],,
+        [#include <libwebsockets.h>])
+
 fi
 
 AM_CONDITIONAL([ENABLE_WEBSOCKETS],

--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -268,9 +268,15 @@ void* guac_kubernetes_client_thread(void* data) {
      * do our own validation - libwebsockets does not validate properly if
      * IP addresses are used. */
     if (settings->use_ssl) {
+#ifdef HAVE_LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT
         context_info.options = LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
+#endif
+#ifdef HAVE_LCCSCF_USE_SSL
         connection_info.ssl_connection = LCCSCF_USE_SSL
             | LCCSCF_SKIP_SERVER_CERT_HOSTNAME_CHECK;
+#else
+        connection_info.ssl_connection = 2; /* SSL + no hostname check */
+#endif
     }
 
     /* Create libwebsockets context */

--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -66,8 +66,13 @@ static int guac_kubernetes_lws_callback(struct lws* wsi,
     guac_client* client = guac_kubernetes_lws_current_client;
 
     /* Do not handle any further events if connection is closing */
-    if (client->state != GUAC_CLIENT_RUNNING)
+    if (client->state != GUAC_CLIENT_RUNNING) {
+#ifdef HAVE_LWS_CALLBACK_HTTP_DUMMY
         return lws_callback_http_dummy(wsi, reason, user, in, length);
+#else
+        return 0;
+#endif
+    }
 
     switch (reason) {
 
@@ -127,7 +132,11 @@ static int guac_kubernetes_lws_callback(struct lws* wsi,
 
     }
 
+#ifdef HAVE_LWS_CALLBACK_HTTP_DUMMY
     return lws_callback_http_dummy(wsi, reason, user, in, length);
+#else
+    return 0;
+#endif
 
 }
 

--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -268,7 +268,6 @@ void* guac_kubernetes_client_thread(void* data) {
         .origin = settings->hostname,
         .port = settings->port,
         .protocol = GUAC_KUBERNETES_LWS_PROTOCOL,
-        .pwsi = &kubernetes_client->wsi,
         .userdata = client
     };
 

--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -120,6 +120,7 @@ static int guac_kubernetes_lws_callback(struct lws* wsi,
 #endif
 
         /* Connection closed */
+        case LWS_CALLBACK_WSI_DESTROY:
         case LWS_CALLBACK_CLOSED:
             guac_client_stop(client);
             guac_client_log(client, GUAC_LOG_DEBUG, "WebSocket connection to "


### PR DESCRIPTION
The build is currently broken on CentOS 7 with EPEL, where libwebsockets is available but at version 1.7.5. Several differences are in play which needed to be addressed here:

* SSL client initialization flags do not exist. Instead, a set of documented integer values is used for no SSL (0), SSL with verification of certificate (1), and SSL which allows self-signed certificates (2). The latter is unfortunately very specific to self-signed certificates, leading to verification failures in other cases - more on that below.
* The `lws_callback_http_dummy()` function which must be invoked within the event callback to perform some sort of housekeeping tasks internal to libwebsockets is not defined. The event callback is instead expected to simply return 0.
* The `pwsi` member of the `lws_client_connect_info` structure does not exist. This can safely be removed - our original purpose for using it, exposing the `guac_client` to the event callback, no longer exists as the `guac_client` is exposed through a static variable instead.
* The SSL verification of server certificates is explicitly bypassed if requested, but the error result is still checked in all cases and still fails the connection for all but extremely specific verification errors related to self-signed certificates. This is addressed through neutering the certificate verification entirely when `ignore_cert` is set, rather than just asking nicely.
* Older libwebsockets will not fire `LWS_CALLBACK_CLOSED` events under some circumstances, instead only firing `LWS_CALLBACK_WSI_DESTROY` for the destruction of the WebSocket structure. Both need to be handled for the connection to close cleanly in all cases.