### PR TITLE
GUACAMOLE-861: Drive redirectrion - fix WINDOWS_TIME calculation

### DIFF
--- a/src/protocols/rdp/rdp_fs.h
+++ b/src/protocols/rdp/rdp_fs.h
@@ -188,7 +188,7 @@
  * Converts a UNIX timestamp (seconds since Jan 1, 1970 UTC) to Windows
  * timestamp (100 nanosecond intervals since Jan 1, 1601 UTC).
  */
-#define WINDOWS_TIME(t) ((t - ((uint64_t) 11644473600)) * 10000000)
+#define WINDOWS_TIME(t) ((t + ((uint64_t) 11644473600)) * 10000000)
 
 /**
  * An arbitrary file on the virtual filesystem of the Guacamole drive.


### PR DESCRIPTION
There is a mistake in the conversion from UNIX time to FILETIME. See the following page: https://support.microsoft.com/en-us/help/167296/how-to-convert-a-unix-time-t-to-a-win32-filetime-or-systemtime. With the current calculation, checking the properties of a file in a redirected drive/folder gives invalid file dates. Changing the '-' to '+' fixes the issue.