### PR TITLE
GUACAMOLE-514: Implement additional VNC authentication support

### DIFF
--- a/src/protocols/vnc/auth.c
+++ b/src/protocols/vnc/auth.c
@@ -41,9 +41,12 @@ rfbCredential* guac_vnc_get_credentials(rfbClient* client, int credentialType) {
         creds->userCredential.password = settings->password;
         return creds;
     }
-    
-    guac_client_log(gc, GUAC_LOG_ERROR,
+
+    guac_client_abort(gc, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
             "Unsupported credential type requested.");
+    guac_client_log(gc, GUAC_LOG_DEBUG,
+            "Unable to provided requested credential %d.",
+            credentialType);
     return NULL;
     
 }

--- a/src/protocols/vnc/auth.c
+++ b/src/protocols/vnc/auth.c
@@ -33,54 +33,17 @@ char* guac_vnc_get_password(rfbClient* client) {
 
 rfbCredential* guac_vnc_get_credentials(rfbClient* client, int credentialType) {
     guac_client* gc = rfbClientGetClientData(client, GUAC_VNC_CLIENT_KEY);
-    rfbCredential *creds = malloc(sizeof(rfbCredential));
     guac_vnc_settings* settings = ((guac_vnc_client*) gc->data)->settings;
     
     if (credentialType == rfbCredentialTypeUser) {
+        rfbCredential *creds = malloc(sizeof(rfbCredential));
         creds->userCredential.username = settings->username;
         creds->userCredential.password = settings->password;
         return creds;
     }
     
-    else if (credentialType == rfbCredentialTypeX509) {
-        char* template = "guac_XXXXXX";
-        
-        if (settings->client_cert != NULL) {
-            settings->client_cert_temp = strdup(template);
-            int cert_fd = mkstemp(settings->client_cert_temp);
-            write(cert_fd, settings->client_cert, strlen(settings->client_cert));
-            close(cert_fd);
-            creds->x509Credential.x509ClientCertFile = settings->client_cert_temp;
-        }
-        
-        if (settings->client_key != NULL) {
-            settings->client_key_temp = strdup(template);
-            int key_fd = mkstemp(settings->client_key_temp);
-            write(key_fd, settings->client_key, strlen(settings->client_key));
-            close(key_fd);
-            creds->x509Credential.x509ClientKeyFile = settings->client_key_temp;
-        }
-        
-        if (settings->ca_cert != NULL) {
-            settings->ca_cert_temp = strdup(template);
-            int ca_fd = mkstemp(settings->ca_cert_temp);
-            write(ca_fd, settings->ca_cert, strlen(settings->ca_cert));
-            close(ca_fd);
-            creds->x509Credential.x509CACertFile = settings->ca_cert_temp;
-        }
-        
-        if (settings->ca_crl != NULL) {
-            settings->ca_crl_temp = strdup(template);
-            int crl_fd = mkstemp(settings->ca_crl_temp);
-            write(crl_fd, settings->ca_crl, strlen(settings->ca_crl));
-            close(crl_fd);
-            creds->x509Credential.x509CACrlFile = settings->ca_crl_temp;
-        }
-        
-        return creds;
-    }
-    
-    guac_client_log(gc, GUAC_LOG_ERROR, "Unknown credential type requested.");
+    guac_client_log(gc, GUAC_LOG_ERROR,
+            "Unsupported credential type requested.");
     return NULL;
     
 }

--- a/src/protocols/vnc/auth.c
+++ b/src/protocols/vnc/auth.c
@@ -45,13 +45,7 @@ rfbCredential* guac_vnc_get_credentials(rfbClient* client, int credentialType) {
         creds->x509Credential.x509ClientCertFile = ((guac_vnc_client*) gc->data)->settings->client_cert;
         creds->x509Credential.x509ClientKeyFile = ((guac_vnc_client*) gc->data)->settings->client_key;
         creds->x509Credential.x509CACertFile = ((guac_vnc_client*) gc->data)->settings->ca_cert;
-        creds->x509Credential.x509CACRLFile = ((guac_vnc_client*) gc->data)->settings->ca_crl;
-        
-        if (creds->x509Credential.x509CACRLFile != NULL)
-            creds->x509Credential.x509CrlVerifyMode = 2;
-        else
-            creds->x509Credential.x509CrlVerifyMode = 0;
-        
+        creds->x509Credential.x509CACrlFile = ((guac_vnc_client*) gc->data)->settings->ca_crl;        
         return creds;
     }
     

--- a/src/protocols/vnc/auth.c
+++ b/src/protocols/vnc/auth.c
@@ -31,3 +31,32 @@ char* guac_vnc_get_password(rfbClient* client) {
     return ((guac_vnc_client*) gc->data)->settings->password;
 }
 
+rfbCredential* guac_vnc_get_credentials(rfbClient* client, int credentialType) {
+    guac_client* gc = rfbClientGetClientData(client, GUAC_VNC_CLIENT_KEY);
+    rfbCredential *creds = malloc(sizeof(rfbCredential));
+    
+    if (credentialType == rfbCredentialTypeUser) {
+        creds->userCredential.username = ((guac_vnc_client*) gc->data)->settings->username;
+        creds->userCredential.password = ((guac_vnc_client*) gc->data)->settings->password;
+        return creds;
+    }
+    
+    else if (credentialType == rfbCredentialTypeX509) {
+        creds->x509Credential.x509ClientCertFile = ((guac_vnc_client*) gc->data)->settings->client_cert;
+        creds->x509Credential.x509ClientKeyFile = ((guac_vnc_client*) gc->data)->settings->client_key;
+        creds->x509Credential.x509CACertFile = ((guac_vnc_client*) gc->data)->settings->ca_cert;
+        creds->x509Credential.x509CACRLFile = ((guac_vnc_client*) gc->data)->settings->ca_crl;
+        
+        if (creds->x509Credential.x509CACRLFile != NULL)
+            creds->x509Credential.x509CrlVerifyMode = 2;
+        else
+            creds->x509Credential.x509CrlVerifyMode = 0;
+        
+        return creds;
+    }
+    
+    guac_client_log(client, GUAC_LOG_ERROR,
+            "Unknown credential type requested.");
+    return NULL;
+    
+}

--- a/src/protocols/vnc/auth.c
+++ b/src/protocols/vnc/auth.c
@@ -55,8 +55,7 @@ rfbCredential* guac_vnc_get_credentials(rfbClient* client, int credentialType) {
         return creds;
     }
     
-    guac_client_log(client, GUAC_LOG_ERROR,
-            "Unknown credential type requested.");
+    guac_client_log(gc, GUAC_LOG_ERROR, "Unknown credential type requested.");
     return NULL;
     
 }

