### PR TITLE
GUACAMOLE-934: Add support for the Play Sound PDU.

### DIFF
--- a/src/libguac/audio.c
+++ b/src/libguac/audio.c
@@ -117,6 +117,12 @@ guac_audio_stream* guac_audio_stream_alloc(guac_client* client,
     audio->client = client;
     audio->stream = guac_client_alloc_stream(client);
 
+    /* Abort allocation if underlying stream cannot be allocated */
+    if (audio->stream == NULL) {
+        free(audio);
+        return NULL;
+    }
+
     /* Load PCM properties */
     audio->rate = rate;
     audio->channels = channels;
@@ -187,6 +193,9 @@ void guac_audio_stream_free(guac_audio_stream* audio) {
     /* Clean up encoder */
     if (audio->encoder != NULL && audio->encoder->end_handler)
         audio->encoder->end_handler(audio);
+
+    /* Release stream back to client pool */
+    guac_client_free_stream(audio->client, audio->stream);
 
     /* Free associated data */
     free(audio);

--- a/src/libguac/guacamole/audio.h
+++ b/src/libguac/guacamole/audio.h
@@ -148,7 +148,8 @@ struct guac_audio_stream {
  * @return
  *     The newly allocated guac_audio_stream, or NULL if no audio stream could
  *     be allocated due to lack of support on the part of the connecting
- *     Guacamole client.
+ *     Guacamole client or due to reaching the maximum number of active
+ *     streams.
  */
 guac_audio_stream* guac_audio_stream_alloc(guac_client* client,
         guac_audio_encoder* encoder, int rate, int channels, int bps);

--- a/src/libguac/guacamole/client.h
+++ b/src/libguac/guacamole/client.h
@@ -383,7 +383,8 @@ void guac_client_free_layer(guac_client* client, guac_layer* layer);
  *     The client to allocate the stream for.
  *
  * @return
- *     The next available stream, or a newly allocated stream.
+ *     The next available stream, or a newly allocated stream, or NULL if the
+ *     maximum number of active streams has been reached.
  */
 guac_stream* guac_client_alloc_stream(guac_client* client);
 

--- a/src/libguac/guacamole/user.h
+++ b/src/libguac/guacamole/user.h
@@ -574,8 +574,12 @@ int guac_user_handle_instruction(guac_user* user, const char* opcode,
  * Allocates a new stream. An arbitrary index is automatically assigned
  * if no previously-allocated stream is available for use.
  *
- * @param user The user to allocate the stream for.
- * @return The next available stream, or a newly allocated stream.
+ * @param user
+ *     The user to allocate the stream for.
+ *
+ * @return
+ *     The next available stream, or a newly allocated stream, or NULL if the
+ *     maximum number of active streams has been reached.
  */
 guac_stream* guac_user_alloc_stream(guac_user* user);
 

--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -38,6 +38,7 @@ nodist_libguac_client_rdp_la_SOURCES =  \
     _generated_keymaps.c
 
 libguac_client_rdp_la_SOURCES =                  \
+    beep.c                                       \
     bitmap.c                                     \
     channels/audio-input/audio-buffer.c          \
     channels/audio-input/audio-input.c           \
@@ -81,6 +82,7 @@ libguac_client_rdp_la_SOURCES =                  \
     user.c
 
 noinst_HEADERS =                                 \
+    beep.h                                       \
     bitmap.h                                     \
     channels/audio-input/audio-buffer.h          \
     channels/audio-input/audio-input.h           \

--- a/src/protocols/rdp/beep.c
+++ b/src/protocols/rdp/beep.c
@@ -123,6 +123,15 @@ BOOL guac_rdp_beep_play_sound(rdpContext* context,
     guac_audio_stream* beep = guac_audio_stream_alloc(client, NULL,
             GUAC_RDP_BEEP_SAMPLE_RATE, 1, 8);
 
+    /* Stream availability is not guaranteed */
+    if (beep == NULL) {
+        guac_client_log(client, GUAC_LOG_DEBUG, "Ignoring request to beep "
+                "for %" PRIu32 " millseconds at %" PRIu32 " Hz as no audio "
+                "stream could be allocated.", play_sound->duration,
+                play_sound->frequency);
+        return TRUE;
+    }
+
     /* Limit maximum duration of each beep */
     int duration = play_sound->duration;
     if (duration > GUAC_RDP_BEEP_MAX_DURATION)

--- a/src/protocols/rdp/beep.c
+++ b/src/protocols/rdp/beep.c
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "beep.h"
+#include "rdp.h"
+#include "settings.h"
+
+#include <freerdp/freerdp.h>
+#include <guacamole/audio.h>
+#include <guacamole/client.h>
+#include <winpr/wtypes.h>
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * Fills the given buffer with signed 8-bit, single-channel PCM at the given
+ * sample rate which will produce a beep of the given frequency.
+ *
+ * @param buffer
+ *     The buffer to fill with PCM data.
+ *
+ * @param frequency
+ *     The frequency of the beep to generate, in hertz.
+ *
+ * @param rate
+ *     The sample rate of the PCM to generate, in samples per second.
+ *
+ * @param buffer_size
+ *     The number of bytes of PCM data to write to the given buffer.
+ */
+static void guac_rdp_beep_fill_square_wave(unsigned char* buffer,
+        int frequency, int rate, int buffer_size) {
+
+    int remaining = buffer_size;
+    int current_value = GUAC_RDP_BEEP_AMPLITUDE;
+    int pulse_width = rate / frequency / 2;
+
+    /* Repeatedly write pulses (whose widths are determined by the desired
+     * frequency) until buffer space is exhausted */
+    while (remaining > 0) {
+
+        /* Truncate pulse if insufficient space remains */
+        int block_size = pulse_width;
+        if (block_size > remaining)
+            block_size = remaining;
+
+        /* Write blocks, alternating the sign of the amplitude of each
+         * successive block */
+        memset(buffer, current_value, block_size);
+        current_value = -current_value;
+
+        buffer += block_size;
+        remaining -= block_size;
+
+    }
+
+}
+
+/**
+ * Writes PCM data to the given guac_audio_stream which produces a beep of the
+ * given frequency and duration. The provided guac_audio_stream may be
+ * configured for any sample rate but MUST be configured for single-channel,
+ * 8-bit PCM.
+ *
+ * @param audio
+ *     The guac_audio_stream which should receive the PCM data.
+ *
+ * @param frequency
+ *     The frequency of the beep, in hertz.
+ *
+ * @param duration
+ *     The duration of the beep, in milliseconds.
+ */
+static void guac_rdp_beep_write_pcm(guac_audio_stream* audio,
+        int frequency, int duration) {
+
+    int buffer_size = audio->rate * duration / 1000;
+    unsigned char* buffer = malloc(buffer_size);
+
+    /* Beep for given frequency/duration using a simple square wave */
+    guac_rdp_beep_fill_square_wave(buffer, frequency, audio->rate, buffer_size);
+    guac_audio_stream_write_pcm(audio, buffer, buffer_size);
+
+    free(buffer);
+
+}
+
+BOOL guac_rdp_beep_play_sound(rdpContext* context,
+        const PLAY_SOUND_UPDATE* play_sound) {
+
+    guac_client* client = ((rdp_freerdp_context*) context)->client;
+    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
+    guac_rdp_settings* settings = rdp_client->settings;
+
+    /* Ignore if audio is not enabled */
+    if (!settings->audio_enabled) {
+        guac_client_log(client, GUAC_LOG_DEBUG, "Ignoring request to beep "
+                "for %" PRIu32 " millseconds at %" PRIu32 " Hz as audio is "
+                "disabled.", play_sound->duration, play_sound->frequency);
+        return TRUE;
+    }
+
+    /* Allocate audio stream which sends audio in a format supported by the
+     * connected client(s) */
+    guac_audio_stream* beep = guac_audio_stream_alloc(client, NULL,
+            GUAC_RDP_BEEP_SAMPLE_RATE, 1, 8);
+
+    /* Limit maximum duration of each beep */
+    int duration = play_sound->duration;
+    if (duration > GUAC_RDP_BEEP_MAX_DURATION)
+        duration = GUAC_RDP_BEEP_MAX_DURATION;
+
+    guac_rdp_beep_write_pcm(beep, play_sound->frequency, duration);
+    guac_audio_stream_free(beep);
+
+    return TRUE;
+
+}
+

--- a/src/protocols/rdp/beep.h
+++ b/src/protocols/rdp/beep.h
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_RDP_BEEP_H
+#define GUAC_RDP_BEEP_H
+
+#include <freerdp/freerdp.h>
+#include <winpr/wtypes.h>
+
+/**
+ * The sample rate of the each generated beep, in samples per second.
+ */
+#define GUAC_RDP_BEEP_SAMPLE_RATE 8000
+
+/**
+ * The amplitude (volume) of each beep. As the beep is generated as 8-bit
+ * signed PCM, this should be kept between 0 and 127 inclusive.
+ */
+#define GUAC_RDP_BEEP_AMPLITUDE 64
+
+/**
+ * The maximum duration of each beep, in milliseconds. This value should be
+ * kept relatively small to ensure the amount of data sent for each beep is
+ * minimal.
+ */
+#define GUAC_RDP_BEEP_MAX_DURATION 500
+
+/**
+ * Processes a Play Sound PDU received from the RDP server, beeping for the
+ * requested duration and at the requested frequency. If audio has been
+ * disabled for the connection, the Play Sound PDU will be silently ignored,
+ * and this function has no effect. Beeps in excess of the maximum specified
+ * by GUAC_RDP_BEEP_MAX_DURATION will be truncated.
+ *
+ * @param context
+ *     The rdpContext associated with the current RDP session.
+ *
+ * @param play_sound
+ *     The PLAY_SOUND_UPDATE structure representing the received Play Sound
+ *     PDU.
+ *
+ * @return
+ *     TRUE if successful, FALSE otherwise.
+ */
+BOOL guac_rdp_beep_play_sound(rdpContext* context,
+        const PLAY_SOUND_UPDATE* play_sound);
+
+#endif
+

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include "beep.h"
 #include "bitmap.h"
 #include "channels/audio-input/audio-buffer.h"
 #include "channels/audio-input/audio-input.h"
@@ -166,6 +167,9 @@ BOOL rdp_freerdp_pre_connect(freerdp* instance) {
     pointer.SetNull = guac_rdp_pointer_set_null;
     pointer.SetDefault = guac_rdp_pointer_set_default;
     graphics_register_pointer(graphics, &pointer);
+
+    /* Beep on receipt of Play Sound PDU */
+    instance->update->PlaySound = guac_rdp_beep_play_sound;
 
     /* Set up GDI */
     instance->update->DesktopResize = guac_rdp_gdi_desktop_resize;


### PR DESCRIPTION
This change adds support for the [Play Sound PDU](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/e9fb1ecb-191c-45ca-84a0-b7db6366e467), which requests that the client beep at a given frequency and for a given duration.

As written, this support limits the maximum duration of each requested beep to half a second, despite RDP technically supporting beeps up to 50 days long.