### PR TITLE
GUACAMOLE-667: Enable loading configuration file from other locations than default.

### DIFF
--- a/src/guacd/conf-args.c
+++ b/src/guacd/conf-args.c
@@ -32,10 +32,15 @@ int guacd_conf_parse_args(guacd_config* config, int argc, char** argv) {
 
     /* Parse arguments */
     int opt;
-    while ((opt = getopt(argc, argv, "l:b:p:L:C:K:fv")) != -1) {
+    while ((opt = getopt(argc, argv, "c:l:b:p:L:C:K:fv")) != -1) {
+
+        /* -c: Configuration file */
+        if (opt == 'c') {
+            continue;
+        }
 
         /* -l: Bind port */
-        if (opt == 'l') {
+        else if (opt == 'l') {
             free(config->bind_port);
             config->bind_port = strdup(optarg);
         }
@@ -102,6 +107,7 @@ int guacd_conf_parse_args(guacd_config* config, int argc, char** argv) {
         else {
 
             fprintf(stderr, "USAGE: %s"
+                    " [-c CONFIG_FILE]"
                     " [-l LISTENPORT]"
                     " [-b LISTENADDRESS]"
                     " [-p PIDFILE]"
@@ -122,3 +128,15 @@ int guacd_conf_parse_args(guacd_config* config, int argc, char** argv) {
 
 }
 
+const char* guacd_conf_get_path(int argc, char** argv) {
+
+    /* Find -c option */
+    int i;
+    for(i=1; i<argc-1; i++) {
+        if(strcmp("-c", argv[i]) == 0) return argv[i+1];
+    }
+
+    /* Not found */
+    return NULL;
+
+}

--- a/src/guacd/conf-args.h
+++ b/src/guacd/conf-args.h
@@ -30,5 +30,11 @@
  */
 int guacd_conf_parse_args(guacd_config* config, int argc, char** argv);
 
+/**
+ * Finds a path to a configuration file in the given arguments. The path is
+ * returned on success, and NULL is returned if appropriate option was not set.
+ */
+const char* guacd_conf_get_path(int argc, char** argv);
+
 #endif
 

--- a/src/guacd/conf-file.c
+++ b/src/guacd/conf-file.c
@@ -189,7 +189,10 @@ guacd_config* guacd_conf_load(const char* conf_file_path) {
 #endif
 
     /* Determine path of configuration file */
-    if(conf_file_path == NULL) conf_file_path = GUACD_CONF_FILE;
+    if(conf_file_path == NULL) {
+        conf_file_path = getenv("GUACD_CONF_FILE");
+        if(conf_file_path == NULL) conf_file_path = GUACD_CONF_FILE;
+    }
 
     /* Read configuration from file */
     int fd = open(conf_file_path, O_RDONLY);

--- a/src/guacd/conf-file.c
+++ b/src/guacd/conf-file.c
@@ -169,7 +169,7 @@ int guacd_conf_parse_file(guacd_config* conf, int fd) {
 
 }
 
-guacd_config* guacd_conf_load() {
+guacd_config* guacd_conf_load(const char* conf_file_path) {
 
     guacd_config* conf = malloc(sizeof(guacd_config));
     if (conf == NULL)
@@ -188,15 +188,18 @@ guacd_config* guacd_conf_load() {
     conf->key_file = NULL;
 #endif
 
+    /* Determine path of configuration file */
+    if(conf_file_path == NULL) conf_file_path = GUACD_CONF_FILE;
+
     /* Read configuration from file */
-    int fd = open(GUACD_CONF_FILE, O_RDONLY);
+    int fd = open(conf_file_path, O_RDONLY);
     if (fd > 0) {
 
         int retval = guacd_conf_parse_file(conf, fd);
         close(fd);
 
         if (retval != 0) {
-            fprintf(stderr, "Unable to parse \"" GUACD_CONF_FILE "\".\n");
+            fprintf(stderr, "Unable to parse \"%s\".\n", conf_file_path);
             free(conf);
             return NULL;
         }
@@ -205,7 +208,7 @@ guacd_config* guacd_conf_load() {
 
     /* Notify of errors preventing reading */
     else if (errno != ENOENT) {
-        fprintf(stderr, "Unable to open \"" GUACD_CONF_FILE "\": %s\n", strerror(errno));
+        fprintf(stderr, "Unable to open \"%s\": %s\n", conf_file_path, strerror(errno));
         free(conf);
         return NULL;
     }

--- a/src/guacd/conf-file.h
+++ b/src/guacd/conf-file.h
@@ -32,10 +32,11 @@
 int guacd_conf_parse_file(guacd_config* conf, int fd);
 
 /**
- * Loads the configuration from any of several default locations, if found. If
- * parsing fails, NULL is returned, and an error message is printed to stderr.
+ * Loads the configuration from the given path or from the default location, if
+ * NULL is passed. Configuration is loaded only if the specified file is found.
+ * If parsing fails, NULL is returned, and an error message is printed to stderr.
  */
-guacd_config* guacd_conf_load();
+guacd_config* guacd_conf_load(const char* conf_file_path);
 
 #endif
 

--- a/src/guacd/daemon.c
+++ b/src/guacd/daemon.c
@@ -276,7 +276,7 @@ int main(int argc, char* argv[]) {
     int retval;
 
     /* Load configuration */
-    guacd_config* config = guacd_conf_load();
+    guacd_config* config = guacd_conf_load(guacd_conf_get_path(argc, argv));
     if (config == NULL || guacd_conf_parse_args(config, argc, argv))
        exit(EXIT_FAILURE);
 


### PR DESCRIPTION
These commits enable setting path to the configuration file during **guacd** startup:

- by "-c path/to/conf-file" command line argument
- by "GUACD_CONF_FILE" environment variable

Ccommand line arg has precedence. If none of above is set then default location is used.

---

After accepting these changes the manual should be updated (both _man guacd_ and _man guacd.conf_).