### PR TITLE
GUACAMOLE-1059: Use FreeRDP function for verifying Stream length

### DIFF
--- a/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages-file-info.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages-file-info.c
@@ -135,6 +135,10 @@ void guac_rdpdr_fs_process_set_rename_info(guac_rdp_common_svc* svc,
     wStream* output_stream;
     char destination_path[GUAC_RDP_FS_MAX_PATH];
 
+    /* Check stream size prior to reading. */
+    if (Stream_GetRemainingLength(input_stream) < 6)
+        return;
+    
     /* Read structure */
     Stream_Seek_UINT8(input_stream); /* ReplaceIfExists */
     Stream_Seek_UINT8(input_stream); /* RootDirectory */

--- a/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages-file-info.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages-file-info.c
@@ -136,9 +136,13 @@ void guac_rdpdr_fs_process_set_rename_info(guac_rdp_common_svc* svc,
     char destination_path[GUAC_RDP_FS_MAX_PATH];
 
     /* Check stream size prior to reading. */
-    if (Stream_GetRemainingLength(input_stream) < 6)
+    if (Stream_GetRemainingLength(input_stream) < 6) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "File Stream does not "
+                "contain the required number of bytes.  File sharing may not "
+                "work as expected.");
         return;
-    
+    }
+        
     /* Read structure */
     Stream_Seek_UINT8(input_stream); /* ReplaceIfExists */
     Stream_Seek_UINT8(input_stream); /* RootDirectory */

--- a/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages-file-info.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages-file-info.c
@@ -137,9 +137,10 @@ void guac_rdpdr_fs_process_set_rename_info(guac_rdp_common_svc* svc,
 
     /* Check stream size prior to reading. */
     if (Stream_GetRemainingLength(input_stream) < 6) {
-        guac_client_log(svc->client, GUAC_LOG_WARNING, "File Stream does not "
-                "contain the required number of bytes.  File sharing may not "
-                "work as expected.");
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Server Drive Set "
+                "Information Request (FileRenameInformation) PDU does not "
+                "contain the expected number of bytes.  File redirection "
+                "may not work as expected.");
         return;
     }
         
@@ -148,6 +149,14 @@ void guac_rdpdr_fs_process_set_rename_info(guac_rdp_common_svc* svc,
     Stream_Seek_UINT8(input_stream); /* RootDirectory */
     Stream_Read_UINT32(input_stream, filename_length); /* FileNameLength */
 
+    if (Stream_GetRemainingLength(input_stream) < filename_length) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Server Drive Set "
+                "Information Request (FileRenameInformation) PDU does not "
+                "contain the expected number of bytes.  File redirection "
+                "may not work as expected.");
+        return;
+    }
+    
     /* Convert name to UTF-8 */
     guac_rdp_utf16_to_utf8(Stream_Pointer(input_stream), filename_length/2,
             destination_path, sizeof(destination_path));
@@ -200,6 +209,15 @@ void guac_rdpdr_fs_process_set_allocation_info(guac_rdp_common_svc* svc,
     UINT64 size;
     wStream* output_stream;
 
+    /* Check to make sure the stream has at least 8 bytes (UINT64) */
+    if (Stream_GetRemainingLength(input_stream) < 8) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Server Drive Set "
+                "Information Request (FileAllocationInformation) PDU does not "
+                "contain the expected number of bytes.  File redirection "
+                "may not work as expected.");
+        return;
+    }
+    
     /* Read new size */
     Stream_Read_UINT64(input_stream, size); /* AllocationSize */
 
@@ -252,6 +270,15 @@ void guac_rdpdr_fs_process_set_end_of_file_info(guac_rdp_common_svc* svc,
     UINT64 size;
     wStream* output_stream;
 
+    /* Check to make sure stream contains at least 8 bytes (UINT64) */
+    if (Stream_GetRemainingLength(input_stream) < 8) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Server Drive Set "
+                "Information Request (FileEndOfFileInformation) PDU does not "
+                "contain the expected number of bytes.  File redirection "
+                "may not work as expected.");
+        return;
+    }
+    
     /* Read new size */
     Stream_Read_UINT64(input_stream, size); /* AllocationSize */
 

--- a/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages.c
@@ -49,8 +49,12 @@ void guac_rdpdr_fs_process_create(guac_rdp_common_svc* svc,
     char path[GUAC_RDP_FS_MAX_PATH];
 
     /* Check remaining stream data prior to reading. */
-    if (Stream_GetRemainingLength(input_stream) < 32)
+    if (Stream_GetRemainingLength(input_stream) < 32) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "File stream does not "
+                "contain the expected number of bytes. File sharing may not "
+                "work as expected.");
         return;
+    }
     
     /* Read "create" information */
     Stream_Read_UINT32(input_stream, desired_access);
@@ -128,8 +132,12 @@ void guac_rdpdr_fs_process_read(guac_rdp_common_svc* svc,
     wStream* output_stream;
 
     /* Check remaining bytes before reading stream. */
-    if (Stream_GetRemainingLength(input_stream) < 12)
+    if (Stream_GetRemainingLength(input_stream) < 12) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "File Stream does not "
+                "contain the expected number of bytes. File sharing may not "
+                "work as expected.");
         return;
+    }
     
     /* Read packet */
     Stream_Read_UINT32(input_stream, length);
@@ -181,8 +189,12 @@ void guac_rdpdr_fs_process_write(guac_rdp_common_svc* svc,
     wStream* output_stream;
 
     /* Check remaining length. */
-    if (Stream_GetRemainingLength(input_stream) < 32)
+    if (Stream_GetRemainingLength(input_stream) < 32) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "File Stream does not "
+                "contain the expected number of bytes. File sharing may not "
+                "work as expected.");
         return;
+    }
     
     /* Read packet */
     Stream_Read_UINT32(input_stream, length);
@@ -257,8 +269,12 @@ void guac_rdpdr_fs_process_volume_info(guac_rdp_common_svc* svc,
     int fs_information_class;
 
     /* Check remaining length */
-    if (Stream_GetRemainingLength(input_stream) < 4)
+    if (Stream_GetRemainingLength(input_stream) < 4) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "File Stream does not "
+                "contain the expected number of bytes. File sharing may not "
+                "work as expected.");
         return;
+    }
     
     Stream_Read_UINT32(input_stream, fs_information_class);
 
