### PR TITLE
GUACAMOLE-1103: Fix the incorrect comment of the enable_sftp variable of the guac_rdp_settings structure.

### DIFF
--- a/src/protocols/rdp/settings.h
+++ b/src/protocols/rdp/settings.h
@@ -397,7 +397,7 @@ typedef struct guac_rdp_settings {
 
 #ifdef ENABLE_COMMON_SSH
     /**
-     * Whether SFTP should be enabled for the VNC connection.
+     * Whether SFTP should be enabled for the RDP connection.
      */
     int enable_sftp;
 


### PR DESCRIPTION
I have fixed the GUACAMOLE-1103 issue.