### PR TITLE
GUACAMOLE-547: Add support for SSH NONE authentication method

### DIFF
--- a/src/common-ssh/common-ssh/ssh.h
+++ b/src/common-ssh/common-ssh/ssh.h
@@ -36,6 +36,9 @@
  *     The name of the credential being requested, which will be shared
  *     with the client in order to generate a meaningful prompt.
  * 
+ * @return
+ *     The credential provided by the user, which should be a dynamically-
+ *     allocated such that it can be freed as required.
  */
 typedef char* guac_ssh_credential_handler(guac_client* client, char* cred_name);
 

--- a/src/common-ssh/common-ssh/ssh.h
+++ b/src/common-ssh/common-ssh/ssh.h
@@ -37,8 +37,8 @@
  *     with the client in order to generate a meaningful prompt.
  * 
  * @return
- *     The credential provided by the user, which should be a dynamically-
- *     allocated such that it can be freed as required.
+ *     A newly-allocated string containing the credentials provided by
+ *     the user, which must be freed by a call to free().
  */
 typedef char* guac_ssh_credential_handler(guac_client* client, char* cred_name);
 
@@ -129,7 +129,8 @@ void guac_common_ssh_uninit();
  * 
  * @param credential_handler
  *     The handler function for retrieving additional credentials from the user
- *     as required by the SSH server.
+ *     as required by the SSH server, or NULL if the user will not be asked
+ *     for additional credentials.
  *
  * @return
  *     A new SSH session if the connection and authentication succeed, or NULL

--- a/src/common-ssh/common-ssh/ssh.h
+++ b/src/common-ssh/common-ssh/ssh.h
@@ -26,6 +26,11 @@
 #include <libssh2.h>
 
 /**
+ * Handler for retrieving additional credentials.
+ */
+typedef char* guac_ssh_credential_handler(guac_client* client, char* credName);
+
+/**
  * An SSH session, backed by libssh2 and associated with a particular
  * Guacamole client.
  */
@@ -50,6 +55,11 @@ typedef struct guac_common_ssh_session {
      * The file descriptor of the socket being used for the SSH connection.
      */
     int fd;
+    
+    /**
+     * Callback function to retrieve credentials.
+     */
+    guac_ssh_credential_handler* credential_handler;
 
 } guac_common_ssh_session;
 
@@ -99,7 +109,7 @@ void guac_common_ssh_uninit();
  */
 guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
         const char* hostname, const char* port, guac_common_ssh_user* user, int keepalive,
-        const char* host_key);
+        const char* host_key, guac_ssh_credential_handler* credential_callback);
 
 /**
  * Disconnects and destroys the given SSH session, freeing all associated

--- a/src/common-ssh/common-ssh/ssh.h
+++ b/src/common-ssh/common-ssh/ssh.h
@@ -27,8 +27,17 @@
 
 /**
  * Handler for retrieving additional credentials.
+ * 
+ * @param client
+ *     The Guacamole Client associated with this need for additional
+ *     credentials.
+ * 
+ * @param cred_name
+ *     The name of the credential being requested, which will be shared
+ *     with the client in order to generate a meaningful prompt.
+ * 
  */
-typedef char* guac_ssh_credential_handler(guac_client* client, char* credName);
+typedef char* guac_ssh_credential_handler(guac_client* client, char* cred_name);
 
 /**
  * An SSH session, backed by libssh2 and associated with a particular
@@ -102,14 +111,31 @@ void guac_common_ssh_uninit();
  *
  * @param user
  *     The user to authenticate as, once connected.
+ * 
+ * @param keepalive
+ *     How frequently the connection should send keepalive packets, in
+ *     seconds.  Zero disables keepalive packets, and 2 is the minimum
+ *     configurable value.
+ * 
+ * @param host_key
+ *     The known public host key of the server, as provided by the client.  If
+ *     provided the identity of the server will be checked against this key,
+ *     and a mis-match between this and the server identity will cause the
+ *     connection to fail.  If not provided, no checks will be done and the
+ *     connection will proceed.
+ * 
+ * @param credential_handler
+ *     The handler function for retrieving additional credentials from the user
+ *     as required by the SSH server.
  *
  * @return
  *     A new SSH session if the connection and authentication succeed, or NULL
  *     if the connection or authentication were not successful.
  */
 guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
