### PR TITLE
GUACAMOLE-1053: Set to NULL after free

### DIFF
--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -509,12 +509,15 @@ static int guac_rdp_handle_connection(guac_client* client) {
 
     /* Free SVC list */
     guac_common_list_free(rdp_client->available_svc);
+    rdp_client->available_svc = NULL;
 
     /* Free RDP keyboard state */
     guac_rdp_keyboard_free(rdp_client->keyboard);
+    rdp_client->keyboard = NULL;
 
     /* Free display */
     guac_common_display_free(rdp_client->display);
+    rdp_client->display = NULL;
 
     /* Client is now disconnected */
     guac_client_log(client, GUAC_LOG_INFO, "Internal RDP client disconnected");


### PR DESCRIPTION
It will make a segfault in GUACAMOLE-1053 much less likely, but race condition between a client and user input threads remains.