### PR TITLE
GUACAMOLE-1047: Notify connecting client on unrecognized connection ID

### DIFF
--- a/src/guacd/connection.c
+++ b/src/guacd/connection.c
@@ -278,10 +278,18 @@ static int guacd_route_connection(guacd_proc_map* map, guac_socket* socket) {
         proc = guacd_proc_map_retrieve(map, identifier);
         new_process = 0;
 
-        /* Warn if requested connection does not exist */
-        if (proc == NULL)
-            guacd_log(GUAC_LOG_INFO, "Connection \"%s\" does not exist.",
-                    identifier);
+        /* Warn and ward off client if requested connection does not exist */
+        if (proc == NULL) {
+            char message[2048];
+
+            snprintf(message, sizeof(message),
+                    "Connection \"%s\" does not exist", identifier);
+
+            guacd_log(GUAC_LOG_INFO, message);
+            guac_protocol_send_error(socket, message,
+                    GUAC_PROTOCOL_STATUS_CLIENT_BAD_REQUEST);
+        }
+
         else
             guacd_log(GUAC_LOG_INFO, "Joining existing connection \"%s\"",
                     identifier);

--- a/src/guacd/connection.c
+++ b/src/guacd/connection.c
@@ -287,7 +287,7 @@ static int guacd_route_connection(guacd_proc_map* map, guac_socket* socket) {
 
             guacd_log(GUAC_LOG_INFO, message);
             guac_protocol_send_error(socket, message,
-                    GUAC_PROTOCOL_STATUS_CLIENT_BAD_REQUEST);
+                    GUAC_PROTOCOL_STATUS_RESOURCE_NOT_FOUND);
         }
 
         else


### PR DESCRIPTION
The can easily be tested by sending a well-formed `select` command using a `$`-prefixed, but fake, connection ID.

Before patch:
```
tomer@druuge:~/dev/guacamole-server$ echo '6.select,10.$123456789;' | nc localhost 4822
tomer@druuge:~/dev/guacamole-server$ 
```

Note complete lack of response above, the server simply drops the connection. Contrast with the same command after the patch:

```
tomer@druuge:~/dev/guacamole-server$ echo '6.select,10.$123456789;' | nc localhost 4822
5.error,38.Connection "$123456789" does not exist,3.768;
tomer@druuge:~/dev/guacamole-server$ 
```