@@ -299,8 +315,12 @@ void guac_rdpdr_fs_process_file_info(guac_rdp_common_svc* svc,
     int fs_information_class;
 
     /* Check remaining length */
-    if (Stream_GetRemainingLength(input_stream) < 4)
+    if (Stream_GetRemainingLength(input_stream) < 4) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "File Stream does not "
+                "contain the expected number of bytes. File sharing may not "
+                "work as expected.");
         return;
+    }
     
     Stream_Read_UINT32(input_stream, fs_information_class);
 
@@ -349,8 +369,12 @@ void guac_rdpdr_fs_process_set_file_info(guac_rdp_common_svc* svc,
     int length;
 
     /* Check remaining length */
-    if (Stream_GetRemainingLength(input_stream) < 32)
+    if (Stream_GetRemainingLength(input_stream) < 32) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "File stream does not "
+                "contain the expected number of bytes. File sharing may not "
+                "work as expected.");
         return;
+    }
     
     Stream_Read_UINT32(input_stream, fs_information_class);
     Stream_Read_UINT32(input_stream, length); /* Length */
@@ -430,8 +454,12 @@ void guac_rdpdr_fs_process_query_directory(guac_rdp_common_svc* svc,
     if (file == NULL)
         return;
 
-    if (Stream_GetRemainingLength(input_stream) < 9)
+    if (Stream_GetRemainingLength(input_stream) < 9) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "File stream does not "
+                "contain the expected number of bytes. File sharing may not "
+                "work as expected.");
         return;
+    }
     
     /* Read main header */
     Stream_Read_UINT32(input_stream, fs_information_class);
