### PR TITLE
GUACAMOLE-966: Bump libguac version number for 1.2.0.

### DIFF
--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -131,7 +131,7 @@ libguac_la_CFLAGS = \
     -Werror -Wall -pedantic
 
 libguac_la_LDFLAGS =     \
-    -version-info 17:0:0 \
+    -version-info 18:0:1 \
     -no-undefined        \
     @CAIRO_LIBS@         \
     @DL_LIBS@            \


### PR DESCRIPTION
Interfaces have been added to libguac for this release (support for WoL), but no existing interface has been changed or removed.

The guidelines we must follow for updating the version info are here: https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html