### PR TITLE
GUACAMOLE-927: Automatically set $HOME for sake of FreeRDP initialization process

### DIFF
--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -367,7 +367,14 @@ static int guac_rdp_handle_connection(guac_client* client) {
     /* Allocate FreeRDP context */
     rdp_inst->ContextSize = sizeof(rdp_freerdp_context);
 
-    freerdp_context_new(rdp_inst);
+    if (!freerdp_context_new(rdp_inst)) {
+        guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+                "FreeRDP initialization failed before connecting. Please "
+                "check for errors earlier in the logs and/or enable "
+                "debug-level logging for guacd.");
+        return 1;
+    }
+
     ((rdp_freerdp_context*) rdp_inst->context)->client = client;
 
     /* Load keymap into client */


### PR DESCRIPTION
The `freerdp_settings_new()` function, part of the FreeRDP initialization process, assumes that the `HOME` environment variable will be set and aborts initialization if it isn't, ultimately resulting in a segfault on the Guacamole side.

This change automatically sets the `HOME` variable based on the home directory retrieved from the system's user database. In case initialization still unexpectedly fails, checking has also been added around `freerdp_context_new()` which will abort the connection cleanly rather than segfault.