@@ -441,8 +469,16 @@ void guac_rdpdr_fs_process_query_directory(guac_rdp_common_svc* svc,
     /* If this is the first query, the path is included after padding */
     if (initial_query) {
 
-        if (Stream_GetRemainingLength(input_stream) < 23)
+        /*
+         * Check to make sure Stream has at least the 23 padding bytes in it
+         * prior to seeking.
+         */
+        if (Stream_GetRemainingLength(input_stream) < 23) {
+            guac_client_log(svc->client, GUAC_LOG_WARNING, "File stream does "
+                    "not contain the expected number of bytes. File sharing "
+                    "may not work as expected.");
             return;
+        }
         
         Stream_Seek(input_stream, 23);       /* Padding */
 

--- a/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages.c
@@ -48,6 +48,10 @@ void guac_rdpdr_fs_process_create(guac_rdp_common_svc* svc,
     int create_disposition, create_options, path_length;
     char path[GUAC_RDP_FS_MAX_PATH];
 
+    /* Check remaining stream data prior to reading. */
+    if (Stream_GetRemainingLength(input_stream) < 32)
+        return;
+    
     /* Read "create" information */
     Stream_Read_UINT32(input_stream, desired_access);
     Stream_Seek_UINT64(input_stream); /* allocation size */
@@ -123,6 +127,10 @@ void guac_rdpdr_fs_process_read(guac_rdp_common_svc* svc,
 
     wStream* output_stream;
 
+    /* Check remaining bytes before reading stream. */
+    if (Stream_GetRemainingLength(input_stream) < 12)
+        return;
+    
     /* Read packet */
     Stream_Read_UINT32(input_stream, length);
     Stream_Read_UINT64(input_stream, offset);
@@ -172,6 +180,10 @@ void guac_rdpdr_fs_process_write(guac_rdp_common_svc* svc,
 
     wStream* output_stream;
 
+    /* Check remaining length. */
+    if (Stream_GetRemainingLength(input_stream) < 32)
+        return;
+    
     /* Read packet */
     Stream_Read_UINT32(input_stream, length);
     Stream_Read_UINT64(input_stream, offset);
@@ -244,6 +256,10 @@ void guac_rdpdr_fs_process_volume_info(guac_rdp_common_svc* svc,
 
     int fs_information_class;
 
+    /* Check remaining length */
+    if (Stream_GetRemainingLength(input_stream) < 4)
+        return;
+    
     Stream_Read_UINT32(input_stream, fs_information_class);
 
     /* Dispatch to appropriate class-specific handler */
@@ -282,6 +298,10 @@ void guac_rdpdr_fs_process_file_info(guac_rdp_common_svc* svc,
 
     int fs_information_class;
 
+    /* Check remaining length */
+    if (Stream_GetRemainingLength(input_stream) < 4)
+        return;
+    
     Stream_Read_UINT32(input_stream, fs_information_class);
 
     /* Dispatch to appropriate class-specific handler */
@@ -328,6 +348,10 @@ void guac_rdpdr_fs_process_set_file_info(guac_rdp_common_svc* svc,
     int fs_information_class;
     int length;
 
+    /* Check remaining length */
+    if (Stream_GetRemainingLength(input_stream) < 32)
+        return;
+    
     Stream_Read_UINT32(input_stream, fs_information_class);
     Stream_Read_UINT32(input_stream, length); /* Length */
     Stream_Seek(input_stream, 24);            /* Padding */
@@ -406,6 +430,9 @@ void guac_rdpdr_fs_process_query_directory(guac_rdp_common_svc* svc,
     if (file == NULL)
         return;
 
+    if (Stream_GetRemainingLength(input_stream) < 9)
+        return;
+    
     /* Read main header */
     Stream_Read_UINT32(input_stream, fs_information_class);
     Stream_Read_UINT8(input_stream,  initial_query);
@@ -414,6 +441,9 @@ void guac_rdpdr_fs_process_query_directory(guac_rdp_common_svc* svc,
     /* If this is the first query, the path is included after padding */
     if (initial_query) {
 
+        if (Stream_GetRemainingLength(input_stream) < 23)
+            return;
+        
         Stream_Seek(input_stream, 23);       /* Padding */
 
         /* Convert path to UTF-8 */

--- a/src/protocols/rdp/channels/rdpdr/rdpdr-messages.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-messages.c
@@ -212,6 +212,9 @@ void guac_rdpdr_process_server_announce(guac_rdp_common_svc* svc,
 
     unsigned int major, minor, client_id;
 
+    if (Stream_GetRemainingLength(input_stream) < 8)
+        return;
+    
     Stream_Read_UINT16(input_stream, major);
     Stream_Read_UINT16(input_stream, minor);
     Stream_Read_UINT32(input_stream, client_id);
@@ -243,6 +246,9 @@ void guac_rdpdr_process_device_reply(guac_rdp_common_svc* svc,
     unsigned int device_id, ntstatus;
     int severity, c, n, facility, code;
 
+    if (Stream_GetRemainingLength(input_stream) < 8)
+        return;
+    
     Stream_Read_UINT32(input_stream, device_id);
     Stream_Read_UINT32(input_stream, ntstatus);
 
@@ -278,6 +284,9 @@ void guac_rdpdr_process_device_iorequest(guac_rdp_common_svc* svc,
     guac_rdpdr* rdpdr = (guac_rdpdr*) svc->data;
     guac_rdpdr_iorequest iorequest;
 
+    if (Stream_GetRemainingLength(input_stream) < 20)
+        return;
+    
     /* Read header */
     Stream_Read_UINT32(input_stream, iorequest.device_id);
     Stream_Read_UINT32(input_stream, iorequest.file_id);
@@ -306,6 +315,9 @@ void guac_rdpdr_process_server_capability(guac_rdp_common_svc* svc,
     int count;
     int i;
 
+    if (Stream_GetRemainingLength(input_stream) < 4)
+        return;
+    
     /* Read header */
     Stream_Read_UINT16(input_stream, count);
     Stream_Seek(input_stream, 2);
@@ -316,9 +328,15 @@ void guac_rdpdr_process_server_capability(guac_rdp_common_svc* svc,
         int type;
         int length;
 
+        if (Stream_GetRemainingLength(input_stream) < 4)
+            break;
+        
         Stream_Read_UINT16(input_stream, type);
         Stream_Read_UINT16(input_stream, length);
 
+        if (Stream_GetRemainingLength(input_stream) < (length - 4))
+            break;
+        
         /* Ignore all for now */
         guac_client_log(svc->client, GUAC_LOG_DEBUG, "Ignoring server capability set type=0x%04x, length=%i", type, length);
         Stream_Seek(input_stream, length - 4);

--- a/src/protocols/rdp/channels/rdpdr/rdpdr-messages.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-messages.c
@@ -213,8 +213,12 @@ void guac_rdpdr_process_server_announce(guac_rdp_common_svc* svc,
     unsigned int major, minor, client_id;
 
     /* Stream should contain at least 8 bytes (UINT16 + UINT16 + UINT32) */
-    if (Stream_GetRemainingLength(input_stream) < 8)
+    if (Stream_GetRemainingLength(input_stream) < 8) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Server Announce "
+                "Request PDU does not contain the expected number of bytes. "
+                "Device redirection may not work as expected.");
         return;
+    }
     
     Stream_Read_UINT16(input_stream, major);
     Stream_Read_UINT16(input_stream, minor);

--- a/src/protocols/rdp/channels/rdpdr/rdpdr-messages.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-messages.c
@@ -249,9 +249,9 @@ void guac_rdpdr_process_device_reply(guac_rdp_common_svc* svc,
 
     /* Stream should contain at least 8 bytes (UINT32 + UINT32 ) */
     if (Stream_GetRemainingLength(input_stream) < 8) {
-        guac_client_log(svc->client, GUAC_LOG_WARNING, "Device Stream does not "
-                "contain the expected number of bytes. Device redirection may "
-                "not work.");
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Server Device Announce"
+                "Response PDU does not contain the expected number of bytes."
+                "Device redirection may not work as expected.");
         return;
     }
     
@@ -292,9 +292,9 @@ void guac_rdpdr_process_device_iorequest(guac_rdp_common_svc* svc,
 
     /* Check to make sure the Stream contains at least 20 bytes (5 x UINT32 ). */
     if (Stream_GetRemainingLength(input_stream) < 20) {
-        guac_client_log(svc->client, GUAC_LOG_WARNING, "Device Stream does not "
-                "contain the expected number of bytes. Device redirection may "
-                "not work as expected.");
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Device I/O Request PDU "
+                "does not contain the expected number of bytes. Device "
+                "redirection may not work as expected.");
         return;
     }
     
@@ -328,9 +328,9 @@ void guac_rdpdr_process_server_capability(guac_rdp_common_svc* svc,
 
     /* Check to make sure the Stream has at least 4 bytes (UINT16 + 2) */
     if (Stream_GetRemainingLength(input_stream) < 4) {
-        guac_client_log(svc->client, GUAC_LOG_WARNING, "Redirection Stream "
-                "does not contain the expected number of bytes. Device "
-                "redirection may not work as expected.");
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Server Core Capability "
+                "Request PDU does not contain the expected number of bytes."
+                "Device redirection may not work as expected.");
         return;
     }
     
@@ -346,9 +346,10 @@ void guac_rdpdr_process_server_capability(guac_rdp_common_svc* svc,
 
         /* Make sure Stream has at least 4 bytes (UINT16 + UINT16) */
         if (Stream_GetRemainingLength(input_stream) < 4) {
-            guac_client_log(svc->client, GUAC_LOG_WARNING, "Redirection Stream "
-                    "does not contain the expected number of bytes. Device "
-                    "redirection may not work as expected.");
+            guac_client_log(svc->client, GUAC_LOG_WARNING, "Server Core "
+                    "Capability Request PDU does not contain the expected "
+                    "number of bytes. Device redirection may not work as "
+                    "expected.");
             break;
         }
         
@@ -357,9 +358,10 @@ void guac_rdpdr_process_server_capability(guac_rdp_common_svc* svc,
 
         /* Make sure Stream has required length remaining for Seek below. */
         if (Stream_GetRemainingLength(input_stream) < (length - 4)) {
-            guac_client_log(svc->client, GUAC_LOG_WARNING, "Redirection Stream "
-                    "does not contain the expected number of bytes. Device "
-                    "redirection may not work as expected.");
+            guac_client_log(svc->client, GUAC_LOG_WARNING, "Server Core "
+                    "Capability Request PDU does not contain the expected "
+                    "number of bytes. Device redirection may not work as "
+                    "expected.");
             break;
         }
         

--- a/src/protocols/rdp/channels/rdpdr/rdpdr-printer.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-printer.c
@@ -67,6 +67,9 @@ void guac_rdpdr_process_print_job_write(guac_rdp_common_svc* svc,
     int length;
     int status;
 
+    if (Stream_GetRemainingLength(input_stream) < 32)
+        return;
+    
     /* Read buffer of print data */
     Stream_Read_UINT32(input_stream, length);
     Stream_Seek(input_stream, 8);  /* Offset */

--- a/src/protocols/rdp/channels/rdpdr/rdpdr-printer.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-printer.c
@@ -69,9 +69,9 @@ void guac_rdpdr_process_print_job_write(guac_rdp_common_svc* svc,
 
     /* Verify that Stream contains at least 32 bytes (UINT32 + 8 + 20) */
     if (Stream_GetRemainingLength(input_stream) < 32) {
-        guac_client_log(client, GUAC_LOG_WARNING, "Printer Stream does not "
-                "contain the required number of bytes. Print redirection may "
-                "not work as expected.");
+        guac_client_log(client, GUAC_LOG_WARNING, "Print job write stream does "
+                "not contain the expected number of bytes. Printer redirection "
+                "may not work as expected.");
         return;
     }
     
@@ -81,6 +81,14 @@ void guac_rdpdr_process_print_job_write(guac_rdp_common_svc* svc,
     Stream_Seek(input_stream, 20); /* Padding */
     buffer = Stream_Pointer(input_stream);
 
+    /* Verify the stream has at least length number of bytes remaining. */
+    if (Stream_GetRemainingLength(input_stream) < length) {
+        guac_client_log(client, GUAC_LOG_WARNING, "Print job write stream does "
+                "not contain the expected number of bytes. Printer redirection "
+                "may not work as expected.");
+        return;
+    }
+    
     /* Write data only if job exists, translating status for RDP */
     if (job != NULL && (length = guac_rdp_print_job_write(job,
                     buffer, length)) >= 0) {

--- a/src/protocols/rdp/channels/rdpdr/rdpdr-printer.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-printer.c
@@ -67,8 +67,13 @@ void guac_rdpdr_process_print_job_write(guac_rdp_common_svc* svc,
     int length;
     int status;
 
-    if (Stream_GetRemainingLength(input_stream) < 32)
+    /* Verify that Stream contains at least 32 bytes (UINT32 + 8 + 20) */
+    if (Stream_GetRemainingLength(input_stream) < 32) {
+        guac_client_log(client, GUAC_LOG_WARNING, "Printer Stream does not "
+                "contain the required number of bytes. Print redirection may "
+                "not work as expected.");
         return;
+    }
     
     /* Read buffer of print data */
     Stream_Read_UINT32(input_stream, length);

--- a/src/protocols/rdp/channels/rdpdr/rdpdr.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr.c
@@ -38,6 +38,9 @@ void guac_rdpdr_process_receive(guac_rdp_common_svc* svc,
     int component;
     int packet_id;
 
+    if (Stream_GetRemainingLength(input_stream) < 4)
+        return;
+    
     /* Read header */
     Stream_Read_UINT16(input_stream, component);
     Stream_Read_UINT16(input_stream, packet_id);

--- a/src/protocols/rdp/channels/rdpdr/rdpdr.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr.c
@@ -44,8 +44,8 @@ void guac_rdpdr_process_receive(guac_rdp_common_svc* svc,
      */
     if (Stream_GetRemainingLength(input_stream) < 4) {
         guac_client_log(svc->client, GUAC_LOG_WARNING, "Device redirection "
-                "channel receive Stream does not contain the expected number "
-                "of bytes. Device redirection may not function as expected.");
+                "channel PDU header does not contain the expected number of "
+                "bytes. Device redirection may not function as expected.");
         return;
     }
     

--- a/src/protocols/rdp/channels/rdpdr/rdpdr.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr.c
@@ -44,8 +44,8 @@ void guac_rdpdr_process_receive(guac_rdp_common_svc* svc,
      */
     if (Stream_GetRemainingLength(input_stream) < 4) {
         guac_client_log(svc->client, GUAC_LOG_WARNING, "Device redirection "
-                "Stream does not contain the required number of bytes. Device "
-                "redirection may not function as expected.");
+                "channel receive Stream does not contain the expected number "
+                "of bytes. Device redirection may not function as expected.");
         return;
     }
     

--- a/src/protocols/rdp/channels/rdpdr/rdpdr.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr.c
@@ -38,8 +38,16 @@ void guac_rdpdr_process_receive(guac_rdp_common_svc* svc,
     int component;
     int packet_id;
 
-    if (Stream_GetRemainingLength(input_stream) < 4)
+    /* 
+     * Check that device redirection stream contains at least 4 bytes
+     * (UINT16 + UINT16).
+     */
+    if (Stream_GetRemainingLength(input_stream) < 4) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Device redirection "
+                "Stream does not contain the required number of bytes. Device "
+                "redirection may not function as expected.");
         return;
+    }
     
     /* Read header */
     Stream_Read_UINT16(input_stream, component);

--- a/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
+++ b/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
@@ -50,6 +50,9 @@ void guac_rdpsnd_formats_handler(guac_rdp_common_svc* svc,
     /* Reset own format count */
     rdpsnd->format_count = 0;
 
+    if (Stream_GetRemainingLength(input_stream) < 20)
+        return;
+    
     /* Format header */
     Stream_Seek(input_stream, 14);
     Stream_Read_UINT16(input_stream, server_format_count);
@@ -96,6 +99,9 @@ void guac_rdpsnd_formats_handler(guac_rdp_common_svc* svc,
             /* Remember position in stream */
             Stream_GetPointer(input_stream, format_start);
 
+            if (Stream_GetRemainingLength(input_stream) < 18)
+                return;
+            
             /* Read format */
             Stream_Read_UINT16(input_stream, format_tag);
             Stream_Read_UINT16(input_stream, channels);
@@ -106,6 +112,10 @@ void guac_rdpsnd_formats_handler(guac_rdp_common_svc* svc,
 
             /* Skip past extra data */
             Stream_Read_UINT16(input_stream, body_size);
+            
+            if (Stream_GetRemainingLength(input_stream) < body_size)
+                return;
+            
             Stream_Seek(input_stream, body_size);
 
             /* If PCM, accept */
@@ -205,6 +215,9 @@ void guac_rdpsnd_training_handler(guac_rdp_common_svc* svc,
 
     guac_rdpsnd* rdpsnd = (guac_rdpsnd*) svc->data;
 
+    if (Stream_GetRemainingLength(input_stream) < 4)
+        return;
+    
     /* Read timestamp and data size */
     Stream_Read_UINT16(input_stream, rdpsnd->server_timestamp);
     Stream_Read_UINT16(input_stream, data_size);
@@ -232,6 +245,9 @@ void guac_rdpsnd_wave_info_handler(guac_rdp_common_svc* svc,
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
     guac_audio_stream* audio = rdp_client->audio;
 
+    if (Stream_GetRemainingLength(input_stream) < 12)
+        return;
+    
     /* Read wave information */
     Stream_Read_UINT16(input_stream, rdpsnd->server_timestamp);
     Stream_Read_UINT16(input_stream, format);

--- a/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
+++ b/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
@@ -310,8 +310,8 @@ void guac_rdpsnd_wave_handler(guac_rdp_common_svc* svc,
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
     guac_audio_stream* audio = rdp_client->audio;
     
-    /* Verify we have at least 4 bytes, which is manually copied below. */
-    if (Stream_Length(input_stream) < 4) {
+    /* Verify that the stream has bytes to cover the wave size plus header. */
+    if (Stream_Length(input_stream) < (rdpsnd->incoming_wave_size + 4)) {
         guac_client_log(svc->client, GUAC_LOG_WARNING, "Audio Wave PDU does "
                 "not contain the expected number of bytes. Sound may not work "
                 "as expected.");

--- a/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
+++ b/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
@@ -52,9 +52,9 @@ void guac_rdpsnd_formats_handler(guac_rdp_common_svc* svc,
 
     /* Check to make sure the stream has at least 20 bytes, which */
     if (Stream_GetRemainingLength(input_stream) < 20) {
-        guac_client_log(client, GUAC_LOG_WARNING, "Audio Stream does not "
-                "contain the expected number of bytes. Sound may not work as "
-                "expected.");
+        guac_client_log(client, GUAC_LOG_WARNING, "Server Audio Formats and "
+                "Version PDU does not contain the expected number of bytes. "
+                "Audio redirection may not work as expected.");
         return;
     }
     
@@ -106,9 +106,10 @@ void guac_rdpsnd_formats_handler(guac_rdp_common_svc* svc,
 
             /* Check to make sure Stream has at least 18 bytes. */
             if (Stream_GetRemainingLength(input_stream) < 18) {
-                guac_client_log(client, GUAC_LOG_WARNING, "Audio Stream does "
-                        "not contain the expected number of bytes. Sound may "
-                        "not work as expected.");
+                guac_client_log(client, GUAC_LOG_WARNING, "Server Audio "
+                        "Formats and Version PDU does not contain the expected "
+                        "number of bytes. Audio redirection may not work as "
+                        "expected.");
                 return;
             }
             
@@ -125,9 +126,10 @@ void guac_rdpsnd_formats_handler(guac_rdp_common_svc* svc,
             
             /* Check that Stream has at least body_size bytes remaining. */
             if (Stream_GetRemainingLength(input_stream) < body_size) {
-                guac_client_log(client, GUAC_LOG_WARNING, "Audio Stream does "
-                        "not contain the expected number of bytes. Sound may "
-                        "not work as expected.");
+                guac_client_log(client, GUAC_LOG_WARNING, "Server Audio "
+                        "Formats and Version PDU does not contain the expected "
+                        "number of bytes. Audio redirection may not work as "
+                        "expected.");
                 return;
             }
             
@@ -232,9 +234,9 @@ void guac_rdpsnd_training_handler(guac_rdp_common_svc* svc,
 
     /* Check to make sure audio stream contains a minimum number of bytes. */
     if (Stream_GetRemainingLength(input_stream) < 4) {
-        guac_client_log(svc->client, GUAC_LOG_WARNING, "Audio Stream does not "
-                "contain the expected number of bytes. Sound may not work as "
-                "expected.");
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Audio Training PDU "
+                "does not contain the expected number of bytes. Audio "
+                "redirection may not work as expected.");
         return;
     }
     
@@ -267,9 +269,9 @@ void guac_rdpsnd_wave_info_handler(guac_rdp_common_svc* svc,
 
     /* Check to make sure audio stream contains a minimum number of bytes. */
     if (Stream_GetRemainingLength(input_stream) < 12) {
-        guac_client_log(svc->client, GUAC_LOG_WARNING, "Audio stream does not "
-                "contain the expected number of bytes. Sound may not work as "
-                "expected.");
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Audio WaveInfo PDU "
+                "does not contain the expected number of bytes. Sound may not "
+                "work as expected.");
         return;
     }
     
@@ -310,9 +312,9 @@ void guac_rdpsnd_wave_handler(guac_rdp_common_svc* svc,
     
     /* Verify we have at least 4 bytes, which is manually copied below. */
     if (Stream_Length(input_stream) < 4) {
-        guac_client_log(svc->client, GUAC_LOG_WARNING, "Sound stream does not "
-                "contain the expected number of bytes. Sound may not work as "
-                "expected.");
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Audio Wave PDU does "
+                "not contain the expected number of bytes. Sound may not work "
+                "as expected.");
         return;
     }
 

--- a/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
+++ b/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
@@ -50,8 +50,13 @@ void guac_rdpsnd_formats_handler(guac_rdp_common_svc* svc,
     /* Reset own format count */
     rdpsnd->format_count = 0;
 
-    if (Stream_GetRemainingLength(input_stream) < 20)
+    /* Check to make sure the stream has at least 20 bytes, which */
+    if (Stream_GetRemainingLength(input_stream) < 20) {
+        guac_client_log(client, GUAC_LOG_WARNING, "Audio Stream does not "
+                "contain the expected number of bytes. Sound may not work as "
+                "expected.");
         return;
+    }
     
     /* Format header */
     Stream_Seek(input_stream, 14);
@@ -99,8 +104,13 @@ void guac_rdpsnd_formats_handler(guac_rdp_common_svc* svc,
             /* Remember position in stream */
             Stream_GetPointer(input_stream, format_start);
 
-            if (Stream_GetRemainingLength(input_stream) < 18)
+            /* Check to make sure Stream has at least 18 bytes. */
+            if (Stream_GetRemainingLength(input_stream) < 18) {
+                guac_client_log(client, GUAC_LOG_WARNING, "Audio Stream does "
+                        "not contain the expected number of bytes. Sound may "
+                        "not work as expected.");
                 return;
+            }
             
             /* Read format */
             Stream_Read_UINT16(input_stream, format_tag);
@@ -113,8 +123,13 @@ void guac_rdpsnd_formats_handler(guac_rdp_common_svc* svc,
             /* Skip past extra data */
             Stream_Read_UINT16(input_stream, body_size);
             
-            if (Stream_GetRemainingLength(input_stream) < body_size)
+            /* Check that Stream has at least body_size bytes remaining. */
+            if (Stream_GetRemainingLength(input_stream) < body_size) {
+                guac_client_log(client, GUAC_LOG_WARNING, "Audio Stream does "
+                        "not contain the expected number of bytes. Sound may "
+                        "not work as expected.");
                 return;
+            }
             
             Stream_Seek(input_stream, body_size);
 
@@ -215,8 +230,13 @@ void guac_rdpsnd_training_handler(guac_rdp_common_svc* svc,
 
     guac_rdpsnd* rdpsnd = (guac_rdpsnd*) svc->data;
 
-    if (Stream_GetRemainingLength(input_stream) < 4)
+    /* Check to make sure audio stream contains a minimum number of bytes. */
+    if (Stream_GetRemainingLength(input_stream) < 4) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Audio Stream does not "
+                "contain the expected number of bytes. Sound may not work as "
+                "expected.");
         return;
+    }
     
     /* Read timestamp and data size */
     Stream_Read_UINT16(input_stream, rdpsnd->server_timestamp);
@@ -245,8 +265,13 @@ void guac_rdpsnd_wave_info_handler(guac_rdp_common_svc* svc,
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
     guac_audio_stream* audio = rdp_client->audio;
 
-    if (Stream_GetRemainingLength(input_stream) < 12)
+    /* Check to make sure audio stream contains a minimum number of bytes. */
+    if (Stream_GetRemainingLength(input_stream) < 12) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Audio stream does not "
+                "contain the expected number of bytes. Sound may not work as "
+                "expected.");
         return;
+    }
     
     /* Read wave information */
     Stream_Read_UINT16(input_stream, rdpsnd->server_timestamp);

--- a/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
+++ b/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
@@ -50,7 +50,10 @@ void guac_rdpsnd_formats_handler(guac_rdp_common_svc* svc,
     /* Reset own format count */
     rdpsnd->format_count = 0;
 
-    /* Check to make sure the stream has at least 20 bytes, which */
+    /* 
+     * Check to make sure the stream has at least 20 bytes (14 byte seek,
+     * 2 x UTF16 reads, and 2 x UTF8 seeks).
+     */
     if (Stream_GetRemainingLength(input_stream) < 20) {
         guac_client_log(client, GUAC_LOG_WARNING, "Server Audio Formats and "
                 "Version PDU does not contain the expected number of bytes. "

--- a/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
+++ b/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
@@ -307,6 +307,14 @@ void guac_rdpsnd_wave_handler(guac_rdp_common_svc* svc,
 
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
     guac_audio_stream* audio = rdp_client->audio;
+    
+    /* Verify we have at least 4 bytes, which is manually copied below. */
+    if (Stream_Length(input_stream) < 4) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Sound stream does not "
+                "contain the expected number of bytes. Sound may not work as "
+                "expected.");
+        return;
+    }
 
     /* Wave Confirmation PDU */
     wStream* output_stream = Stream_New(NULL, 8);

--- a/src/protocols/rdp/channels/rdpsnd/rdpsnd.c
+++ b/src/protocols/rdp/channels/rdpsnd/rdpsnd.c
@@ -44,14 +44,6 @@ void guac_rdpsnd_process_receive(guac_rdp_common_svc* svc,
     Stream_Seek_UINT8(input_stream);
     Stream_Read_UINT16(input_stream, header.body_size);
     
-    if (Stream_GetRemainingLength(input_stream) < header.body_size) {
-        guac_client_log(svc->client, GUAC_LOG_DEBUG, "Not enough bytes in stream."
-                "  Remaining: %d, Body size: %d",
-                Stream_GetRemainingLength(input_stream),
-                header.body_size);
-        return;
-    }
-    
     /* 
      * If next PDU is SNDWAVE (due to receiving WaveInfo PDU previously),
      * ignore the header and parse as a Wave PDU.
@@ -60,6 +52,10 @@ void guac_rdpsnd_process_receive(guac_rdp_common_svc* svc,
         guac_rdpsnd_wave_handler(svc, input_stream, &header);
         return;
     }
+    
+    /* Check body size */
+    if (Stream_GetRemainingLength(input_stream) < header.body_size)
+        return;
 
     /* Dispatch message to standard handlers */
     switch (header.message_type) {

--- a/src/protocols/rdp/channels/rdpsnd/rdpsnd.c
+++ b/src/protocols/rdp/channels/rdpsnd/rdpsnd.c
@@ -56,14 +56,6 @@ void guac_rdpsnd_process_receive(guac_rdp_common_svc* svc,
         guac_rdpsnd_wave_handler(svc, input_stream, &header);
         return;
     }
-    
-    /* Check Stream size against body size */
-    if (Stream_GetRemainingLength(input_stream) < header.body_size) {
-        guac_client_log(svc->client, GUAC_LOG_WARNING, "Audio Stream does not "
-                "contain the expected number of bytes. Sound may not work as "
-                "expected.");
-        return;
-    }
 
     /* Dispatch message to standard handlers */
     switch (header.message_type) {

--- a/src/protocols/rdp/channels/rdpsnd/rdpsnd.c
+++ b/src/protocols/rdp/channels/rdpsnd/rdpsnd.c
@@ -35,7 +35,7 @@ void guac_rdpsnd_process_receive(guac_rdp_common_svc* svc,
     guac_rdpsnd* rdpsnd = (guac_rdpsnd*) svc->data;
     guac_rdpsnd_pdu_header header;
 
-    /* Check that we at least the 4 byte header (UINT8 + UINT8 + UINT16) */
+    /* Check that we have at least the 4 byte header (UINT8 + UINT8 + UINT16) */
     if (Stream_GetRemainingLength(input_stream) < 4) {
         guac_client_log(svc->client, GUAC_LOG_WARNING, "Audio Stream does not "
                 "contain the expected number of bytes. Audio redirection may "

--- a/src/protocols/rdp/channels/rdpsnd/rdpsnd.c
+++ b/src/protocols/rdp/channels/rdpsnd/rdpsnd.c
@@ -38,8 +38,8 @@ void guac_rdpsnd_process_receive(guac_rdp_common_svc* svc,
     /* Check that we at least the 4 byte header (UINT8 + UINT8 + UINT16) */
     if (Stream_GetRemainingLength(input_stream) < 4) {
         guac_client_log(svc->client, GUAC_LOG_WARNING, "Audio Stream does not "
-                "contain the expected number of bytes. Sound may not work as "
-                "expected.");
+                "contain the expected number of bytes. Audio redirection may "
+                "not work as expected.");
         return;
     }
     

--- a/src/protocols/rdp/channels/rdpsnd/rdpsnd.c
+++ b/src/protocols/rdp/channels/rdpsnd/rdpsnd.c
@@ -35,9 +35,13 @@ void guac_rdpsnd_process_receive(guac_rdp_common_svc* svc,
     guac_rdpsnd* rdpsnd = (guac_rdpsnd*) svc->data;
     guac_rdpsnd_pdu_header header;
 
-    /* Check that we at least have a header. */
-    if (Stream_GetRemainingLength(input_stream) < 4)
+    /* Check that we at least the 4 byte header (UINT8 + UINT8 + UINT16) */
+    if (Stream_GetRemainingLength(input_stream) < 4) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Audio Stream does not "
+                "contain the expected number of bytes. Sound may not work as "
+                "expected.");
         return;
+    }
     
     /* Read RDPSND PDU header */
     Stream_Read_UINT8(input_stream, header.message_type);
@@ -53,9 +57,13 @@ void guac_rdpsnd_process_receive(guac_rdp_common_svc* svc,
         return;
     }
     
-    /* Check body size */
-    if (Stream_GetRemainingLength(input_stream) < header.body_size)
+    /* Check Stream size against body size */
+    if (Stream_GetRemainingLength(input_stream) < header.body_size) {
+        guac_client_log(svc->client, GUAC_LOG_WARNING, "Audio Stream does not "
+                "contain the expected number of bytes. Sound may not work as "
+                "expected.");
         return;
+    }
 
     /* Dispatch message to standard handlers */
     switch (header.message_type) {

--- a/src/protocols/rdp/plugins/guac-common-svc/guac-common-svc.c
+++ b/src/protocols/rdp/plugins/guac-common-svc/guac-common-svc.c
@@ -116,6 +116,10 @@ static VOID guac_rdp_common_svc_handle_open_event(LPVOID user_param,
         svc->_input_stream = Stream_New(NULL, total_length);
     }
 
+    /* leave if we don't have a stream. */
+    if (svc->_input_stream == NULL)
+        return;
+    
     /* Add chunk to buffer only if sufficient space remains */
     if (Stream_EnsureRemainingCapacity(svc->_input_stream, data_length))
         Stream_Write(svc->_input_stream, data, data_length);
@@ -137,6 +141,7 @@ static VOID guac_rdp_common_svc_handle_open_event(LPVOID user_param,
             svc->_receive_handler(svc, svc->_input_stream);
 
         Stream_Free(svc->_input_stream, TRUE);
+        svc->_input_stream = NULL;
 
     }
 

--- a/src/protocols/rdp/plugins/guacai/guacai-messages.c
+++ b/src/protocols/rdp/plugins/guacai/guacai-messages.c
@@ -239,9 +239,9 @@ void guac_rdp_ai_process_version(guac_client* client,
 
     /* Verify we have at least 4 bytes available (UINT32) */
     if (Stream_GetRemainingLength(stream) < 4) {
-        guac_client_log(client, GUAC_LOG_WARNING, "Audio input stream does not "
-                "contain the expected number of bytes. Audio input may not "
-                "work as expected.");
+        guac_client_log(client, GUAC_LOG_WARNING, "Audio input Versoin PDU "
+                "does not contain the expected number of bytes. Audio input "
+                "redirection may not work as expected.");
         return;
     }
     
@@ -273,9 +273,9 @@ void guac_rdp_ai_process_formats(guac_client* client,
 
     /* Verify we have at least 8 bytes available (2 x UINT32) */
     if (Stream_GetRemainingLength(stream) < 8) {
-        guac_client_log(client, GUAC_LOG_WARNING, "Audio input stream does not "
-                "contain the expected number of bytes. Audio input may not "
-                "work as expected.");
+        guac_client_log(client, GUAC_LOG_WARNING, "Audio input Sound Formats "
+                "PDU does not contain the expected number of bytes. Audio "
+                "input redirection may not work as expected.");
         return;
     }
     
@@ -329,9 +329,9 @@ void guac_rdp_ai_process_open(guac_client* client,
 
     /* Verify we have at least 8 bytes available (2 x UINT32) */
     if (Stream_GetRemainingLength(stream) < 8) {
-        guac_client_log(client, GUAC_LOG_WARNING, "Audio input stream does not "
-                "contain the expected number of bytes. Audio input may not "
-                "work as expected.");
+        guac_client_log(client, GUAC_LOG_WARNING, "Audio input Open PDU does "
+                "not contain the expected number of bytes. Audio input "
+                "redirection may not work as expected.");
         return;
     }
     

--- a/src/protocols/rdp/plugins/guacai/guacai-messages.c
+++ b/src/protocols/rdp/plugins/guacai/guacai-messages.c
@@ -39,6 +39,9 @@
 static void guac_rdp_ai_read_format(wStream* stream,
         guac_rdp_ai_format* format) {
 
+    if (Stream_GetRemainingLength(stream) < 18)
+        return;
+    
     /* Read audio format into structure */
     Stream_Read_UINT16(stream, format->tag); /* wFormatTag */
     Stream_Read_UINT16(stream, format->channels); /* nChannels */
@@ -49,7 +52,8 @@ static void guac_rdp_ai_read_format(wStream* stream,
     Stream_Read_UINT16(stream, format->data_size); /* cbSize */
 
     /* Read arbitrary data block (if applicable) */
-    if (format->data_size != 0) {
+    if (format->data_size != 0
+            && Stream_GetRemainingLength(stream) >= format->data_size) {
         format->data = Stream_Pointer(stream); /* data */
         Stream_Seek(stream, format->data_size);
     }
@@ -232,6 +236,12 @@ static void guac_rdp_ai_send_formatchange(IWTSVirtualChannel* channel,
 void guac_rdp_ai_process_version(guac_client* client,
         IWTSVirtualChannel* channel, wStream* stream) {
 
+    if (Stream_GetRemainingLength(stream) < 4) {
+        guac_client_log(client, GUAC_LOG_WARNING,
+                "Invalid value provided for AUDIO_INPUT version.");
+        return;
+    }
+    
     UINT32 version;
     Stream_Read_UINT32(stream, version);
 
@@ -258,10 +268,13 @@ void guac_rdp_ai_process_formats(guac_client* client,
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
     guac_rdp_audio_buffer* audio_buffer = rdp_client->audio_input;
 
+    if (Stream_GetRemainingLength(stream) < 8)
+        return;
+    
     UINT32 num_formats;
     Stream_Read_UINT32(stream, num_formats); /* NumFormats */
     Stream_Seek_UINT32(stream); /* cbSizeFormatsPacket (MUST BE IGNORED) */
-
+    
     UINT32 index;
     for (index = 0; index < num_formats; index++) {
 
@@ -306,6 +319,9 @@ void guac_rdp_ai_process_open(guac_client* client,
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
     guac_rdp_audio_buffer* audio_buffer = rdp_client->audio_input;
 
+    if (Stream_GetRemainingLength(stream) < 8)
+        return;
+    
     UINT32 packet_frames;
     UINT32 initial_format;
 

--- a/src/protocols/rdp/plugins/guacai/guacai-messages.c
+++ b/src/protocols/rdp/plugins/guacai/guacai-messages.c
@@ -39,6 +39,7 @@
 static void guac_rdp_ai_read_format(wStream* stream,
         guac_rdp_ai_format* format) {
 
+    /* Check that we have at least 18 bytes (5 x UINT16, 2 x UINT32) */
     if (Stream_GetRemainingLength(stream) < 18)
         return;
     
@@ -51,7 +52,7 @@ static void guac_rdp_ai_read_format(wStream* stream,
     Stream_Read_UINT16(stream, format->bps); /* wBitsPerSample */
     Stream_Read_UINT16(stream, format->data_size); /* cbSize */
 
-    /* Read arbitrary data block (if applicable) */
+    /* Read arbitrary data block (if applicable) and data is available. */
     if (format->data_size != 0
             && Stream_GetRemainingLength(stream) >= format->data_size) {
         format->data = Stream_Pointer(stream); /* data */
@@ -236,9 +237,11 @@ static void guac_rdp_ai_send_formatchange(IWTSVirtualChannel* channel,
 void guac_rdp_ai_process_version(guac_client* client,
         IWTSVirtualChannel* channel, wStream* stream) {
 
+    /* Verify we have at least 4 bytes available (UINT32) */
     if (Stream_GetRemainingLength(stream) < 4) {
-        guac_client_log(client, GUAC_LOG_WARNING,
-                "Invalid value provided for AUDIO_INPUT version.");
+        guac_client_log(client, GUAC_LOG_WARNING, "Audio input stream does not "
+                "contain the expected number of bytes. Audio input may not "
+                "work as expected.");
         return;
     }
     
@@ -268,8 +271,13 @@ void guac_rdp_ai_process_formats(guac_client* client,
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
     guac_rdp_audio_buffer* audio_buffer = rdp_client->audio_input;
 
-    if (Stream_GetRemainingLength(stream) < 8)
+    /* Verify we have at least 8 bytes available (2 x UINT32) */
+    if (Stream_GetRemainingLength(stream) < 8) {
+        guac_client_log(client, GUAC_LOG_WARNING, "Audio input stream does not "
+                "contain the expected number of bytes. Audio input may not "
+                "work as expected.");
         return;
+    }
     
     UINT32 num_formats;
     Stream_Read_UINT32(stream, num_formats); /* NumFormats */
@@ -319,8 +327,13 @@ void guac_rdp_ai_process_open(guac_client* client,
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
     guac_rdp_audio_buffer* audio_buffer = rdp_client->audio_input;
 
-    if (Stream_GetRemainingLength(stream) < 8)
+    /* Verify we have at least 8 bytes available (2 x UINT32) */
+    if (Stream_GetRemainingLength(stream) < 8) {
+        guac_client_log(client, GUAC_LOG_WARNING, "Audio input stream does not "
+                "contain the expected number of bytes. Audio input may not "
+                "work as expected.");
         return;
+    }
     
     UINT32 packet_frames;
     UINT32 initial_format;

--- a/src/protocols/rdp/plugins/guacai/guacai.c
+++ b/src/protocols/rdp/plugins/guacai/guacai.c
@@ -52,10 +52,13 @@
 static void guac_rdp_ai_handle_data(guac_client* client,
         IWTSVirtualChannel* channel, wStream* stream) {
 
+    if (Stream_GetRemainingLength(stream) < 1)
+        return;
+    
     /* Read message ID from received PDU */
     BYTE message_id;
     Stream_Read_UINT8(stream, message_id);
-
+    
     /* Invoke appropriate message processor based on ID */
     switch (message_id) {
 

--- a/src/protocols/rdp/plugins/guacai/guacai.c
+++ b/src/protocols/rdp/plugins/guacai/guacai.c
@@ -52,8 +52,13 @@
 static void guac_rdp_ai_handle_data(guac_client* client,
         IWTSVirtualChannel* channel, wStream* stream) {
 
-    if (Stream_GetRemainingLength(stream) < 1)
+    /* Verify we have at least 1 byte in the stream (UINT8) */
+    if (Stream_GetRemainingLength(stream) < 1) {
+        guac_client_log(client, GUAC_LOG_WARNING, "Audio input stream does not "
+                "contain the expected number of bytes. Audio input may not "
+                "work as expected.");
         return;
+    }
     
     /* Read message ID from received PDU */
     BYTE message_id;

--- a/src/protocols/rdp/plugins/guacai/guacai.c
+++ b/src/protocols/rdp/plugins/guacai/guacai.c
@@ -55,8 +55,8 @@ static void guac_rdp_ai_handle_data(guac_client* client,
     /* Verify we have at least 1 byte in the stream (UINT8) */
     if (Stream_GetRemainingLength(stream) < 1) {
         guac_client_log(client, GUAC_LOG_WARNING, "Audio input stream does not "
-                "contain the expected number of bytes. Audio input may not "
-                "work as expected.");
+                "contain the expected number of bytes. Audio input redirection "
+                "may not work as expected.");
         return;
     }
     

--- a/src/protocols/rdp/plugins/guacai/guacai.c
+++ b/src/protocols/rdp/plugins/guacai/guacai.c
@@ -54,9 +54,9 @@ static void guac_rdp_ai_handle_data(guac_client* client,
 
     /* Verify we have at least 1 byte in the stream (UINT8) */
     if (Stream_GetRemainingLength(stream) < 1) {
-        guac_client_log(client, GUAC_LOG_WARNING, "Audio input stream does not "
-                "contain the expected number of bytes. Audio input redirection "
-                "may not work as expected.");
+        guac_client_log(client, GUAC_LOG_WARNING, "Audio input PDU header does "
+                "not contain the expected number of bytes. Audio input "
+                "redirection may not work as expected.");
         return;
     }
     


### PR DESCRIPTION
This implements the use of the `Stream_GetRemainingLength()` function prior to reading RDP Streams throughout the code.

There is one place that I need a little help with - will make a note at the correct place in the pull request...