### PR TITLE
GUACAMOLE-513: Several updates to Wake-on-LAN functionality

### DIFF
--- a/src/common/common/defaults.h
+++ b/src/common/common/defaults.h
@@ -24,7 +24,7 @@
  * The default number of seconds to wait after sending the Wake-on-LAN packet
  * for the destination host to start responding.
  */
-#define GUAC_WOL_DEFAULT_BOOT_WAIT_TIME 60
+#define GUAC_WOL_DEFAULT_BOOT_WAIT_TIME 0
 
 
 #endif /* GUAC_COMMON_DEFAULTS_H */

--- a/src/libguac/wol.c
+++ b/src/libguac/wol.c
@@ -86,10 +86,10 @@ static ssize_t __guac_wol_send_packet(const char* broadcast_addr,
     wol_dest.sin_family = AF_INET;
     int retval = inet_pton(wol_dest.sin_family, broadcast_addr, &(wol_dest.sin_addr));
     
-    /* If return value is less than zero, the address doesn't match any known family. */
+    /* If return value is less than zero, this system doesn't know about IPv4. */
     if (retval < 0) {
         guac_error = GUAC_STATUS_SEE_ERRNO;
-        guac_error_message = "Unknown broadcast or multicast address type specified for Wake-on-LAN";
+        guac_error_message = "IPv4 address family is not supported";
         return 0;
     }
     
@@ -98,8 +98,15 @@ static ssize_t __guac_wol_send_packet(const char* broadcast_addr,
         wol_dest.sin_family = AF_INET6;
         retval = inet_pton(wol_dest.sin_family, broadcast_addr, &(wol_dest.sin_addr));
         
-        /* IPv6 didn't work, either, so bail out. */
-        if (retval == 0) {
+        /* System does not support IPv6. */
+        if (retval < 0) {
+            guac_error = GUAC_STATUS_SEE_ERRNO;
+            guac_error_message = "IPv6 address family is not supported";
+            return 0;
+        }
+        
+        /* Address didn't match IPv6. */
+        else if (retval == 0) {
             guac_error = GUAC_STATUS_INVALID_ARGUMENT;
             guac_error_message = "Invalid broadcast or multicast address specified for Wake-on-LAN";
             return 0;

--- a/src/libguac/wol.c
+++ b/src/libguac/wol.c
@@ -95,10 +95,8 @@ static ssize_t __guac_wol_send_packet(const char* broadcast_addr,
         wol_socket = socket(AF_INET, SOCK_DGRAM, 0);
         
         /* If opening a socket fails, bail out. */
-        if (wol_socket < 0) {
-            close(wol_socket);
+        if (wol_socket < 0)
             return 0;
-        }
 
         /* Attempt to set broadcast; exit with error if this fails. */
         if (setsockopt(wol_socket, SOL_SOCKET, SO_BROADCAST, &wol_bcast,
@@ -113,16 +111,14 @@ static ssize_t __guac_wol_send_packet(const char* broadcast_addr,
         wol_socket = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
         
         /* If opening the socket fails, bail out. */
-        if (wol_socket < 0) {
-            close(wol_socket);
+        if (wol_socket < 0)
             return 0;
-        }
         
         /* Stick to a single hop for now. */
         int hops = 1;
         
         if (setsockopt(wol_socket, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &hops,
-                sizeof(hops))) {
+                sizeof(hops)) < 0) {
             close(wol_socket);
             return 0;
         }

--- a/src/libguac/wol.c
+++ b/src/libguac/wol.c
@@ -93,6 +93,12 @@ static ssize_t __guac_wol_send_packet(const char* broadcast_addr,
     if (wol_dest.sin_family == AF_INET) {
         int wol_bcast = 1;
         wol_socket = socket(AF_INET, SOCK_DGRAM, 0);
+        
+        /* If opening a socket fails, bail out. */
+        if (wol_socket < 0) {
+            close(wol_socket);
+            return 0;
+        }
 
         /* Attempt to set broadcast; exit with error if this fails. */
         if (setsockopt(wol_socket, SOL_SOCKET, SO_BROADCAST, &wol_bcast,
@@ -105,6 +111,12 @@ static ssize_t __guac_wol_send_packet(const char* broadcast_addr,
     /* Set up socket for IPv6 multicast. */
     else {
         wol_socket = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+        
+        /* If opening the socket fails, bail out. */
+        if (wol_socket < 0) {
+            close(wol_socket);
+            return 0;
+        }
         
         /* Stick to a single hop for now. */
         int hops = 1;

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -612,7 +612,8 @@ enum RDP_ARGS_IDX {
      * The amount of time, in seconds, to wait after sending the WoL packet
      * before attempting to connect to the host.  This should be a reasonable
      * amount of time to allow the remote host to fully boot and respond to
-     * network connection requests.  The default amount of time is 60 seconds.
+     * network connection requests.  The default is not to wait at all
+     * (0 seconds).
      */
     IDX_WOL_WAIT_TIME,
 

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -318,7 +318,8 @@ enum SSH_ARGS_IDX {
     
     /**
      * The amount of time to wait after sending the magic WoL packet prior to
-     * continuing the connection attempt.
+     * continuing the connection attempt.  The default is no wait time
+     * (0 seconds).
      */
     IDX_WOL_WAIT_TIME,
 

--- a/src/protocols/telnet/settings.c
+++ b/src/protocols/telnet/settings.c
@@ -259,7 +259,8 @@ enum TELNET_ARGS_IDX {
     
     /**
      * The amount of time, in seconds, to wait after the magic WoL packet is
-     * sent before continuing the connection attempt.
+     * sent before continuing the connection attempt.  The default is not to
+     * wait at all (0 seconds).
      */
     IDX_WOL_WAIT_TIME,
 

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -361,7 +361,8 @@ enum VNC_ARGS_IDX {
     
     /**
      * The number of seconds to wait after sending the magic WoL packet before
-     * attempting to connect to the remote host.
+     * attempting to connect to the remote host.  The default is not to wait
+     * at all (0 seconds).
      */
     IDX_WOL_WAIT_TIME,
 


### PR DESCRIPTION
In addition to the issues identified by Coverity for socket open failures, this pull request enhances error logging and also changes the default boot time to zero in the recently-merged Wake-on-LAN functionality.