### PR TITLE
GUACAMOLE-859: Incorrect Caps Lock keysym sent to Windows via RDP

### DIFF
--- a/src/protocols/rdp/keymaps/base.keymap
+++ b/src/protocols/rdp/keymaps/base.keymap
@@ -42,7 +42,7 @@ map +ext 0x37 ~ 0xff61 # Print Screen
 # Locks
 map      0x45 ~ 0xff7f # Num_Lock
 map      0x46 ~ 0xff14 # Scroll_Lock
-map +ext 0x3A ~ 0xffe5 # Caps_Lock
+map      0x3A ~ 0xffe5 # Caps_Lock
 
 # Keypad numerals
 map -shift +num 0x52 ~ 0xffb0 # KP_0


### PR DESCRIPTION
When connected with a Guacamole RDP session, the keysym for Caps Lock (0xffe5) is sent over RDP as scancode 0xe03a. Windows does not understand this scancode, thus does not generate the correct VK (Virtual Key) events. Removing +ext from the keymap sends the scancode 0x003a, which is correctly recognized by Windows as Caps Lock. This enables Windows applications to listen for key down and key up events on the Caps Lock key while connected via a Guacamole RDP session.

Note: this issue likely went un-noticed for a long time because it only impacts the key up and down events for the Caps Lock key, not Caps Lock's effect on sending uppercase [A-Z] characters.

## Testing notes

Pulling up this [JSBin](https://jsbin.com/reviciceke/2/edit?js,console,output) in the remote desktop is an easy way to see the key up/down events that your browser is receiving. However, I found it helpful to inspect the low-level events that Windows sends to applications so I can see the scancodes and VK codes. To view those, I've [attached a small test `.exe`](https://github.com/apache/guacamole-server/files/3484231/main.exe.txt) (remove the `.txt` extension) that prints the events to std out. You can also compile it from source using [these instructions](https://gist.github.com/WestonThayer/9b7a0e04b045be1656ce9f01de141cd2).

I have not tested RDP connections to non-Windows RDP servers. It'd be great if someone could test with a Linux or macOS RDP server to confirm that they weren't expecting a 0xe03a scancode. After searching the web a fair bit, I suspect not. I couldn't find anything on a 0xe03a scancode online.
