### PR TITLE
GUACAMOLE-966: Bump server version to 1.2.0

### DIFF
--- a/bin/guacctl
+++ b/bin/guacctl
@@ -117,7 +117,7 @@ error() {
 ##
 usage() {
     cat >&2 <<END
-guacctl 1.1.0, Apache Guacamole terminal session control utility.
+guacctl 1.2.0, Apache Guacamole terminal session control utility.
 Usage: guacctl [OPTION] [FILE or NAME]...
 
     -d, --download         download each of the files listed.

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@
 #
 
 AC_PREREQ([2.61])
-AC_INIT([guacamole-server], [1.1.0])
+AC_INIT([guacamole-server], [1.2.0])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
This pull request bumps the server versions to 1.2.0.  I did not modify the libguac version, as that has not changed (yet).