### PR TITLE
GUACAMOLE-951: Add ability to set KeyboardType for FreeRDP

### DIFF
--- a/src/protocols/rdp/keymap.h
+++ b/src/protocols/rdp/keymap.h
@@ -103,6 +103,24 @@ struct guac_rdp_keymap {
      */
     const UINT32 freerdp_keyboard_layout;
 
+    /**
+     * FreeRDP keyboard type definition.
+     * See https://docs.microsoft.com/ja-jp/windows/win32/api/winuser/nf-winuser-getkeyboardtype
+     */
+    const UINT32 freerdp_keyboard_type;
+
+    /**
+     * FreeRDP keyboard subtype definition.
+     * See https://docs.microsoft.com/ja-jp/windows/win32/api/winuser/nf-winuser-getkeyboardtype
+     */
+    const UINT32 freerdp_keyboard_subtype;
+
+    /**
+     * FreeRDP keyboard number of function keys.
+     * See https://docs.microsoft.com/ja-jp/windows/win32/api/winuser/nf-winuser-getkeyboardtype#remarks
+     */
+    const UINT32 freerdp_keyboard_function_key;
+
 };
 
 /**

--- a/src/protocols/rdp/keymaps/generate.pl
+++ b/src/protocols/rdp/keymaps/generate.pl
@@ -81,6 +81,22 @@ for my $filename (@ARGV) {
         elsif ((my $name) = m/^\s*freerdp\s+"(.*)"\s*(?:#.*)?$/) {
             $freerdp = $name;
         }
+        
+        # FreeRDP keyboard type
+        elsif ((my $name) = m/^\s*freerdp_keyboard_type\s+"(.*)"\s*(?:#.*)?$/) {
+            $freerdp_keyboard_type = $name;
+        }
+
+        # FreeRDP keyboard subtype
+        elsif ((my $name) = m/^\s*freerdp_keyboard_subtype\s+"(.*)"\s*(?:#.*)?$/) {
+            $freerdp_keyboard_subtype = $name;
+        }
+
+        # FreeRDP keyboard function key
+        elsif ((my $name) = m/^\s*freerdp_keyboard_function_key\s+"(.*)"\s*(?:#.*)?$/) {
+            $freerdp_keyboard_function_key = $name;
+        }
+
 
         # Map
         elsif ((my $range, my $onto) =
@@ -252,6 +268,18 @@ for my $filename (@ARGV) {
     # FreeRDP layout (if any)
     if ($freerdp) {
         print OUTPUT "    .freerdp_keyboard_layout = $freerdp,\n";
+    }
+    # FreeRDP keyboard type (if any)
+    if ($freerdp_keyboard_type) {
+        print OUTPUT "    .freerdp_keyboard_type = $freerdp_keyboard_type,\n";
+    }
+    # FreeRDP layout (if any)
+    if ($freerdp_keyboard_subtype) {
+        print OUTPUT "    .freerdp_keyboard_subtype = $freerdp_keyboard_subtype,\n";
+    }
+    # FreeRDP layout (if any)
+    if ($freerdp_keyboard_function_key) {
+        print OUTPUT "    .freerdp_keyboard_function_key = $freerdp_keyboard_function_key,\n";
     }
 
     # Desc footer

--- a/src/protocols/rdp/keymaps/ja_jp_qwerty.keymap
+++ b/src/protocols/rdp/keymaps/ja_jp_qwerty.keymap
@@ -20,6 +20,9 @@
 parent  "base"
 name    "ja-jp-qwerty"
 freerdp "KBD_JAPANESE"
+freerdp_keyboard_type "KBD_TYPE_JAPANESE"
+freerdp_keyboard_subtype "2"
+freerdp_keyboard_function_key "12"
 
 map -shift      0x02..0x0D 0x7D ~ "1234567890-^\"
 map -shift      0x10..0x1B      ~ "qwertyuiop@["

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -1189,6 +1189,9 @@ void guac_rdp_push_settings(guac_client* client,
     rdp_settings->DesktopHeight = guac_settings->height;
     rdp_settings->AlternateShell = guac_rdp_strdup(guac_settings->initial_program);
     rdp_settings->KeyboardLayout = guac_settings->server_layout->freerdp_keyboard_layout;
+    rdp_settings->KeyboardType = guac_settings->server_layout->freerdp_keyboard_type;
+    rdp_settings->KeyboardSubType = guac_settings->server_layout->freerdp_keyboard_subtype;
+    rdp_settings->KeyboardFunctionKey = guac_settings->server_layout->freerdp_keyboard_function_key;
 
     /* Performance flags */
     /* Explicitly set flag value */


### PR DESCRIPTION
KeyboardType, KeyboardSubtype, KeyboardFunctionKey is required for Japanese keyboard setting actually,
but the patch has been applied to overwrite values only for Japanese keyboards.
see: https://github.com/FreeRDP/FreeRDP/pull/707

I think it should be specified from Guacamole as FreeRDP user side.