### PR TITLE
GUACAMOLE-474: Properly enforce file new upload/download restrictions.

### DIFF
--- a/src/common-ssh/sftp.c
+++ b/src/common-ssh/sftp.c
@@ -516,6 +516,15 @@ guac_stream* guac_common_ssh_sftp_download_file(
     guac_stream* stream;
     LIBSSH2_SFTP_HANDLE* file;
 
+    /* Ignore download if downloads have been disabled */
+    if (filesystem->disable_download) {
+        guac_user_log(user, GUAC_LOG_WARNING, "A download attempt has "
+                "been blocked due to downloads being disabled, however it "
+                "should have been blocked at a higher level. This is likely "
+                "a bug.");
+        return NULL;
+    }
+
     /* Attempt to open file for reading */
     file = libssh2_sftp_open(filesystem->sftp_session, filename,
             LIBSSH2_FXF_READ, 0);

--- a/src/common-ssh/sftp.c
+++ b/src/common-ssh/sftp.c
@@ -376,6 +376,18 @@ int guac_common_ssh_sftp_handle_file_stream(
     char fullpath[GUAC_COMMON_SSH_SFTP_MAX_PATH];
     LIBSSH2_SFTP_HANDLE* file;
 
+    /* Ignore upload if uploads have been disabled */
+    if (filesystem->disable_upload) {
+        guac_user_log(user, GUAC_LOG_WARNING, "A upload attempt has "
+                "been blocked due to uploads being disabled, however it "
+                "should have been blocked at a higher level. This is likely "
+                "a bug.");
+        guac_protocol_send_ack(user->socket, stream, "SFTP: Upload disabled",
+                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
+        guac_socket_flush(user->socket);
+        return 0;
+    }
+
     /* Concatenate filename with path */
     if (!guac_ssh_append_filename(fullpath, filesystem->upload_path,
                 filename)) {
@@ -858,6 +870,18 @@ static int guac_common_ssh_sftp_put_handler(guac_user* user,
 
     guac_common_ssh_sftp_filesystem* filesystem =
         (guac_common_ssh_sftp_filesystem*) object->data;
+
+    /* Ignore upload if uploads have been disabled */
+    if (filesystem->disable_upload) {
+        guac_user_log(user, GUAC_LOG_WARNING, "A upload attempt has "
+                "been blocked due to uploads being disabled, however it "
+                "should have been blocked at a higher level. This is likely "
+                "a bug.");
+        guac_protocol_send_ack(user->socket, stream, "SFTP: Upload disabled",
+                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
+        guac_socket_flush(user->socket);
+        return 0;
+    }
 
     LIBSSH2_SFTP* sftp = filesystem->sftp_session;
 

--- a/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages-file-info.c
+++ b/src/protocols/rdp/channels/rdpdr/rdpdr-fs-messages-file-info.c
@@ -166,7 +166,8 @@ void guac_rdpdr_fs_process_set_rename_info(guac_rdp_common_svc* svc,
             destination_path);
 
     /* If file moving to \Download folder, start stream, do not move */
-    if (strncmp(destination_path, "\\Download\\", 10) == 0) {
+    if (strncmp(destination_path, "\\Download\\", 10) == 0
+			&& !((guac_rdp_fs*) device->data)->disable_download) {
 
         guac_rdp_fs_file* file;
 

--- a/src/protocols/rdp/download.c
+++ b/src/protocols/rdp/download.c
@@ -148,8 +148,8 @@ int guac_rdp_download_get_handler(guac_user* user, guac_object* object,
 
     }
 
-    /* Otherwise, send file contents */
-    else {
+    /* Otherwise, send file contents if downloads are allowed */
+    else if (!fs->disable_download) {
 
         /* Create stream data */
         guac_rdp_download_status* download_status = malloc(sizeof(guac_rdp_download_status));
@@ -166,6 +166,10 @@ int guac_rdp_download_get_handler(guac_user* user, guac_object* object,
                 "application/octet-stream", name);
 
     }
+
+    else
+        guac_client_log(client, GUAC_LOG_INFO, "Unable to download file "
+                "\"%s\", file downloads have been disabled.", name);
 
     guac_socket_flush(user->socket);
     return 0;

--- a/src/protocols/rdp/download.c
+++ b/src/protocols/rdp/download.c
@@ -185,6 +185,15 @@ void* guac_rdp_download_to_user(guac_user* user, void* data) {
     if (filesystem == NULL)
         return NULL;
 
+    /* Ignore download if downloads have been disabled */
+    if (filesystem->disable_download) {
+        guac_client_log(client, GUAC_LOG_WARNING, "A download attempt has "
+                "been blocked due to downloads being disabled, however it "
+                "should have been blocked at a higher level. This is likely "
+                "a bug.");
+        return NULL;
+    }
+
     /* Attempt to open requested file */
     char* path = (char*) data;
     int file_id = guac_rdp_fs_open(filesystem, path,

--- a/src/protocols/rdp/upload.c
+++ b/src/protocols/rdp/upload.c
@@ -87,6 +87,18 @@ int guac_rdp_upload_file_handler(guac_user* user, guac_stream* stream,
         return 0;
     }
 
+    /* Ignore upload if uploads have been disabled */
+    if (fs->disable_upload) {
+        guac_client_log(client, GUAC_LOG_WARNING, "A upload attempt has "
+                "been blocked due to uploads being disabled, however it "
+                "should have been blocked at a higher level. This is likely "
+                "a bug.");
+        guac_protocol_send_ack(user->socket, stream, "FAIL (UPLOAD DISABLED)",
+                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
+        guac_socket_flush(user->socket);
+        return 0;
+    }
+
     /* Translate name */
     __generate_upload_path(filename, file_path);
 
@@ -201,6 +213,18 @@ int guac_rdp_upload_put_handler(guac_user* user, guac_object* object,
     if (fs == NULL) {
         guac_protocol_send_ack(user->socket, stream, "FAIL (NO FS)",
                 GUAC_PROTOCOL_STATUS_SERVER_ERROR);
+        guac_socket_flush(user->socket);
+        return 0;
+    }
+
+    /* Ignore upload if uploads have been disabled */
+    if (fs->disable_upload) {
+        guac_client_log(client, GUAC_LOG_WARNING, "A upload attempt has "
+                "been blocked due to uploads being disabled, however it "
+                "should have been blocked at a higher level. This is likely "
+                "a bug.");
+        guac_protocol_send_ack(user->socket, stream, "FAIL (UPLOAD DISABLED)",
+                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
         guac_socket_flush(user->socket);
         return 0;
     }


### PR DESCRIPTION
This change:

* Corrects a bug in the new download restrictions which failed to block:
  1. Downloads initiated using the RDPDR `Download` folder
  2. Downloads initiated via the Guacamole menu (using `get` instructions)
* Adds additional low-level blocking, in case an unknown bug should surface which attempts to initiate a download or service an upload, despite the same being disabled.