### PR TITLE
GUACAMOLE-1059: Correct verification of sound format index.

### DIFF
--- a/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
+++ b/src/protocols/rdp/channels/rdpsnd/rdpsnd-messages.c
@@ -297,7 +297,7 @@ void guac_rdpsnd_wave_info_handler(guac_rdp_common_svc* svc,
 
     /* Reset audio stream if format has changed */
     if (audio != NULL) {
-        if (format < sizeof(rdpsnd->formats)) 
+        if (format < GUAC_RDP_MAX_FORMATS)
             guac_audio_stream_reset(audio, NULL,
                     rdpsnd->formats[format].rate,
                     rdpsnd->formats[format].channels,


### PR DESCRIPTION
The index of the RDPSND format should be checked against the maximum number of formats supported (`GUAC_RDP_MAX_FORMATS`), not the byte size of the underlying array (`sizeof(rdpsnd->formats)`).