### PR TITLE
GUACAMOLE-422: Add empty handler and trace logging for nop instruction.

### DIFF
--- a/src/libguac/user-handlers.c
+++ b/src/libguac/user-handlers.c
@@ -51,6 +51,7 @@ __guac_instruction_handler_mapping __guac_instruction_handler_map[] = {
    {"put",        __guac_handle_put},
    {"audio",      __guac_handle_audio},
    {"argv",       __guac_handle_argv},
+   {"nop",        __guac_handle_nop},
    {NULL,         NULL}
 };
 
@@ -585,6 +586,12 @@ int __guac_handle_put(guac_user* user, int argc, char** argv) {
     /* Otherwise, abort */
     guac_protocol_send_ack(user->socket, stream,
             "Object write unsupported", GUAC_PROTOCOL_STATUS_UNSUPPORTED);
+    return 0;
+}
+
+int __guac_handle_nop(guac_user* user, int argc, char** argv) {
+    guac_user_log(user, GUAC_LOG_TRACE,
+            "Received nop instruction");
     return 0;
 }
 

--- a/src/libguac/user-handlers.h
+++ b/src/libguac/user-handlers.h
@@ -178,6 +178,13 @@ __guac_instruction_handler __guac_handle_size;
 __guac_instruction_handler __guac_handle_disconnect;
 
 /**
+ * Internal handler for the nop instruction.  This handler will be called when
+ * the nop instruction is received, and will do nothing more than a TRACE level
+ * log of the instruction.
+ */
+__guac_instruction_handler __guac_handle_nop;
+
+/**
  * Internal handler function that is called when the size instruction is
  * received during the handshake process.
  */


### PR DESCRIPTION
This adds an empty handler for the nop instruction with a TRACE-level log for received instructions.  I went ahead and left the other logging as DEBUG-level to capture any instructions that should not actually make it through.