### PR TITLE
GUACAMOLE-962: Allow misbehaving RDP servers to use OpaqueRect and PatBlt.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -722,6 +722,21 @@ then
 
 fi
 
+# Support for receiving unannounced orders from the RDP server
+if test "x${have_freerdp2}" = "xyes"
+then
+    AC_CHECK_MEMBERS([rdpSettings.AllowUnanouncedOrdersFromServer],,
+                     [AC_MSG_WARN([
+  --------------------------------------------
+   This version of FreeRDP does not support relaxed order checks. RDP servers
+   that send orders that the client did not announce as supported (such as the
+   VirtualBox RDP server) will likely not be usable.
+
+   See: https://issues.apache.org/jira/browse/GUACAMOLE-962
+  --------------------------------------------])],
+                     [[#include <freerdp/freerdp.h>]])
+fi
+
 # Restore CPPFLAGS, removing FreeRDP-specific options needed for testing
 CPPFLAGS="$OLDCPPFLAGS"
 

--- a/src/protocols/rdp/gdi.h
+++ b/src/protocols/rdp/gdi.h
@@ -63,6 +63,25 @@ guac_composite_mode guac_rdp_rop3_transfer_function(guac_client* client,
 BOOL guac_rdp_gdi_dstblt(rdpContext* context, const DSTBLT_ORDER* dstblt);
 
 /**
+ * Handler for the PatBlt Primary Drawing Order. A PatBlt Primary Drawing Order
+ * paints a rectangle of image data, a brush pattern, and a three-way raster
+ * operation which considers the source data, the destination, AND the brush
+ * pattern. See:
+ *
+ * https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegdi/bd4bf5e7-b988-45f9-8201-3b22cc9aeeb8
+ *
+ * @param context
+ *     The rdpContext associated with the current RDP session.
+ *
+ * @param patblt
+ *     The PATBLT update to handle.
+ *
+ * @return
+ *     TRUE if successful, FALSE otherwise.
+ */
+BOOL guac_rdp_gdi_patblt(rdpContext* context, PATBLT_ORDER* patblt);
+
+/**
  * Handler for the ScrBlt Primary Drawing Order. A ScrBlt Primary Drawing Order
  * paints a rectangle of image data using a raster operation which considers
  * the source and destination. See:
@@ -97,6 +116,26 @@ BOOL guac_rdp_gdi_scrblt(rdpContext* context, const SCRBLT_ORDER* scrblt);
  *     TRUE if successful, FALSE otherwise.
  */
 BOOL guac_rdp_gdi_memblt(rdpContext* context, MEMBLT_ORDER* memblt);
+
+/**
+ * Handler for the OpaqueRect Primary Drawing Order. An OpaqueRect Primary
+ * Drawing Order draws an opaque rectangle of a single solid color. Note that
+ * support for OpaqueRect cannot be claimed without also supporting PatBlt, as
+ * both use the same negotiation order number. See:
+ *
+ * https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegdi/1eead7aa-ac63-411a-9f8c-b1b227526877
+ *
+ * @param context
+ *     The rdpContext associated with the current RDP session.
+ *
+ * @param opaque_rect
+ *     The OPAQUE RECT update to handle.
+ *
+ * @return
+ *     TRUE if successful, FALSE otherwise.
+ */
+BOOL guac_rdp_gdi_opaquerect(rdpContext* context,
+        const OPAQUE_RECT_ORDER* opaque_rect);
 
 /**
  * Handler called prior to calling the handlers for specific updates when

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -179,8 +179,10 @@ BOOL rdp_freerdp_pre_connect(freerdp* instance) {
 
     rdpPrimaryUpdate* primary = instance->update->primary;
     primary->DstBlt = guac_rdp_gdi_dstblt;
+    primary->PatBlt = guac_rdp_gdi_patblt;
     primary->ScrBlt = guac_rdp_gdi_scrblt;
     primary->MemBlt = guac_rdp_gdi_memblt;
+    primary->OpaqueRect = guac_rdp_gdi_opaquerect;
 
     pointer_cache_register_callbacks(instance->update);
     glyph_cache_register_callbacks(instance->update);

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -1356,5 +1356,10 @@ void guac_rdp_push_settings(guac_client* client,
     rdp_settings->OrderSupport[NEG_FAST_INDEX_INDEX] = !guac_settings->disable_glyph_caching;
     rdp_settings->OrderSupport[NEG_FAST_GLYPH_INDEX] = !guac_settings->disable_glyph_caching;
 
+#ifdef HAVE_RDPSETTINGS_ALLOWUNANOUNCEDORDERSFROMSERVER
+    /* Do not consider server use of unannounced orders to be a fatal error */
+    rdp_settings->AllowUnanouncedOrdersFromServer = TRUE;
+#endif
+
 }
 


### PR DESCRIPTION
This change requests relaxed validation of server orders if supported by FreeRDP, warning the user during the build process if their version of FreeRDP lacks this support.

Fallback support for OpaqueRect and PatBlt orders is restored through reverting commit 9855d875c794e9517567e89ad13acccd7e7e03d0, allowing RDP servers that (incorrectly) assume support for those orders to generally function without introducing visual artifacts.