### PR TITLE
GUACAMOLE-547: Do not ignore password from settings.

### DIFF
--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -131,7 +131,7 @@ static guac_common_ssh_user* guac_ssh_get_user(guac_client* client) {
     } /* end if key given */
 
     /* If available, get password from settings */
-    else if (settings->password != NULL){
+    else if (settings->password != NULL) {
         guac_common_ssh_user_set_password(user, settings->password);
     }
 

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -130,6 +130,11 @@ static guac_common_ssh_user* guac_ssh_get_user(guac_client* client) {
 
     } /* end if key given */
 
+    /* If available, get password from settings */
+    else if (settings->password != NULL){
+        guac_common_ssh_user_set_password(user, settings->password);
+    }
+
     /* Clear screen of any prompts */
     guac_terminal_printf(ssh_client->term, "\x1B[H\x1B[J");
 


### PR DESCRIPTION
The password set for a SSH connection is always ignored.

Every SSH password set as connection parameter is now ignored, even if it is not NULL.
The issue is quite simple to reproduce:
1. Set up a working SSH connection with a password parameter with the latest stable (1.0.0).
2. Try the same connection compiling master with GUACAMOLE-547 commits. The terminal prompt the password request, ignoring the configured one.