### PR TITLE
GUACAMOLE-465: Produce MPEG-4 output within a proper container.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -203,6 +203,24 @@ fi
 AM_CONDITIONAL([ENABLE_AVCODEC], [test "x${have_libavcodec}" = "xyes"])
 
 #
+# libavformat
+#
+
+have_libavformat=disabled
+AC_ARG_WITH([libavformat],
+	    [AS_HELP_STRING([--with-libavformat],
+	                    [use libavformat when encoding video @<:@default=check@:>@])],
+            [].
+            [with_libavformat=check])
+if test "x$with_libavformat" != "xno"
+then
+    have_libavformat=yes
+    PKG_CHECK_MODULES([AVFORMAT], [libavformat],, [have_libavformat=no]);
+fi
+
+AM_CONDITIONAL([ENABLE_AVFORMAT], [test "x${have_libavformat}" = "xyes"])
+
+#
 # libavutil
 #
 
@@ -980,10 +998,11 @@ AC_ARG_ENABLE([guacenc],
               [],
               [enable_guacenc=yes])
 
-AM_CONDITIONAL([ENABLE_GUACENC], [test "x${enable_guacenc}"  = "xyes" \
-                                    -a "x${have_libavcodec}" = "xyes" \
-                                    -a "x${have_libavutil}"  = "xyes" \
-                                    -a "x${have_libswscale}" = "xyes"])
+AM_CONDITIONAL([ENABLE_GUACENC], [test "x${enable_guacenc}"   = "xyes" \
+                                    -a "x${have_libavcodec}"  = "xyes" \
+                                    -a "x${have_libavutil}"   = "xyes" \
+                                    -a "x${have_libswscale}"  = "xyes" \
+                                    -a "x${have_libavformat}" = "xyes"])
 
 #
 # guaclog
@@ -1076,6 +1095,7 @@ $PACKAGE_NAME version $PACKAGE_VERSION
      freerdp2 ............ ${have_freerdp2}
      pango ............... ${have_pango}
      libavcodec .......... ${have_libavcodec}
+     libavformat.......... ${have_libavformat}
      libavutil ........... ${have_libavutil}
      libssh2 ............. ${have_libssh2}
      libssl .............. ${have_ssl}

--- a/src/guacenc/Makefile.am
+++ b/src/guacenc/Makefile.am
@@ -90,6 +90,7 @@ endif
 guacenc_CFLAGS =            \
     -Werror -Wall           \
     @AVCODEC_CFLAGS@        \
+    @AVFORMAT_CFLAGS@       \
     @AVUTIL_CFLAGS@         \
     @LIBGUAC_INCLUDE@       \
     @SWSCALE_CFLAGS@
@@ -97,12 +98,13 @@ guacenc_CFLAGS =            \
 guacenc_LDADD =     \
     @LIBGUAC_LTLIB@
 
-guacenc_LDFLAGS =  \
-    @AVCODEC_LIBS@ \
-    @AVUTIL_LIBS@  \
-    @CAIRO_LIBS@   \
-    @JPEG_LIBS@    \
-    @SWSCALE_LIBS@ \
+guacenc_LDFLAGS =   \
+    @AVCODEC_LIBS@  \
+    @AVFORMAT_LIBS@ \
+    @AVUTIL_LIBS@   \
+    @CAIRO_LIBS@    \
+    @JPEG_LIBS@     \
+    @SWSCALE_LIBS@  \
     @WEBP_LIBS@
 
 EXTRA_DIST =         \

