### PR TITLE
GUACAMOLE-249: Remove extra warning resulting from merge.

### DIFF
--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -103,9 +103,6 @@ BOOL rdp_freerdp_pre_connect(freerdp* instance) {
     /* Load "cliprdr" service if not disabled */
     if (!(settings->disable_copy && settings->disable_paste))
         guac_rdp_clipboard_load_plugin(rdp_client->clipboard, context);
-    else
-        guac_client_log(client, GUAC_LOG_WARNING,
-                "Copy and paste are both disabled.  Clipboard plugin will not be loaded.");
 
     /* If RDPSND/RDPDR required, load them */
     if (settings->printing_enabled


### PR DESCRIPTION
The merge of `staging/1.1.0` to `master` resulted in the addition of a warning if both copy and paste are disabled. I think this probably shouldn't be present. An administrator can be expected to intentionally disable both copy and paste in some environments, and warnings should be used only for conditions that the admin should look into and correct when possible.