--- a/src/protocols/vnc/auth.c
+++ b/src/protocols/vnc/auth.c
@@ -45,7 +45,7 @@ rfbCredential* guac_vnc_get_credentials(rfbClient* client, int credentialType) {
     guac_client_abort(gc, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
             "Unsupported credential type requested.");
     guac_client_log(gc, GUAC_LOG_DEBUG,
-            "Unable to provided requested credential %d.",
+            "Unable to provide requested type of credential: %d.",
             credentialType);
     return NULL;
     

--- a/src/protocols/vnc/auth.h
+++ b/src/protocols/vnc/auth.h
@@ -47,6 +47,10 @@ char* guac_vnc_get_password(rfbClient* client);
  *     The rfbClient associated with the VNC connection requiring the
  *     authentication.
  * 
+ * @param credentialType
+ *     The credential type being requested, as defined by the libVNCclient
+ *     code in the rfbclient.h header.
+ * 
  * @return
  *     The rfbCredential object that contains the required credentials.
  */

--- a/src/protocols/vnc/auth.h
+++ b/src/protocols/vnc/auth.h
@@ -27,7 +27,7 @@
 
 /**
  * Callback which is invoked by libVNCServer when it needs to read the user's
- * VNC password. As ths user's password, if any, will be stored in the
+ * VNC password. As this user's password, if any, will be stored in the
  * connection settings, this function does nothing more than return that value.
  *
  * @param client
@@ -37,6 +37,20 @@
  *     The password to provide to the VNC server.
  */
 char* guac_vnc_get_password(rfbClient* client);
+
+/**
+ * Callback which is invoked by libVNCServer when it needs to read the user's
+ * VNC credentials.  The credentials are stored in the connection settings,
+ * so they will be retrieved from that.
+ * 
+ * @param client
+ *     The rfbClient associated with the VNC connection requiring the
+ *     authentication.
+ * 
+ * @return
+ *     The rfbCredential object that contains the required credentials.
+ */
+rfbCredential* guac_vnc_get_credentials(rfbClient* client, int credentialType);
 
 #endif
 

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -35,7 +35,12 @@ const char* GUAC_VNC_CLIENT_ARGS[] = {
     "port",
     "read-only",
     "encodings",
+    "username",
     "password",
+    "client-cert",
+    "client-key",
+    "ca-cert",
+    "ca-crl",
     "swap-red-blue",
     "color-depth",
     "cursor",
@@ -109,9 +114,36 @@ enum VNC_ARGS_IDX {
     IDX_ENCODINGS,
 
     /**
+     * The username to send to the VNC server if authentication is requested.
+     */
+    IDX_USERNAME,
+    
+    /**
      * The password to send to the VNC server if authentication is requested.
      */
     IDX_PASSWORD,
+    
+    /**
+     * The client certificate to send to the VNC server if x509 authentication
+     * is being used.
+     */
+    IDX_CLIENT_CERT,
+    
+    /**
+     * The client private key to send to the VNC server if x509 authentication
+     * is being used.
+     */
+    IDX_CLIENT_KEY,
+    
+    /**
+     * The CA certificate to use when performing x509 authentication.
+     */
+    IDX_CA_CERT,
+    
+    /**
+     * The location of the CA CRL to use when performing x509 authentication.
+     */
+    IDX_CA_CRL,
 
     /**
      * "true" if the red and blue components of each color should be swapped,
@@ -337,10 +369,30 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
         guac_user_parse_args_int(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_PORT, 0);
 
+    settings->username =
+        guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_USERNAME, ""); /* NOTE: freed by libvncclient */
+    
     settings->password =
         guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_PASSWORD, ""); /* NOTE: freed by libvncclient */
 
+    settings->client_cert =
+        guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_CLIENT_CERT, NULL);
+    
+    settings->client_key =
+        guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_CLIENT_KEY, NULL);
+    
+    settings->ca_cert =
+        guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_CA_CERT, NULL);
+    
+    settings->ca_crl =
+        guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_CA_CRL, NULL);
+    
     /* Remote cursor */
     if (strcmp(argv[IDX_CURSOR], "remote") == 0) {
         guac_user_log(user, GUAC_LOG_INFO, "Cursor rendering: remote");
@@ -530,6 +582,10 @@ void guac_vnc_settings_free(guac_vnc_settings* settings) {
     free(settings->hostname);
     free(settings->recording_name);
     free(settings->recording_path);
+    free(settings->client_cert);
+    free(settings->client_key);
+    free(settings->ca_cert);
+    free(settings->ca_crl);
 
 #ifdef ENABLE_VNC_REPEATER
     /* Free VNC repeater settings */

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -28,7 +28,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <unistd.h>
 
 /* Client plugin arguments */
 const char* GUAC_VNC_CLIENT_ARGS[] = {
@@ -38,10 +37,6 @@ const char* GUAC_VNC_CLIENT_ARGS[] = {
     "encodings",
     "username",
     "password",
-    "client-cert",
-    "client-key",
-    "ca-cert",
-    "ca-crl",
     "swap-red-blue",
     "color-depth",
     "cursor",
@@ -123,28 +118,6 @@ enum VNC_ARGS_IDX {
      * The password to send to the VNC server if authentication is requested.
      */
     IDX_PASSWORD,
-    
-    /**
-     * The client certificate to send to the VNC server if x509 authentication
-     * is being used.
-     */
-    IDX_CLIENT_CERT,
-    
-    /**
-     * The client private key to send to the VNC server if x509 authentication
-     * is being used.
-     */
-    IDX_CLIENT_KEY,
-    
-    /**
-     * The CA certificate to use when performing x509 authentication.
-     */
-    IDX_CA_CERT,
-    
-    /**
-     * The location of the CA CRL to use when performing x509 authentication.
-     */
-    IDX_CA_CRL,
 
     /**
      * "true" if the red and blue components of each color should be swapped,
@@ -377,22 +350,6 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
     settings->password =
         guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_PASSWORD, ""); /* NOTE: freed by libvncclient */
-
-    settings->client_cert =
-        guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
-                IDX_CLIENT_CERT, NULL);
-    
-    settings->client_key =
-        guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
-                IDX_CLIENT_KEY, NULL);
-    
-    settings->ca_cert =
-        guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
-                IDX_CA_CERT, NULL);
-    
-    settings->ca_crl =
-        guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
-                IDX_CA_CRL, NULL);
     
     /* Remote cursor */
     if (strcmp(argv[IDX_CURSOR], "remote") == 0) {
@@ -583,30 +540,6 @@ void guac_vnc_settings_free(guac_vnc_settings* settings) {
     free(settings->hostname);
     free(settings->recording_name);
     free(settings->recording_path);
-    free(settings->client_cert);
-    free(settings->client_key);
-    free(settings->ca_cert);
-    free(settings->ca_crl);
-    
-    if (settings->client_cert_temp != NULL) {
-        unlink(settings->client_cert_temp);
-        free(settings->client_cert_temp);
-    }
-    
-    if (settings->client_key_temp != NULL) {
-        unlink(settings->client_key_temp);
-        free(settings->client_key_temp);
-    }
-    
-    if (settings->ca_cert_temp != NULL) {
-        unlink(settings->ca_cert_temp);
-        free(settings->ca_cert_temp);
-    }
-    
-    if (settings->ca_crl_temp != NULL) {
-        unlink(settings->ca_crl_temp);
-        free(settings->ca_crl_temp);
-    }
 
 #ifdef ENABLE_VNC_REPEATER
     /* Free VNC repeater settings */

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 /* Client plugin arguments */
 const char* GUAC_VNC_CLIENT_ARGS[] = {
@@ -586,6 +587,26 @@ void guac_vnc_settings_free(guac_vnc_settings* settings) {
     free(settings->client_key);
     free(settings->ca_cert);
     free(settings->ca_crl);
+    
+    if (settings->client_cert_temp != NULL) {
+        unlink(settings->client_cert_temp);
+        free(settings->client_cert_temp);
+    }
+    
+    if (settings->client_key_temp != NULL) {
+        unlink(settings->client_key_temp);
+        free(settings->client_key_temp);
+    }
+    
+    if (settings->ca_cert_temp != NULL) {
+        unlink(settings->ca_cert_temp);
+        free(settings->ca_cert_temp);
+    }
+    
+    if (settings->ca_crl_temp != NULL) {
+        unlink(settings->ca_crl_temp);
+        free(settings->ca_crl_temp);
+    }
 
 #ifdef ENABLE_VNC_REPEATER
     /* Free VNC repeater settings */

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -56,25 +56,45 @@ typedef struct guac_vnc_settings {
     char* password;
     
     /**
-     * The client certificate to use for authentication.
+     * The contents of the client certificate to use for authentication.
      */
     char* client_cert;
     
     /**
-     * The client private key to use for authentication.
+     * The location of the temporary client certificate file.
+     */
+    char* client_cert_temp;
+    
+    /**
+     * The contents of the client private key to use for authentication.
      */
     char* client_key;
     
     /**
-     * The CA certificate file to use for authentication.
+     * The location of the temporary client key file.
+     */
+    char* client_key_temp;
+    
+    /**
+     * The contents of the CA certificate file to use for authentication.
      */
     char* ca_cert;
     
     /**
-     * The CA CRL location to use for checking for revoked certificates during
-     * authentication.
+     * The location of the temporary CA file.
+     */
+    char* ca_cert_temp;
+    
+    /**
+     * The contents of the CA CRL location to use for checking for revoked
+     * certificates during authentication.
      */
     char* ca_crl;
+    
+    /**
+     * The location of the temporary CRL file.
+     */
+    char* ca_crl_temp;
 
     /**
      * Space-separated list of encodings to use within the VNC session.

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -46,9 +46,35 @@ typedef struct guac_vnc_settings {
     int port;
 
     /**
+     * The username given in the arguments.
+     */
+    char* username;
+    
+    /**
      * The password given in the arguments.
      */
     char* password;
+    
+    /**
+     * The client certificate to use for authentication.
+     */
+    char* client_cert;
+    
+    /**
+     * The client private key to use for authentication.
+     */
+    char* client_key;
+    
+    /**
+     * The CA certificate file to use for authentication.
+     */
+    char* ca_cert;
+    
+    /**
+     * The CA CRL location to use for checking for revoked certificates during
+     * authentication.
+     */
+    char* ca_crl;
 
     /**
      * Space-separated list of encodings to use within the VNC session.

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -54,47 +54,6 @@ typedef struct guac_vnc_settings {
      * The password given in the arguments.
      */
     char* password;
-    
-    /**
-     * The contents of the client certificate to use for authentication.
-     */
-    char* client_cert;
-    
-    /**
-     * The location of the temporary client certificate file.
-     */
-    char* client_cert_temp;
-    
-    /**
-     * The contents of the client private key to use for authentication.
-     */
-    char* client_key;
-    
-    /**
-     * The location of the temporary client key file.
-     */
-    char* client_key_temp;
-    
-    /**
-     * The contents of the CA certificate file to use for authentication.
-     */
-    char* ca_cert;
-    
-    /**
-     * The location of the temporary CA file.
-     */
-    char* ca_cert_temp;
-    
-    /**
-     * The contents of the CA CRL location to use for checking for revoked
-     * certificates during authentication.
-     */
-    char* ca_crl;
-    
-    /**
-     * The location of the temporary CRL file.
-     */
-    char* ca_crl_temp;
 
     /**
      * Space-separated list of encodings to use within the VNC session.

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -153,6 +153,9 @@ rfbClient* guac_vnc_get_client(guac_client* client) {
 
     }
 
+    /* Authentication */
+    rfb_client->GetCredential = guac_vnc_get_credentials;
+    
     /* Password */
     rfb_client->GetPassword = guac_vnc_get_password;
 


### PR DESCRIPTION
This pull request implements the callback and parameters required to support additional authentication mechanisms by VNC servers that don't do just password-based authentication.  Ideally this should implement both username/password support as well as X509 support.  I have tested the username/password support and it appears to work - I don't have a way of testing X509 right now so I'm not 100% certain that it will work; however, since I think most of that is handled internally in libvncserver(client), it's reasonable that it will work.