### PR TITLE
GUACAMOLE-871: Add support for hidden cursor (DECTECM)

### DIFF
--- a/src/terminal/terminal/terminal.h
+++ b/src/terminal/terminal/terminal.h
@@ -338,12 +338,19 @@ struct guac_terminal {
     int cursor_col;
 
     /**
+     * The desired visibility state of the cursor.
+     */
+    bool cursor_visible;
+
+    /**
      * The row of the rendered cursor.
+     * Will be set to -1 if the cursor is not visible.
      */
     int visible_cursor_row;
 
     /**
      * The column of the rendered cursor.
+     * Will be set to -1 if the cursor is not visible.
      */
     int visible_cursor_col;
 

--- a/src/terminal/terminal_handlers.c
+++ b/src/terminal/terminal_handlers.c
@@ -432,6 +432,7 @@ static bool* __guac_terminal_get_flag(guac_terminal* term, int num, char private
     if (private_mode == '?') {
         switch (num) {
             case 1:  return &(term->application_cursor_keys); /* DECCKM */
+            case 25: return &(term->cursor_visible); /* DECTECM */
         }
     }
 


### PR DESCRIPTION
As requested on JIRA, here is the patch as a pull request. Please not that I did not test this as I dont know how to put all the pieces in place to check that. It can be easily tested with:

```
printf '\e[?25l' # cursor should be hidden after this
printf '\e[?25h' # cursor should be visible again after this
```