--- a/src/guacenc/ffmpeg-compat.c
+++ b/src/guacenc/ffmpeg-compat.c
@@ -55,7 +55,7 @@ static int guacenc_write_packet(guacenc_video* video, void* data, int size) {
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(54,1,0)
     AVPacket pkt;
-    /* have to create a packet around the encoded data we have */
+    /* Have to create a packet around the encoded data we have */
     av_init_packet(&pkt);
 
     if (video->context->coded_frame->pts != AV_NOPTS_VALUE) {
@@ -207,9 +207,7 @@ AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, AVCodec* codec,
     stream->codec->qmin = qmin;
     stream->codec->pix_fmt = pix_fmt;
     stream->codec->time_base = time_base;
-#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(55, 44, 100)
-    stream->codec->time_base = time_base;
-#else
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(55, 44, 100)
     stream->time_base = time_base;
 #endif
     return stream->codec;
@@ -234,12 +232,10 @@ AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, AVCodec* codec,
 int guacenc_open_avcodec(AVCodecContext *avcodec_context,
         AVCodec *codec, AVDictionary **options,
         AVStream* stream) {
-    int ret = 0;
-    ret = avcodec_open2(avcodec_context, codec, options);
+    int ret = avcodec_open2(avcodec_context, codec, options);
 #if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 33, 100)
-    int codecpar_ret = 0;
     /* copy stream parameters to the muxer */
-    codecpar_ret = avcodec_parameters_from_context(stream->codecpar,
+    int codecpar_ret = avcodec_parameters_from_context(stream->codecpar,
             avcodec_context);
     if (codecpar_ret < 0) {
         return codecpar_ret;

--- a/src/guacenc/ffmpeg-compat.h
+++ b/src/guacenc/ffmpeg-compat.h
@@ -52,6 +52,16 @@
 #define av_packet_unref av_free_packet
 #endif
 
+/* For libavcodec <= 56.41.100: Global header flag didn't have AV_ prefix.
+ * Guacenc defines its own flag here to avoid conflicts with libavcodec
+ * macros.
+ */
+#if LIBAVCODEC_VERSION_INT <= AV_VERSION_INT(56,41,100)
+#define GUACENC_FLAG_GLOBAL_HEADER CODEC_FLAG_GLOBAL_HEADER
+#else
+#define GUACENC_FLAG_GLOBAL_HEADER AV_CODEC_FLAG_GLOBAL_HEADER
+#endif
+
 /* For libavutil < 51.42.0: AV_PIX_FMT_* was PIX_FMT_* */
 #if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(51,42,0)
 #define AV_PIX_FMT_RGB32 PIX_FMT_RGB32
@@ -80,7 +90,9 @@ int guacenc_avcodec_encode_video(guacenc_video* video, AVFrame* frame);
 
 /**
  * Creates and sets up the AVCodecContext for the appropriate version
- * of libavformat installed
+ * of libavformat installed. The AVCodecContext will be built, but
+ * the AVStream will also be affected by having its time_base field
+ * set to the value passed into this function.
  *
  * @param stream
  *     The open AVStream
@@ -112,6 +124,9 @@ int guacenc_avcodec_encode_video(guacenc_video* video, AVFrame* frame);
  * @param time_base
  *     The target time base for the encoded video
  *
+ * @return
+ *     The pointer to the configured AVCodecContext
+ *
  */
 AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, AVCodec* codec,
         int bitrate, int width, int height, int gop_size, int qmax, int qmin,
@@ -125,19 +140,25 @@ AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, AVCodec* codec,
  * So this wrapper handles that. Otherwise, it's the
  * same as avcodec_open2().
  *
- * @param avcodec_context The context to initialize.
- * @param codec The codec to open this context for. If a non-NULL codec has
- *              been previously passed to avcodec_alloc_context3() or
- *              for this context, then this parameter MUST be either NULL or
- *              equal to the previously passed codec.
- * @param options A dictionary filled with AVCodecContext and codec-private
- *                options. On return this object will be filled with options
- *                that were not found.
- * @param stream The stream for the codec context.
- *               Only used in libavformat >= 57.33.100. Can be NULL in
- *               lower versions
+ * @param avcodec_context
+ *     The context to initialize.
  *
- * @return zero on success, a negative value on error
+ * @param codec
+ *     The codec to open this context for. If a non-NULL codec has
+ *     been previously passed to avcodec_alloc_context3() or
+ *     for this context, then this parameter MUST be either NULL or
+ *     equal to the previously passed codec.
+ *
+ * @param options
+ *     A dictionary filled with AVCodecContext and codec-private
+ *     options. On return this object will be filled with options
+ *     that were not found.
+ *
+ * @param stream
+ *     The stream for the codec context.
+ *
+ * @return
+ *     Zero on success, a negative value on error
  */
 int guacenc_open_avcodec(AVCodecContext *avcodec_context,
         AVCodec *codec, AVDictionary **options,

--- a/src/guacenc/ffmpeg-compat.h
+++ b/src/guacenc/ffmpeg-compat.h
@@ -78,5 +78,77 @@
  */
 int guacenc_avcodec_encode_video(guacenc_video* video, AVFrame* frame);
 
+/**
+ * Creates and sets up the AVCodecContext for the appropriate version
+ * of libavformat installed
+ *
+ * @param stream
+ *     The open AVStream
+ *
+ * @param codec
+ *     The codec used on the AVStream
+ *
+ * @param bitrate
+ *     The target bitrate for the encoded video
+ *
+ * @param width
+ *     The target width for the encoded video
+ *
+ * @param height
+ *     The target width for the encoded video
+ *
+ * @param gop_size
+ *     The size of the Group of Pictures
+ *
+ * @param qmax
+ *     The max value of the quantizer
+ *
+ * @param qmin
+ *     The min value of the quantizer
+ *
+ * @param pix_fmt
+ *     The target pixel format for the encoded video
+ *
+ * @param time_base
+ *     The target time base for the encoded video
+ *
+ */
+AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream,
+        AVCodec* codec,
+        int bitrate,
+        int width,
+        int height,
+        int gop_size,
+        int qmax,
+        int qmin,
+        int pix_fmt,
+        AVRational time_base);
+
+/**
+ * A wrapper for avcodec_open2(). Because libavformat ver
+ * 57.33.100 and greater use stream->codecpar rather than
+ * stream->codec to handle information to the codec,
+ * there needs to be an additional step in that version.
+ * So this wrapper handles that. Otherwise, it's the
+ * same as avcodec_open2().
+ *
+ * @param avcodec_context The context to initialize.
+ * @param codec The codec to open this context for. If a non-NULL codec has
+ *              been previously passed to avcodec_alloc_context3() or
+ *              for this context, then this parameter MUST be either NULL or
+ *              equal to the previously passed codec.
+ * @param options A dictionary filled with AVCodecContext and codec-private
+ *                options. On return this object will be filled with options
+ *                that were not found.
+ * @param stream The stream for the codec context.
+ *               Only used in libavformat >= 57.33.100. Can be NULL in
+ *               lower versions
+ *
+ * @return zero on success, a negative value on error
+ */
+int guacenc_open_avcodec(AVCodecContext *avcodec_context,
+        AVCodec *codec, AVDictionary **options,
+        AVStream* stream);
+
 #endif
 

--- a/src/guacenc/ffmpeg-compat.h
+++ b/src/guacenc/ffmpeg-compat.h
@@ -89,43 +89,43 @@
 int guacenc_avcodec_encode_video(guacenc_video* video, AVFrame* frame);
 
 /**
- * Creates and sets up the AVCodecContext for the appropriate version
- * of libavformat installed. The AVCodecContext will be built, but
- * the AVStream will also be affected by having its time_base field
- * set to the value passed into this function.
+ * Creates and sets up the AVCodecContext for the appropriate version of
+ * libavformat installed. The AVCodecContext will be built, but the AVStream
+ * will also be affected by having its time_base field set to the value passed
+ * into this function.
  *
  * @param stream
- *     The open AVStream
+ *     The open AVStream.
  *
  * @param codec
- *     The codec used on the AVStream
+ *     The codec used on the AVStream.
  *
  * @param bitrate
  *     The target bitrate for the encoded video
  *
  * @param width
- *     The target width for the encoded video
+ *     The target width for the encoded video.
  *
  * @param height
- *     The target width for the encoded video
+ *     The target height for the encoded video.
  *
  * @param gop_size
- *     The size of the Group of Pictures
+ *     The size of the Group of Pictures.
  *
  * @param qmax
- *     The max value of the quantizer
+ *     The max value of the quantizer.
  *
  * @param qmin
- *     The min value of the quantizer
+ *     The min value of the quantizer.
  *
  * @param pix_fmt
- *     The target pixel format for the encoded video
+ *     The target pixel format for the encoded video.
  *
  * @param time_base
- *     The target time base for the encoded video
+ *     The target time base for the encoded video.
  *
  * @return
- *     The pointer to the configured AVCodecContext
+ *     The pointer to the configured AVCodecContext.
  *
  */
 AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, AVCodec* codec,
@@ -133,32 +133,29 @@ AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, AVCodec* codec,
         int pix_fmt, AVRational time_base);
 
 /**
- * A wrapper for avcodec_open2(). Because libavformat ver
- * 57.33.100 and greater use stream->codecpar rather than
- * stream->codec to handle information to the codec,
- * there needs to be an additional step in that version.
- * So this wrapper handles that. Otherwise, it's the
- * same as avcodec_open2().
+ * A wrapper for avcodec_open2(). Because libavformat ver 57.33.100 and greater
+ * use stream->codecpar rather than stream->codec to handle information to the
+ * codec, there needs to be an additional step in that version.  So this
+ * wrapper handles that. Otherwise, it's the same as avcodec_open2().
  *
  * @param avcodec_context
  *     The context to initialize.
  *
  * @param codec
- *     The codec to open this context for. If a non-NULL codec has
- *     been previously passed to avcodec_alloc_context3() or
- *     for this context, then this parameter MUST be either NULL or
- *     equal to the previously passed codec.
+ *     The codec to open this context for. If a non-NULL codec has been
+ *     previously passed to avcodec_alloc_context3() or for this context, then
+ *     this parameter MUST be either NULL or equal to the previously passed
+ *     codec.
  *
  * @param options
- *     A dictionary filled with AVCodecContext and codec-private
- *     options. On return this object will be filled with options
- *     that were not found.
+ *     A dictionary filled with AVCodecContext and codec-private options. On
+ *     return this object will be filled with options that were not found.
  *
  * @param stream
  *     The stream for the codec context.
  *
  * @return
- *     Zero on success, a negative value on error
+ *     Zero on success, a negative value on error.
  */
 int guacenc_open_avcodec(AVCodecContext *avcodec_context,
         AVCodec *codec, AVDictionary **options,

--- a/src/guacenc/ffmpeg-compat.h
+++ b/src/guacenc/ffmpeg-compat.h
@@ -113,16 +113,9 @@ int guacenc_avcodec_encode_video(guacenc_video* video, AVFrame* frame);
  *     The target time base for the encoded video
  *
  */
-AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream,
-        AVCodec* codec,
-        int bitrate,
-        int width,
-        int height,
-        int gop_size,
-        int qmax,
-        int qmin,
-        int pix_fmt,
-        AVRational time_base);
+AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, AVCodec* codec,
+        int bitrate, int width, int height, int gop_size, int qmax, int qmin,
+        int pix_fmt, AVRational time_base);
 
 /**
  * A wrapper for avcodec_open2(). Because libavformat ver

--- a/src/guacenc/guacenc.c
+++ b/src/guacenc/guacenc.c
@@ -25,6 +25,7 @@
 #include "parse.h"
 
 #include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
 
 #include <getopt.h>
 #include <stdbool.h>
@@ -79,6 +80,9 @@ int main(int argc, char* argv[]) {
     /* Prepare libavcodec */
     avcodec_register_all();
 #endif
+
+    /* Prepare libavformat */
+    av_register_all();
 
     /* Track number of overall failures */
     int total_files = argc - optind;

--- a/src/guacenc/guacenc.c
+++ b/src/guacenc/guacenc.c
@@ -81,8 +81,9 @@ int main(int argc, char* argv[]) {
     avcodec_register_all();
 #endif
 
-    /* Prepare libavformat */
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 9, 100)
     av_register_all();
+#endif
 
     /* Track number of overall failures */
     int total_files = argc - optind;

--- a/src/guacenc/man/guacenc.1.in
+++ b/src/guacenc/man/guacenc.1.in
@@ -38,7 +38,7 @@ is essentially an implementation of a Guacamole client which accepts
 its input from files instead of a network connection, and renders directly to
 video instead of to the user's screen.
 .P
-Each \fIFILE\fR specified will be encoded as a raw MPEG-4 video stream to a new
+Each \fIFILE\fR specified will be encoded as MPEG-4 video to a new
 file named \fIFILE\fR.m4v, encoded according to the other options specified. By
 default, the output video will be \fI640\fRx\fI480\fR pixels, and will be saved
 with a bitrate of \fI2000000\fR bits per second (2 Mbps). These defaults can be

--- a/src/guacenc/video.c
+++ b/src/guacenc/video.c
@@ -80,14 +80,8 @@ guacenc_video* guacenc_video_alloc(const char* path, const char* codec_name,
 
     /* Retrieve encoding context */
     AVCodecContext* avcodec_context =
-            guacenc_build_avcodeccontext(video_stream,
-                    codec,
-                    bitrate,
-                    width,
-                    height,
-                    /*gop size*/ 10,
-                    /*qmax*/ 31,
-                    /*qmin*/ 2,
+            guacenc_build_avcodeccontext(video_stream, codec, bitrate, width,
+                    height, /*gop size*/ 10, /*qmax*/ 31, /*qmin*/ 2,
                     /*pix fmt*/ AV_PIX_FMT_YUV420P,
                     /*time base*/ (AVRational) { 1, GUACENC_VIDEO_FRAMERATE });
 

--- a/src/guacenc/video.c
+++ b/src/guacenc/video.c
@@ -91,9 +91,9 @@ guacenc_video* guacenc_video_alloc(const char* path, const char* codec_name,
         goto fail_context;
     }
 
-    //if format needs global headers, write them
+    /* If format needs global headers, write them */
     if (container_format_context->oformat->flags & AVFMT_GLOBALHEADER) {
-        avcodec_context->flags |= CODEC_FLAG_GLOBAL_HEADER;
+        avcodec_context->flags |= GUACENC_FLAG_GLOBAL_HEADER;
     }
 
     /* Open codec for use */

--- a/src/guacenc/video.h
+++ b/src/guacenc/video.h
@@ -51,7 +51,8 @@ typedef struct guacenc_video {
 
     /**
      * AVStream for video output.
-     * Persists via the AVFormatContext.
+     * Frames sent to this stream are written into
+     * the output file in the specified container format.
      */
     AVStream* output_stream;
 

--- a/src/guacenc/video.h
+++ b/src/guacenc/video.h
@@ -26,6 +26,14 @@
 #include <guacamole/timestamp.h>
 #include <libavcodec/avcodec.h>
 
+#ifndef AVCODEC_AVCODEC_H
+#include <libavcodec/avcodec.h>
+#endif
+
+#ifndef AVFORMAT_AVFORMAT_H
+#include <libavformat/avformat.h>
+#endif
+
 #include <stdint.h>
 #include <stdio.h>
 
@@ -42,15 +50,22 @@
 typedef struct guacenc_video {
 
     /**
-     * Output file stream.
+     * AVStream for video output.
+     * Persists via the AVFormatContext.
      */
-    FILE* output;
+    AVStream* output_stream;
 
     /**
      * The open encoding context from libavcodec, created for the codec
      * specified when this guacenc_video was created.
      */
     AVCodecContext* context;
+
+    /**
+     * The open format context from libavformat, created for the file
+     * container specified when this guacenc_video was created.
+     */
+    AVFormatContext* container_format_context;
 
     /**
      * The width of the video, in pixels.


### PR DESCRIPTION
This change builds off #159, adding the following additional changes:

* Minor corrections to address the comment style nitpicks from the latest review of #159.
* Minor update to the guacenc manpage, noting that the output is now simply normal MPEG-4 video (now a raw MPEG-4 video stream).

The original commits from #159 are here and untouched.