### PR TITLE
GUACAMOLE-772: Reducing Docker image size for Guacd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN ${PREFIX_DIR}/bin/list-dependencies.sh    \
         > ${PREFIX_DIR}/DEPENDENCIES
 
 # Use same Debian as the base for the runtime image
-FROM debian:${DEBIAN_VERSION}
+FROM debian:${DEBIAN_VERSION}-slim
 
 # Base directory for installed build artifacts.
 # Due to limitations of the Docker image build process, this value is


### PR DESCRIPTION
Debian:stable-slim base reduce the final Docker image size.