### PR TITLE
GUACAMOLE-465: Remove superfluous access check prior to attempting file deletion.

### DIFF
--- a/src/guacenc/video.c
+++ b/src/guacenc/video.c
@@ -37,10 +37,11 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
-#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 guacenc_video* guacenc_video_alloc(const char* path, const char* codec_name,
@@ -166,10 +167,11 @@ guacenc_video* guacenc_video_alloc(const char* path, const char* codec_name,
 
 fail_output_file:
     avio_close(container_format_context->pb);
-    /* delete the file that was created if it was actually created */
-    if (access(path, F_OK) != -1) {
-        remove(path);
-    }
+
+    /* Delete the file that was created if it was actually created */
+    if (unlink(path) == -1 && errno != ENOENT)
+        guacenc_log(GUAC_LOG_WARNING, "Failed output file \"%s\" could not "
+                "be automatically deleted: %s", path, strerror(errno));
 
 fail_output_avio:
     av_freep(&frame->data[0]);


### PR DESCRIPTION
There are a couple issues with `access()` and `remove()` as they are currently used within guacenc:

* If checking `access()` prior to attempting `remove()` in order to avoid a failed removal, there is no guarantee that the status of the file pending removal will not change between the calls. This sort of check should be made atomically.

  A good way to do this is through just attempting the removal and handling the possible failure. If the file does not exist, that is one of the distinct types of failures that will be reported.

* `remove()` is useful when the type of file is unknown, as it will automatically choose between `unlink()` and `rmdir()` depending on whether the file is a directory. As we know ahead of time that this file will never be a directory, it is more appropriate to use `unlink()`.