### PR TITLE
GUACAMOLE-1053: guacd segfaults if user actively presses keys during RDP disconnect

### DIFF
--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -155,6 +155,9 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
     pthread_mutexattr_settype(&(rdp_client->attributes),
             PTHREAD_MUTEX_RECURSIVE);
 
+    /* Initalize the lock */
+    pthread_rwlock_init(&(rdp_client->lock), NULL);
+
     /* Set handlers */
     client->join_handler = guac_rdp_user_join_handler;
     client->free_handler = guac_rdp_client_free_handler;
@@ -215,6 +218,8 @@ int guac_rdp_client_free_handler(guac_client* client) {
     /* Clean up audio input buffer, if allocated */
     if (rdp_client->audio_input != NULL)
         guac_rdp_audio_buffer_free(rdp_client->audio_input);
+
+    pthread_rwlock_destroy(&(rdp_client->lock));
 
     /* Free client data */
     free(rdp_client);

--- a/src/protocols/rdp/rdp.h
+++ b/src/protocols/rdp/rdp.h
@@ -158,6 +158,14 @@ typedef struct guac_rdp_client {
      */
     pthread_mutexattr_t attributes;
 
+    /**
+     * Lock which is used to synchronizes access to RDP data structures
+     * between user input and client threads. It prevents input handlers
+     * from running when RDP data structures are allocated or freed
+     * by the client thread.
+     */
+    pthread_rwlock_t lock;
+
 } guac_rdp_client;
 
 /**


### PR DESCRIPTION
Added a read/write lock to the **guac_rdp_client** structure, and acquire/release the lock in input handlers and RDP client thread.
I was not able to reproduce a segmentation fault with this patch applied.