### PR TITLE
GUACAMOLE-958: Avoid race/deadlock in guacd_timed_client_free()

### DIFF
--- a/src/guacd/proc.c
+++ b/src/guacd/proc.c
@@ -267,24 +267,24 @@ static int guacd_timed_client_free(guac_client* client, int timeout) {
         .tv_nsec = current_time.tv_usec * 1000
     };
 
-    /* Free the client in a separate thread, so we can time the free operation */
-    if (pthread_create(&client_free_thread, NULL,
-                guacd_client_free_thread, &free_operation))
-        return 1;
-
     /* The mutex associated with the pthread conditional and flag MUST be
      * acquired before attempting to wait for the condition */
     if (pthread_mutex_lock(&free_operation.completed_mutex))
         return 1;
 
-    /* Wait a finite amount of time for the free operation to finish */
-    if (pthread_cond_timedwait(&free_operation.completed_cond,
-                &free_operation.completed_mutex, &deadline))
-        return 1;
+    /* Free the client in a separate thread, so we can time the free operation */
+    if (!pthread_create(&client_free_thread, NULL,
+                guacd_client_free_thread, &free_operation)) {
+
+        /* Wait a finite amount of time for the free operation to finish */
+        (void) pthread_cond_timedwait(&free_operation.completed_cond,
+                    &free_operation.completed_mutex, &deadline);
+    }
+
+    (void) pthread_mutex_unlock(&free_operation.completed_mutex);
 
     /* Return status of free operation */
     return !free_operation.completed;
-
 }
 
 /**


### PR DESCRIPTION
Fix for GUACAMOLE-958.

Two separate problems:

1. Race condition may lead to unwarranted wait and then timeout:
`guacd_timed_client_free()` raced with `guacd_client_free_thread()` for signalling on `free_operation.completed_cond`

2. Potential deadlock/hang of the thread `client_free_thread` if `pthread_cond_timedwait()` failed early or `guacd_client_free_thread()` took longer to reach it's signalling part than the timeout. The reason is that `pthread_cond_timedwait()` re-acquires the mutex before returning 0 or ETIMEDOUT and doesn't ever release it on other errors. Please refer to the man page.

Reference:
http://man7.org/linux/man-pages/man3/pthread_cond_timedwait.3p.html
