### PR TITLE
GUACAMOLE-249: Automatically determine correct location for FreeRDP plugins.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -532,11 +532,19 @@ fi
 #
 
 have_freerdp2=disabled
+FREERDP2_PLUGIN_DIR=
+
 AC_ARG_WITH([rdp],
             [AS_HELP_STRING([--with-rdp],
                             [support RDP @<:@default=check@:>@])],
             [],
             [with_rdp=check])
+
+# FreeRDP plugin directory
+AC_ARG_WITH(freerdp_plugin_dir,
+            [AS_HELP_STRING([--with-freerdp-plugin-dir=<path>],
+                            [install FreeRDP plugins to the given directory @<:@default=check@:>@])
+            ],FREERDP2_PLUGIN_DIR=$withval)
 
 # Preserve CPPFLAGS so it can be restored later, following the addition of
 # options specific to FreeRDP tests
@@ -547,7 +555,8 @@ then
     have_freerdp2=yes
     PKG_CHECK_MODULES([RDP], [freerdp2 freerdp-client2 winpr2],
                       [CPPFLAGS="${RDP_CFLAGS} -Werror $CPPFLAGS"]
-                      [FREERDP2_PLUGIN_DIR="`$PKG_CONFIG --variable=libdir freerdp2`/freerdp2"],
+                      [AS_IF([test "x${FREERDP2_PLUGIN_DIR}" = "x"],
+                             [FREERDP2_PLUGIN_DIR="`$PKG_CONFIG --variable=libdir freerdp2`/freerdp2"])],
                       [AC_MSG_WARN([
   --------------------------------------------
    Unable to find FreeRDP (libfreerdp2 / libfreerdp-client2 / libwinpr2)

--- a/configure.ac
+++ b/configure.ac
@@ -546,7 +546,8 @@ if test "x$with_rdp" != "xno"
 then
     have_freerdp2=yes
     PKG_CHECK_MODULES([RDP], [freerdp2 freerdp-client2 winpr2],
-                      [CPPFLAGS="${RDP_CFLAGS} -Werror $CPPFLAGS"],
+                      [CPPFLAGS="${RDP_CFLAGS} -Werror $CPPFLAGS"]
+                      [FREERDP2_PLUGIN_DIR="`$PKG_CONFIG --variable=libdir freerdp2`/freerdp2"],
                       [AC_MSG_WARN([
   --------------------------------------------
    Unable to find FreeRDP (libfreerdp2 / libfreerdp-client2 / libwinpr2)
@@ -664,6 +665,7 @@ fi
 # Restore CPPFLAGS, removing FreeRDP-specific options needed for testing
 CPPFLAGS="$OLDCPPFLAGS"
 
+AC_SUBST(FREERDP2_PLUGIN_DIR)
 AM_CONDITIONAL([ENABLE_RDP], [test "x${have_freerdp2}" = "xyes"])
 
 #
@@ -995,6 +997,12 @@ AM_COND_IF([ENABLE_INIT], [build_init="${init_dir}"], [build_init=no])
 AM_COND_IF([ENABLE_SYSTEMD], [build_systemd="${systemd_dir}"], [build_systemd=no])
 
 #
+# FreeRDP plugins
+#
+
+AM_COND_IF([ENABLE_RDP], [build_rdp_plugins="${FREERDP2_PLUGIN_DIR}"], [build_rdp_plugins=no])
+
+#
 # Display summary
 #
 
@@ -1034,6 +1042,7 @@ $PACKAGE_NAME version $PACKAGE_VERSION
       guacenc .... ${build_guacenc}
       guaclog .... ${build_guaclog}
 
+   FreeRDP plugins: ${build_rdp_plugins}
    Init scripts: ${build_init}
    Systemd units: ${build_systemd}
 

--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -150,7 +150,7 @@ freerdp_LTLIBRARIES =            \
     libguac-common-svc-client.la \
     libguacai-client.la
 
-freerdpdir = ${libdir}/freerdp2
+freerdpdir = @FREERDP2_PLUGIN_DIR@
 
 #
 # Common SVC plugin (shared by RDPDR, RDPSND, etc.)


### PR DESCRIPTION
This change leverages pkg-config to determine the actual, correct location used by FreeRDP for its plugins, logging the discovered directory in the summary at the end of `configure` and using that directory for the install location of the FreeRDP plugins (regardless of any prefix, libdir, etc. that might otherwise have been given as options to the `configure` script):

```
[mjumper@dev-mjumper guacamole-server]$ ./configure
...
config.status: creating config.h
config.status: executing depfiles commands
config.status: executing libtool commands

------------------------------------------------
guacamole-server version 1.1.0
------------------------------------------------

   Library status:

     freerdp2 ............ yes
     pango ............... yes
     libavcodec .......... yes
     libavutil ........... yes
     libssh2 ............. yes
     libssl .............. yes
     libswscale .......... yes
     libtelnet ........... yes
     libVNCServer ........ yes
     libvorbis ........... yes
     libpulse ............ yes
     libwebsockets ....... yes
     libwebp ............. yes
     wsock32 ............. no

   Protocol support:

      Kubernetes .... yes
      RDP ........... yes
      SSH ........... yes
      Telnet ........ yes
      VNC ........... yes

   Services / tools:

      guacd ...... yes
      guacenc .... yes
      guaclog .... yes

   FreeRDP plugins: /usr/lib64/freerdp2
   Init scripts: no
   Systemd units: no

Type "make" to compile guacamole-server.

[mjumper@dev-mjumper guacamole-server]$ 
```

I figured this might be worth doing as part of GUACAMOLE-249, given that the FreeRDP plugins being installed are changing and symbolic links from installs of Apache Guacamole 1.0.0 and older will not work. If others think this should be a separate issue, I'm not extremely against letting this wait, but I think this will save everyone some pain.