### PR TITLE
GUACAMOLE-625: Remove trailing whitespace in Makefile.am and fix style

### DIFF
--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -221,24 +221,24 @@ BUILT_SOURCES =                         \
     _generated_channel_entry_wrappers.c \
     _generated_keymaps.c
 
-rdp_keymaps =                             \
-    $(srcdir)/keymaps/base.keymap         \
-    $(srcdir)/keymaps/failsafe.keymap     \
-    $(srcdir)/keymaps/de_de_qwertz.keymap \
-    $(srcdir)/keymaps/de_ch_qwertz.keymap \
-    $(srcdir)/keymaps/en_gb_qwerty.keymap \
-    $(srcdir)/keymaps/en_us_qwerty.keymap \
-    $(srcdir)/keymaps/es_es_qwerty.keymap \
-    $(srcdir)/keymaps/es_latam_qwerty.keymap \    
-    $(srcdir)/keymaps/fr_be_azerty.keymap \
-    $(srcdir)/keymaps/fr_ch_qwertz.keymap \
-    $(srcdir)/keymaps/fr_fr_azerty.keymap \
-    $(srcdir)/keymaps/hu_hu_qwertz.keymap \
-    $(srcdir)/keymaps/it_it_qwerty.keymap \
-    $(srcdir)/keymaps/ja_jp_qwerty.keymap \
-    $(srcdir)/keymaps/pt_br_qwerty.keymap \
-    $(srcdir)/keymaps/sv_se_qwerty.keymap \
-    $(srcdir)/keymaps/da_dk_qwerty.keymap \
+rdp_keymaps =                                \
+    $(srcdir)/keymaps/base.keymap            \
+    $(srcdir)/keymaps/failsafe.keymap        \
+    $(srcdir)/keymaps/de_de_qwertz.keymap    \
+    $(srcdir)/keymaps/de_ch_qwertz.keymap    \
+    $(srcdir)/keymaps/en_gb_qwerty.keymap    \
+    $(srcdir)/keymaps/en_us_qwerty.keymap    \
+    $(srcdir)/keymaps/es_es_qwerty.keymap    \
+    $(srcdir)/keymaps/es_latam_qwerty.keymap \
+    $(srcdir)/keymaps/fr_be_azerty.keymap    \
+    $(srcdir)/keymaps/fr_ch_qwertz.keymap    \
+    $(srcdir)/keymaps/fr_fr_azerty.keymap    \
+    $(srcdir)/keymaps/hu_hu_qwertz.keymap    \
+    $(srcdir)/keymaps/it_it_qwerty.keymap    \
+    $(srcdir)/keymaps/ja_jp_qwerty.keymap    \
+    $(srcdir)/keymaps/pt_br_qwerty.keymap    \
+    $(srcdir)/keymaps/sv_se_qwerty.keymap    \
+    $(srcdir)/keymaps/da_dk_qwerty.keymap    \
     $(srcdir)/keymaps/tr_tr_qwerty.keymap
 
 _generated_keymaps.c: $(rdp_keymaps)


### PR DESCRIPTION
Fixes issue introduced by #253 with trailing whitespace in one of the lines; also fixes style in the Makefile.am file.