### PR TITLE
GUACAMOLE-935: Do not assign SVC plugin context as it may be automatically freed.

### DIFF
--- a/src/protocols/rdp/plugins/guac-common-svc/guac-common-svc.c
+++ b/src/protocols/rdp/plugins/guac-common-svc/guac-common-svc.c
@@ -294,7 +294,7 @@ BOOL VirtualChannelEntryEx(PCHANNEL_ENTRY_POINTS_EX entry_points,
     svc->_init_handle = init_handle;
 
     /* Complete initialization */
-    if (svc->_entry_points.pVirtualChannelInitEx(svc, svc, init_handle,
+    if (svc->_entry_points.pVirtualChannelInitEx(svc, NULL, init_handle,
                 &svc->_channel_def, 1, VIRTUAL_CHANNEL_VERSION_WIN2000,
                 guac_rdp_common_svc_handle_init_event) != CHANNEL_RC_OK) {
         return FALSE;


### PR DESCRIPTION
FreeRDP version 2.0.0-rc0 and older will automatically free whatever `entry_points->pInterface` is set to when the channel plugin is unloaded. This doesn't happen in later versions, but will result in a double-free upon disconnect for 2.0.0-rc0 in our case. As we don't need `pInterface`, we can safely set this to `NULL` and avoid the issue entirely.