-        const char* hostname, const char* port, guac_common_ssh_user* user, int keepalive,
-        const char* host_key, guac_ssh_credential_handler* credential_callback);
+        const char* hostname, const char* port, guac_common_ssh_user* user,
+        int keepalive, const char* host_key,
+        guac_ssh_credential_handler* credential_handler);
 
 /**
  * Disconnects and destroys the given SSH session, freeing all associated

--- a/src/common-ssh/ssh.c
+++ b/src/common-ssh/ssh.c
@@ -304,20 +304,18 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
     LIBSSH2_SESSION* session = common_session->session;
 
     /* Get user credentials */
-    char* username = user->username;
-    char* password = user->password;
     guac_common_ssh_key* key = user->private_key;
 
     /* Validate username provided */
-    if (username == NULL) {
+    if (user->username == NULL) {
         guac_client_abort(client, GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
                 "SSH authentication requires a username.");
         return 1;
     }
 
     /* Get list of supported authentication methods */
-    char* user_authlist = libssh2_userauth_list(session, username,
-            strlen(username));
+    char* user_authlist = libssh2_userauth_list(session, user->username,
+            strlen(user->username));
 
     /* If auth list is NULL, then authentication has succeeded with NONE */
     if (user_authlist == NULL) {
@@ -342,7 +340,7 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
         }
 
         /* Attempt public key auth */
-        if (libssh2_userauth_publickey(session, username,
+        if (libssh2_userauth_publickey(session, user->username,
                     (unsigned char*) key->public_key, key->public_key_length,
                     guac_common_ssh_sign_callback, (void**) key)) {
 
@@ -361,14 +359,18 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
 
     }
 
+    /* Down to username + password authentication. */
+    if (user->password == NULL && common_session->credential_handler)
+            user->password = common_session->credential_handler(client, "Password: ");
+    
     /* Authenticate with password, if provided */
-    else if (password != NULL) {
+    if (user->password != NULL) {
 
         /* Check if password auth is supported on the server */
         if (strstr(user_authlist, "password") != NULL) {
 
             /* Attempt password authentication */
-            if (libssh2_userauth_password(session, username, password)) {
+            if (libssh2_userauth_password(session, user->username, user->password)) {
 
                 /* Abort on failure */
                 char* error_message;
@@ -389,7 +391,7 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
         if (strstr(user_authlist, "keyboard-interactive") != NULL) {
 
             /* Attempt keyboard-interactive auth using provided password */
-            if (libssh2_userauth_keyboard_interactive(session, username,
+            if (libssh2_userauth_keyboard_interactive(session, user->username,
                         &guac_common_ssh_kbd_callback)) {
 
                 /* Abort on failure */
@@ -425,7 +427,7 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
 
 guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
         const char* hostname, const char* port, guac_common_ssh_user* user, int keepalive,
-        const char* host_key) {
+        const char* host_key, guac_ssh_credential_handler* credential_handler) {
 
     int retval;
 
@@ -570,6 +572,7 @@ guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
     common_session->user = user;
     common_session->session = session;
     common_session->fd = fd;
+    common_session->credential_handler = credential_handler;
 
     /* Attempt authentication */
     if (guac_common_ssh_authenticate(common_session)) {

--- a/src/common-ssh/ssh.c
+++ b/src/common-ssh/ssh.c
@@ -321,6 +321,10 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
     guac_client_log(client, GUAC_LOG_DEBUG,
             "Supported authentication methods: %s", user_authlist);
 
+    /* If auth list is NULL, then authentication has succeeded with NONE */
+    if (user_authlist == NULL)
+        return 0;
+
     /* Authenticate with private key, if provided */
     if (key != NULL) {
 

--- a/src/common-ssh/ssh.c
+++ b/src/common-ssh/ssh.c
@@ -327,7 +327,6 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
     guac_client_log(client, GUAC_LOG_DEBUG,
             "Supported authentication methods: %s", user_authlist);
 
-
     /* Authenticate with private key, if provided */
     if (key != NULL) {
 
@@ -359,7 +358,7 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
 
     }
 
-    /* Down to username + password authentication. */
+    /* Attempt authentication with username + password. */
     if (user->password == NULL && common_session->credential_handler)
             user->password = common_session->credential_handler(client, "Password: ");
     
@@ -426,8 +425,9 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
 }
 
 guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
-        const char* hostname, const char* port, guac_common_ssh_user* user, int keepalive,
-        const char* host_key, guac_ssh_credential_handler* credential_handler) {
+        const char* hostname, const char* port, guac_common_ssh_user* user,
+        int keepalive, const char* host_key,
+        guac_ssh_credential_handler* credential_handler) {
 
     int retval;
 

--- a/src/common-ssh/ssh.c
+++ b/src/common-ssh/ssh.c
@@ -318,12 +318,17 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
     /* Get list of supported authentication methods */
     char* user_authlist = libssh2_userauth_list(session, username,
             strlen(username));
+
+    /* If auth list is NULL, then authentication has succeeded with NONE */
+    if (user_authlist == NULL) {
+        guac_client_log(client, GUAC_LOG_DEBUG,
+            "SSH NONE authentication succeeded.");
+        return 0;
+    }
+
     guac_client_log(client, GUAC_LOG_DEBUG,
             "Supported authentication methods: %s", user_authlist);
 
-    /* If auth list is NULL, then authentication has succeeded with NONE */
-    if (user_authlist == NULL)
-        return 0;
 
     /* Authenticate with private key, if provided */
     if (key != NULL) {

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -975,7 +975,7 @@ void* guac_rdp_client_thread(void* data) {
         rdp_client->sftp_session =
             guac_common_ssh_create_session(client, settings->sftp_hostname,
                     settings->sftp_port, rdp_client->sftp_user, settings->sftp_server_alive_interval,
-                    settings->sftp_host_key);
+                    settings->sftp_host_key, NULL);
 
         /* Fail if SSH connection does not succeed */
         if (rdp_client->sftp_session == NULL) {

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -138,25 +138,25 @@ static guac_common_ssh_user* guac_ssh_get_user(guac_client* client) {
 }
 
 /**
- * A call-back function used to gather additional credentials from a client
- * during a connection.  It takes the guac_client object and a string to
- * display to the user, and returns the credentials entered by the user.
+ * A function used to generate a terminal prompt to gather additional
+ * credentials from the guac_client during a connection, and using
+ * the specified string to generate the prompt for the user.
  * 
  * @param client
  *     The guac_client object associated with the current connection
  *     where additional credentials are required.
  * 
- * @param credName
+ * @param cred_name
  *     The prompt text to display to the screen when prompting for the
  *     additional credentials.
  * 
  * @return 
  *     The string of credentials gathered from the user.
  */
-char* guac_ssh_get_credential(guac_client *client, char* credName) {
+static char* guac_ssh_get_credential(guac_client *client, char* cred_name) {
 
     guac_ssh_client* ssh_client = (guac_ssh_client*) client->data;
-    return guac_terminal_prompt(ssh_client->term, credName, false);
+    return guac_terminal_prompt(ssh_client->term, cred_name, false);
     
 }
 

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -137,6 +137,22 @@ static guac_common_ssh_user* guac_ssh_get_user(guac_client* client) {
 
 }
 
+/**
+ * A call-back function used to gather additional credentials from a client
+ * during a connection.  It takes the guac_client object and a string to
+ * display to the user, and returns the credentials entered by the user.
+ * 
+ * @param client
+ *     The guac_client object associated with the current connection
+ *     where additional credentials are required.
+ * 
+ * @param credName
+ *     The prompt text to display to the screen when prompting for the
+ *     additional credentials.
+ * 
+ * @return 
+ *     The string of credentials gathered from the user.
+ */
 char* guac_ssh_get_credential(guac_client *client, char* credName) {
 
     guac_ssh_client* ssh_client = (guac_ssh_client*) client->data;

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -262,7 +262,7 @@ void* guac_vnc_client_thread(void* data) {
         vnc_client->sftp_session =
             guac_common_ssh_create_session(client, settings->sftp_hostname,
                     settings->sftp_port, vnc_client->sftp_user, settings->sftp_server_alive_interval,
-                    settings->sftp_host_key);
+                    settings->sftp_host_key, NULL);
 
         /* Fail if SSH connection does not succeed */
         if (vnc_client->sftp_session == NULL) {


### PR DESCRIPTION
I'm not 100% certain that this is all that's needed, because I don't have a SSH server to test this against, but, according to the libssh2 documentation, this may be all that's required to allow the session to continue when there's no authentication required.

https://libssh2.org/libssh2_userauth_list.html