### PR TITLE
GUACAMOLE-729: Bump version to 1.1.0.

### DIFF
--- a/bin/guacctl
+++ b/bin/guacctl
@@ -117,7 +117,7 @@ error() {
 ##
 usage() {
     cat >&2 <<END
-guacctl 1.0.0, Apache Guacamole terminal session control utility.
+guacctl 1.1.0, Apache Guacamole terminal session control utility.
 Usage: guacctl [OPTION] [FILE or NAME]...
 
     -d, --download         download each of the files listed.

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@
 #
 
 AC_PREREQ([2.61])
-AC_INIT([guacamole-server], [1.0.0])
+AC_INIT([guacamole-server], [1.1.0])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AM_SILENT_RULES([yes])

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -125,7 +125,7 @@ libguac_la_CFLAGS = \
     -Werror -Wall -pedantic -I$(srcdir)/guacamole
 
 libguac_la_LDFLAGS =     \
-    -version-info 16:0:0 \
+    -version-info 17:0:0 \
     -no-undefined        \
     @CAIRO_LIBS@         \
     @DL_LIBS@            \


### PR DESCRIPTION
As an interface has been changed (a new member has been added to the `guac_user` struct), the libtool version info had to be bumped from 16:0:0 to 17:0:0.