### PR TITLE
GUACAMOLE-694: Add ca-certificates packages as runtime dependency.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ ENV LD_LIBRARY_PATH=${PREFIX_DIR}/lib
 ENV GUACD_LOG_LEVEL=info
 
 ARG RUNTIME_DEPENDENCIES="            \
+        ca-certificates               \
         ghostscript                   \
         libfreerdp-plugins-standard   \
         fonts-liberation              \


### PR DESCRIPTION
Quick update to `Dockerfile` to add `ca-certificates` package as a runtime dependency for guacd container.