### PR TITLE
GUACAMOLE-928: Keep all build artifacts of Docker image within /usr/local/guacamole, including FreeRDP plugins.

### DIFF
--- a/src/guacd-docker/bin/build-guacd.sh
+++ b/src/guacd-docker/bin/build-guacd.sh
@@ -43,7 +43,7 @@ PREFIX_DIR="$2"
 
 cd "$BUILD_DIR"
 autoreconf -fi
-./configure --prefix="$PREFIX_DIR" --disable-guaclog
+./configure --prefix="$PREFIX_DIR" --disable-guaclog --with-freerdp-plugin-dir="$PREFIX_DIR/lib/freerdp2"
 make
 make install
 ldconfig


### PR DESCRIPTION
The change introduced by #245 actually causes issues with the Docker image build due to the way a separate builder image is used. The image build process expects that absolutely all build artifacts will be installed beneath `/usr/local/guacamole`, but this is no longer the case by default due to the automatic detection of FreeRDP plugin location.

This change overrides the FreeRDP plugin location detection that is part of the guacamole-server build, keeping things together for the sake of the Docker image build and relying instead on the rest of the build to add any symbolic links needed for FreeRDP to find the plugins.