### PR TITLE
GUACAMOLE-414: Implement TLS Write Locking Callbacks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -513,6 +513,33 @@ then
 fi
 
 #
+# TLS Locking Support within libVNCServer
+#
+
+if test "x${have_libvncserver}" = "xyes"
+then
+
+    have_vnc_tls_locking=yes
+    AC_CHECK_MEMBERS([rfbClient.LockWriteToTLS, rfbClient.UnlockWriteToTLS],
+                     [], [have_vnc_tls_locking=no],
+                     [[#include <rfb/rfbclient.h>]])
+
+    if test "x${have_vnc_tls_locking}" = "xno"
+    then
+        AC_MSG_WARN([
+      --------------------------------------------
+       This version of libvncclient lacks support
+       for TLS locking.  VNC connections that use
+       TLS may experience instability as documented
+       in GUACAMOLE-414])
+    else
+        AC_DEFINE([ENABLE_VNC_TLS_LOCKING],,
+                  [Whether support for TLS locking within VNC is enabled.])
+    fi
+
+fi
+
+#
 # FreeRDP
 #
 

--- a/src/protocols/vnc/client.c
+++ b/src/protocols/vnc/client.c
@@ -36,6 +36,7 @@
 
 #include <guacamole/client.h>
 
+#include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -47,6 +48,11 @@ int guac_client_init(guac_client* client) {
     /* Alloc client data */
     guac_vnc_client* vnc_client = calloc(1, sizeof(guac_vnc_client));
     client->data = vnc_client;
+
+#ifdef ENABLE_VNC_TLS_LOCKING
+    /* Initialize the write lock */
+    pthread_mutex_init(&(vnc_client->tls_lock), NULL);
+#endif
 
     /* Init clipboard */
     vnc_client->clipboard = guac_common_clipboard_alloc(GUAC_VNC_CLIPBOARD_MAX_LENGTH);
@@ -124,6 +130,11 @@ int guac_vnc_client_free_handler(guac_client* client) {
     /* Free parsed settings */
     if (settings != NULL)
         guac_vnc_settings_free(settings);
+
+#ifdef ENABLE_VNC_TLS_LOCKING
+    /* Clean up TLS lock mutex. */
+    pthread_mutex_destroy(&(vnc_client->tls_lock));
+#endif
 
     /* Free generic data struct */
     free(client->data);

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -77,7 +77,8 @@ static rfbBool guac_vnc_lock_write_to_tls(rfbClient* rfb_client) {
     /* Lock write access */
     int retval = pthread_mutex_lock(&(vnc_client->tls_lock));
     if (retval) {
-        guac_client_log(gc, GUAC_LOG_ERROR, "Error locking TLS write mutex: %d", retval);
+        guac_client_log(gc, GUAC_LOG_ERROR, "Error locking TLS write mutex: %s",
+                strerror(retval));
         return FALSE;
     }
     return TRUE;
@@ -106,7 +107,8 @@ static rfbBool guac_vnc_unlock_write_to_tls(rfbClient* rfb_client) {
     /* Unlock write access */
     int retval = pthread_mutex_unlock(&(vnc_client->tls_lock));
     if (retval) {
-        guac_client_log(gc, GUAC_LOG_ERROR, "Error unlocking TLS write mutex: %d", retval);
+        guac_client_log(gc, GUAC_LOG_ERROR, "Error unlocking TLS write mutex: %d",
+                strerror(retval));
         return FALSE;
     }
     return TRUE;

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -47,6 +47,7 @@
 #include <guacamole/socket.h>
 #include <guacamole/timestamp.h>
 #include <rfb/rfbclient.h>
+#include <rfb/rfbconfig.h>
 #include <rfb/rfbproto.h>
 
 #include <stdlib.h>
@@ -55,6 +56,7 @@
 
 char* GUAC_VNC_CLIENT_KEY = "GUAC_VNC";
 
+#if LIBVNCSERVER_VERSION_MAJOR >=0 && LIBVNCSERVER_VERSION_MINOR >= 9 && LIBVNCSERVER_VERSION_PATCHLEVEL >= 11
 /**
  * A callback function that is called by the VNC library prior to writing
  * data to a TLS-encrypted socket.  This returns the rfbBool FALSE value
@@ -110,6 +112,7 @@ static rfbBool guac_vnc_unlock_write_to_tls(rfbClient* rfb_client) {
     }
     return TRUE;
 }
+#endif
 
 rfbClient* guac_vnc_get_client(guac_client* client) {
 
@@ -124,9 +127,11 @@ rfbClient* guac_vnc_get_client(guac_client* client) {
     rfb_client->GotFrameBufferUpdate = guac_vnc_update;
     rfb_client->GotCopyRect = guac_vnc_copyrect;
 
+#if LIBVNCSERVER_VERSION_MAJOR >=0 && LIBVNCSERVER_VERSION_MINOR >= 9 && LIBVNCSERVER_VERSION_PATCHLEVEL >= 11
     /* TLS Locking and Unlocking */
     rfb_client->LockWriteToTLS = guac_vnc_lock_write_to_tls;
     rfb_client->UnlockWriteToTLS = guac_vnc_unlock_write_to_tls;
+#endif
 
     /* Do not handle clipboard and local cursor if read-only */
     if (vnc_settings->read_only == 0) {
@@ -242,8 +247,10 @@ void* guac_vnc_client_thread(void* data) {
     rfbClientLog = guac_vnc_client_log_info;
     rfbClientErr = guac_vnc_client_log_error;
 
+#if LIBVNCSERVER_VERSION_MAJOR >=0 && LIBVNCSERVER_VERSION_MINOR >= 9 && LIBVNCSERVER_VERSION_PATCHLEVEL >= 11
     /* Initialize the write lock */
     pthread_mutex_init(&(vnc_client->tls_lock), NULL);
+#endif
 
     /* Attempt connection */
     rfbClient* rfb_client = guac_vnc_get_client(client);

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -47,7 +47,6 @@
 #include <guacamole/socket.h>
 #include <guacamole/timestamp.h>
 #include <rfb/rfbclient.h>
-#include <rfb/rfbconfig.h>
 #include <rfb/rfbproto.h>
 
 #include <stdlib.h>
@@ -71,11 +70,11 @@ char* GUAC_VNC_CLIENT_KEY = "GUAC_VNC";
  */
 static rfbBool guac_vnc_lock_write_to_tls(rfbClient* rfb_client) {
 
-    // Retrieve the Guacamole data structures
+    /* Retrieve the Guacamole data structures */
     guac_client* gc = rfbClientGetClientData(rfb_client, GUAC_VNC_CLIENT_KEY);
     guac_vnc_client* vnc_client = (guac_vnc_client*) gc->data;
 
-    // Lock write access
+    /* Lock write access */
     int retval = pthread_mutex_lock(&(vnc_client->tls_lock));
     if (retval) {
         guac_client_log(gc, GUAC_LOG_ERROR, "Error locking TLS write mutex: %d", retval);
@@ -100,11 +99,11 @@ static rfbBool guac_vnc_lock_write_to_tls(rfbClient* rfb_client) {
  */
 static rfbBool guac_vnc_unlock_write_to_tls(rfbClient* rfb_client) {
 
-    // Retrieve the Guacamole data structures
+    /* Retrieve the Guacamole data structures */
     guac_client* gc = rfbClientGetClientData(rfb_client, GUAC_VNC_CLIENT_KEY);
     guac_vnc_client* vnc_client = (guac_vnc_client*) gc->data;
 
-    // Unlock write access
+    /* Unlock write access */
     int retval = pthread_mutex_unlock(&(vnc_client->tls_lock));
     if (retval) {
         guac_client_log(gc, GUAC_LOG_ERROR, "Error unlocking TLS write mutex: %d", retval);
@@ -246,11 +245,6 @@ void* guac_vnc_client_thread(void* data) {
     /* Set up libvncclient logging */
     rfbClientLog = guac_vnc_client_log_info;
     rfbClientErr = guac_vnc_client_log_error;
-
-#ifdef ENABLE_VNC_TLS_LOCKING
-    /* Initialize the write lock */
-    pthread_mutex_init(&(vnc_client->tls_lock), NULL);
-#endif
 
     /* Attempt connection */
     rfbClient* rfb_client = guac_vnc_get_client(client);

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -107,7 +107,7 @@ static rfbBool guac_vnc_unlock_write_to_tls(rfbClient* rfb_client) {
     /* Unlock write access */
     int retval = pthread_mutex_unlock(&(vnc_client->tls_lock));
     if (retval) {
-        guac_client_log(gc, GUAC_LOG_ERROR, "Error unlocking TLS write mutex: %d",
+        guac_client_log(gc, GUAC_LOG_ERROR, "Error unlocking TLS write mutex: %s",
                 strerror(retval));
         return FALSE;
     }

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -56,7 +56,7 @@
 
 char* GUAC_VNC_CLIENT_KEY = "GUAC_VNC";
 
-#if LIBVNCSERVER_VERSION_MAJOR >=0 && LIBVNCSERVER_VERSION_MINOR >= 9 && LIBVNCSERVER_VERSION_PATCHLEVEL >= 11
+#ifdef ENABLE_VNC_TLS_LOCKING
 /**
  * A callback function that is called by the VNC library prior to writing
  * data to a TLS-encrypted socket.  This returns the rfbBool FALSE value
@@ -127,7 +127,7 @@ rfbClient* guac_vnc_get_client(guac_client* client) {
     rfb_client->GotFrameBufferUpdate = guac_vnc_update;
     rfb_client->GotCopyRect = guac_vnc_copyrect;
 
-#if LIBVNCSERVER_VERSION_MAJOR >=0 && LIBVNCSERVER_VERSION_MINOR >= 9 && LIBVNCSERVER_VERSION_PATCHLEVEL >= 11
+#ifdef ENABLE_VNC_TLS_LOCKING
     /* TLS Locking and Unlocking */
     rfb_client->LockWriteToTLS = guac_vnc_lock_write_to_tls;
     rfb_client->UnlockWriteToTLS = guac_vnc_unlock_write_to_tls;
@@ -247,7 +247,7 @@ void* guac_vnc_client_thread(void* data) {
     rfbClientLog = guac_vnc_client_log_info;
     rfbClientErr = guac_vnc_client_log_error;
 
-#if LIBVNCSERVER_VERSION_MAJOR >=0 && LIBVNCSERVER_VERSION_MINOR >= 9 && LIBVNCSERVER_VERSION_PATCHLEVEL >= 11
+#ifdef ENABLE_VNC_TLS_LOCKING
     /* Initialize the write lock */
     pthread_mutex_init(&(vnc_client->tls_lock), NULL);
 #endif

--- a/src/protocols/vnc/vnc.h
+++ b/src/protocols/vnc/vnc.h
@@ -56,7 +56,7 @@ typedef struct guac_vnc_client {
      */
     pthread_t client_thread;
 
-#if LIBVNCSERVER_VERSION_MAJOR >=0 && LIBVNCSERVER_VERSION_MINOR >= 9 && LIBVNCSERVER_VERSION_PATCHLEVEL >= 11
+#ifdef ENABLE_VNC_TLS_LOCKING
     /**
      * The TLS mutex lock for the client.
      */

--- a/src/protocols/vnc/vnc.h
+++ b/src/protocols/vnc/vnc.h
@@ -32,6 +32,7 @@
 #include <guacamole/client.h>
 #include <guacamole/layer.h>
 #include <rfb/rfbclient.h>
+#include <rfb/rfbconfig.h>
 
 #ifdef ENABLE_PULSE
 #include "pulse/pulse.h"
@@ -55,10 +56,12 @@ typedef struct guac_vnc_client {
      */
     pthread_t client_thread;
 
+#if LIBVNCSERVER_VERSION_MAJOR >=0 && LIBVNCSERVER_VERSION_MINOR >= 9 && LIBVNCSERVER_VERSION_PATCHLEVEL >= 11
     /**
      * The TLS mutex lock for the client.
      */
     pthread_mutex_t tls_lock;
+#endif
 
     /**
      * The underlying VNC client.

--- a/src/protocols/vnc/vnc.h
+++ b/src/protocols/vnc/vnc.h
@@ -32,7 +32,6 @@
 #include <guacamole/client.h>
 #include <guacamole/layer.h>
 #include <rfb/rfbclient.h>
-#include <rfb/rfbconfig.h>
 
 #ifdef ENABLE_PULSE
 #include "pulse/pulse.h"

--- a/src/protocols/vnc/vnc.h
+++ b/src/protocols/vnc/vnc.h
@@ -56,6 +56,11 @@ typedef struct guac_vnc_client {
     pthread_t client_thread;
 
     /**
+     * The TLS mutex lock for the client.
+     */
+    pthread_mutex_t tls_lock;
+
+    /**
      * The underlying VNC client.
      */
     rfbClient* rfb_client;


### PR DESCRIPTION
This pull request implements the `LockWriteToTLS()` and `UnlockWriteToTLS()` callbacks used by LibVNCClient to avoid race conditions when TLS is in use that cause the VNC connection to fail/crash.

Note that support for these callbacks was released in LibVNCServer/Client 0.9.11, so it will only work against 0.9.11 or later- the bug documented in GUACAMOLE-414 will still be present when using libvncserver/client prior to 0.9.11.