### PR TITLE
GUACAMOLE-935: Free internals of rdpBitmap only when required.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -589,23 +589,16 @@ then
     # manually free all data associated with the rdpBitmap, even data which
     # was not allocated by the implementation.
     AC_MSG_CHECKING([whether Bitmap_Free() frees the rdpBitmap and its image data])
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
+    AC_EGREP_CPP([\"2.0.0-dev\"], [
 
         #include <freerdp/version.h>
+        FREERDP_VERSION_FULL
 
-        #include <string.h>
-
-        int main() {
-            /* Return successfully if version is 2.0.0-rc0 */
-            return strcmp(FREERDP_VERSION_FULL, "2.0.0-dev");
-        }
-
-    ]])],
+    ],
     [AC_MSG_RESULT([yes])]
     [AC_DEFINE([FREERDP_BITMAP_FREE_FREES_BITMAP],,
                [Whether Bitmap_Free() frees the rdpBitmap and its image data])],
-    [AC_MSG_RESULT([no])],
-    [AC_MSG_RESULT([assuming no (cross-compiling)])])
+    [AC_MSG_RESULT([no])])
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -578,6 +578,37 @@ then
 
 fi
 
+# Variation in memory internal allocation/free behavior
+if test "x${have_freerdp2}" = "xyes"
+then
+
+    # FreeRDP 2.0.0-rc0 and older automatically free rdpBitmap and its
+    # associated data member within Bitmap_Free(), relying on the
+    # implementation-specific free handler to free only implementation-specific
+    # data. This changed in commit 2cf10cc, and implementations must now
+    # manually free all data associated with the rdpBitmap, even data which
+    # was not allocated by the implementation.
+    AC_MSG_CHECKING([whether Bitmap_Free() frees the rdpBitmap and its image data])
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[
+
+        #include <freerdp/version.h>
+
+        #include <string.h>
+
+        int main() {
+            /* Return successfully if version is 2.0.0-rc0 */
+            return strcmp(FREERDP_VERSION_FULL, "2.0.0-dev");
+        }
+
+    ]])],
+    [AC_MSG_RESULT([yes])]
+    [AC_DEFINE([FREERDP_BITMAP_FREE_FREES_BITMAP],,
+               [Whether Bitmap_Free() frees the rdpBitmap and its image data])],
+    [AC_MSG_RESULT([no])],
+    [AC_MSG_RESULT([assuming no (cross-compiling)])])
+
+fi
+
 # Glyph callback variants
 if test "x${have_freerdp2}" = "xyes"
 then

--- a/configure.ac
+++ b/configure.ac
@@ -589,7 +589,7 @@ then
     # manually free all data associated with the rdpBitmap, even data which
     # was not allocated by the implementation.
     AC_MSG_CHECKING([whether Bitmap_Free() frees the rdpBitmap and its image data])
-    AC_EGREP_CPP([\"2.0.0-dev\"], [
+    AC_EGREP_CPP([\"2\\.0\\.0-dev\"], [
 
         #include <freerdp/version.h>
         FREERDP_VERSION_FULL

--- a/src/protocols/rdp/bitmap.c
+++ b/src/protocols/rdp/bitmap.c
@@ -20,6 +20,7 @@
 #include "bitmap.h"
 #include "common/display.h"
 #include "common/surface.h"
+#include "config.h"
 #include "rdp.h"
 
 #include <cairo/cairo.h>
@@ -127,12 +128,14 @@ void guac_rdp_bitmap_free(rdpContext* context, rdpBitmap* bitmap) {
     if (buffer != NULL)
         guac_common_display_free_buffer(rdp_client->display, buffer);
 
-    /* NOTE: FreeRDP-allocated memory for the rdpBitmap will NOT be
-     * automatically released after this free handler is invoked, thus we must
-     * do so manually here */
+#ifndef FREERDP_BITMAP_FREE_FREES_BITMAP
+    /* NOTE: Except in FreeRDP 2.0.0-rc0 and earlier, FreeRDP-allocated memory
+     * for the rdpBitmap will NOT be automatically released after this free
+     * handler is invoked, thus we must do so manually here */
 
     _aligned_free(bitmap->data);
     free(bitmap);
+#endif
 
 }
 


### PR DESCRIPTION
This change adds an test to the `configure` script which determines whether we are building against FreeRDP 2.0.0-rc0, which had a `Bitmap_Free()` which freed bitmaps. For all newer versions of FreeRDP 2.0.0, `Bitmap_Free()` doesn't - it simply wraps the implementation-specific free handler, and it's on the implementation to know which internal parts of `rdpBitmap` were allocated by `Bitmap_Alloc()` and must now be freed.

The latter was handled in commit 8dda26a when the resulting memory leak was discovered during valgrind testing, but this now must be made conditional as this would result in a double-free against 2.0.0-rc0.

Unfortunately, the test itself is awkward:

* It is not possible to test `Bitmap_Free()` behavior in itself. We must test version numbers.
* While we can test numeric version macros, the only numeric version macros available always indicate that the version is "2.0.0".
* Version macros exist which indicate the RC number and inter-RC number, but they are strings. The C preprocessor cannot test string values.

Because of these limitations, the test can only be performed by either compiling a test program and running it (which can only be done when not cross-compiling) or by checking preprocessor output. This change ultimately goes with the latter approach.