### PR TITLE
GUACAMOLE-638: avcodec_register_all() should be used only if not deprecated.

### DIFF
--- a/src/guacenc/guacenc.c
+++ b/src/guacenc/guacenc.c
@@ -75,8 +75,10 @@ int main(int argc, char* argv[]) {
     guacenc_log(GUAC_LOG_INFO, "Guacamole video encoder (guacenc) "
             "version " VERSION);
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 10, 100)
     /* Prepare libavcodec */
     avcodec_register_all();
+#endif
 
     /* Track number of overall failures */
     int total_files = argc - optind;


### PR DESCRIPTION
`avcodec_register_all()` is deprecated as of libavcodec 58.10.100. From the relevant section of the [FFmpeg API changelog](https://github.com/FFmpeg/FFmpeg/blob/23f589e073406f8c9d80092d3ff9ef8c22f27e63/doc/APIchanges#L108-L111):

```
2018-02-06 - 36c85d6e77 - lavc 58.10.100 - avcodec.h
 Deprecate use of avcodec_register(), avcodec_register_all(),
 av_codec_next(), av_register_codec_parser(), and av_parser_next().
 Add av_codec_iterate() and av_parser_iterate().
```