### PR TITLE
GUACAMOLE-979: Ensure all FreeRDP settings strings are independent duplicates of their corresponding Guacamole settings.

### DIFF
--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -1296,9 +1296,9 @@ void guac_rdp_push_settings(guac_client* client,
         rdp_settings->Workarea = TRUE;
         rdp_settings->RemoteApplicationMode = TRUE;
         rdp_settings->RemoteAppLanguageBarSupported = TRUE;
-        rdp_settings->RemoteApplicationProgram = guac_settings->remote_app;
+        rdp_settings->RemoteApplicationProgram = guac_rdp_strdup(guac_settings->remote_app);
         rdp_settings->ShellWorkingDirectory = guac_rdp_strdup(guac_settings->remote_app_dir);
-        rdp_settings->RemoteApplicationCmdLine = guac_settings->remote_app_args;
+        rdp_settings->RemoteApplicationCmdLine = guac_rdp_strdup(guac_settings->remote_app_args);
     }
 
     /* Preconnection ID */
@@ -1312,7 +1312,7 @@ void guac_rdp_push_settings(guac_client* client,
     if (guac_settings->preconnection_blob != NULL) {
         rdp_settings->NegotiateSecurityLayer = FALSE;
         rdp_settings->SendPreconnectionPdu = TRUE;
-        rdp_settings->PreconnectionBlob = guac_settings->preconnection_blob;
+        rdp_settings->PreconnectionBlob = guac_rdp_strdup(guac_settings->preconnection_blob);
     }
 
     /* Enable use of RD gateway if a gateway hostname is provided */


### PR DESCRIPTION
FreeRDP 2.0.0 will automatically free all settings strings when the settings structure is freed. As we will also do the same for our own settings strings, the FreeRDP settings must be kept independent. This change adds calls to `guac_rdp_strdup()` for the few strings remaining that lacked this call.

Note that we can't simply not free the strings on our side and rely purely on FreeRDP to do so. There is no guarantee that FreeRDP will be given control of the strings before before an error causes the Guacamole connection to abort, nor is there any guarantee that the FreeRDP settings structure will not need to be repeatedly recreated from the same source material (the original copies of those strings) during an automatic internal reconnect.