### PR TITLE
GUACAMOLE-221: Add convenience API for automatically handling received "argv" streams.

### DIFF
--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -32,6 +32,9 @@ SUBDIRS = . tests
 libguacincdir = $(includedir)/guacamole
 
 libguacinc_HEADERS =                  \
+    guacamole/argv.h                  \
+    guacamole/argv-constants.h        \
+    guacamole/argv-fntypes.h          \
     guacamole/audio.h                 \
     guacamole/audio-fntypes.h         \
     guacamole/audio-types.h           \
@@ -83,6 +86,7 @@ noinst_HEADERS =      \
     wait-fd.h
 
 libguac_la_SOURCES =   \
+    argv.c             \
     audio.c            \
     client.c           \
     encode-jpeg.c      \

--- a/src/libguac/argv.c
+++ b/src/libguac/argv.c
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+
+#include "guacamole/argv.h"
+#include "guacamole/protocol.h"
+#include "guacamole/socket.h"
+#include "guacamole/stream.h"
+#include "guacamole/string.h"
+#include "guacamole/user.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * The state of an argument that will be automatically processed. Note that
+ * this is distinct from the state of an argument value that is currently being
+ * processed. Argument value states are dynamically-allocated and scoped by the
+ * associated guac_stream.
+ */
+typedef struct guac_argv_state {
+
+    /**
+     * The name of the argument.
+     */
+    char name[GUAC_ARGV_MAX_NAME_LENGTH];
+
+    /**
+     * Whether at least one value for this argument has been received since it
+     * was registered.
+     */
+    int received;
+
+    /**
+     * Bitwise OR of all option flags that should affect processing of this
+     * argument. The only current flag is GUAC_ARGV_OPTION_ONCE.
+     */
+    int options;
+
+    /**
+     * The callback that should be invoked when a new value for the associated
+     * argument has been received. If the GUAC_ARGV_OPTION_ONCE flag is set,
+     * the callback will be invoked at most once.
+     */
+    guac_argv_callback* callback;
+
+    /**
+     * The arbitrary data that should be passed to the callback.
+     */
+    void* data;
+
+} guac_argv_state;
+
+/**
+ * The current state of automatic processing of "argv" streams.
+ */
+typedef struct guac_argv_await_state {
+
+    /**
+     * Whether automatic argument processing has been stopped via a call to
+     * guac_argv_stop().
+     */
+    int stopped;
+
+    /**
+     * The total number of arguments registered.
+     */
+    unsigned int num_registered;
+
+    /**
+     * All registered arguments and their corresponding callbacks.
+     */
+    guac_argv_state registered[GUAC_ARGV_MAX_REGISTERED];
+
+    /**
+     * Lock which protects multi-threaded access to this entire state
+     * structure, including the condition that signals specific modifications
+     * to the structure.
+     */
+    pthread_mutex_t lock;
+
+    /**
+     * Condition which is signalled whenever the overall state of "argv"
+     * processing changes, either through the receipt of a new argument value
+     * or due to a call to guac_argv_stop().
+     */
+    pthread_cond_t changed;
+
+} guac_argv_await_state;
+
+/**
+ * The value or current status of a connection parameter received over an
+ * "argv" stream.
+ */
+typedef struct guac_argv {
+
+    /**
+     * The state of the specific setting being updated.
+     */
+    guac_argv_state* state;
+
+    /**
+     * The mimetype of the data being received.
+     */
+    char mimetype[GUAC_ARGV_MAX_MIMETYPE_LENGTH];
+
+    /**
+     * Buffer space for containing the received argument value.
+     */
+    char buffer[GUAC_ARGV_MAX_LENGTH];
+
+    /**
+     * The number of bytes received so far.
+     */
+    int length;
+
+} guac_argv;
+
+/**
+ * Statically-allocated, shared state of the guac_argv_*() family of functions.
+ */
+static guac_argv_await_state await_state = {
+    .lock = PTHREAD_MUTEX_INITIALIZER,
+    .changed = PTHREAD_COND_INITIALIZER
+};
+
+/**
+ * Returns whether at least one value for each of the provided arguments has
+ * been received.
+ *
+ * @param args
+ *     A NULL-terminated array of the names of all arguments to test.
+ *
+ * @return
+ *     Non-zero if at least one value has been received for each of the
+ *     provided arguments, zero otherwise.
+ */
+static int guac_argv_is_received(const char** args) {
+
+    for (int i = 0; i < await_state.num_registered; i++) {
+
+        /* Ignore all received arguments */
+        guac_argv_state* state = &await_state.registered[i];
+        if (state->received)
+            continue;
+
+        /* Fail immediately for any matching non-received arguments */
+        for (const char** arg = args; *arg != NULL; arg++) {
+            if (strcmp(state->name, *(arg++)) == 0)
+                return 0;
+        }
+
+    }
+
+    /* All arguments were received */
+    return 1;
+
+}
+
+int guac_argv_register(const char* name, guac_argv_callback* callback, void* data, int options) {
+
+    pthread_mutex_lock(&await_state.lock);
+
+    if (await_state.num_registered == GUAC_ARGV_MAX_REGISTERED) {
+        pthread_mutex_unlock(&await_state.lock);
+        return 1;
+    }
+
+    guac_argv_state* state = &await_state.registered[await_state.num_registered++];
+    guac_strlcpy(state->name, name, sizeof(state->name));
+    state->options = options;
+    state->callback = callback;
+    state->data = data;
+
+    pthread_mutex_unlock(&await_state.lock);
+    return 0;
+
+}
+
+int guac_argv_await(const char** args) {
+
+    /* Wait for all requested arguments to be received (or for receipt to be
+     * stopped) */
+    pthread_mutex_lock(&await_state.lock);
+    while (!await_state.stopped && !guac_argv_is_received(args))
+        pthread_cond_wait(&await_state.changed, &await_state.lock);
+
+    /* Arguments were successfully received only if receipt was not stopped */
+    int retval = await_state.stopped;
+    pthread_mutex_unlock(&await_state.lock);
+    return retval;
+
+}
+
+/**
+ * Handler for "blob" instructions which appends the data from received blobs
+ * to the end of the in-progress argument value buffer.
+ *
+ * @see guac_user_blob_handler
+ */
+static int guac_argv_blob_handler(guac_user* user, guac_stream* stream,
+        void* data, int length) {
+
+    guac_argv* argv = (guac_argv*) stream->data;
+
+    /* Calculate buffer size remaining, including space for null terminator,
+     * adjusting received length accordingly */
+    int remaining = sizeof(argv->buffer) - argv->length - 1;
+    if (length > remaining)
+        length = remaining;
+
+    /* Append received data to end of buffer */
+    memcpy(argv->buffer + argv->length, data, length);
+    argv->length += length;
+
+    return 0;
+
+}
+
+/**
+ * Handler for "end" instructions which applies the changes specified by the
+ * argument value buffer associated with the stream.
+ *
+ * @see guac_user_end_handler
+ */
+static int guac_argv_end_handler(guac_user* user, guac_stream* stream) {
+
+    /* Append null terminator to value */
+    guac_argv* argv = (guac_argv*) stream->data;
+    argv->buffer[argv->length] = '\0';
+
+    pthread_mutex_lock(&await_state.lock);
+
+    /* Invoke callback, limiting to a single invocation if
+     * GUAC_ARGV_OPTION_ONCE applies */
+    guac_argv_state* state = argv->state;
+    if (!(state->options & GUAC_ARGV_OPTION_ONCE) || !state->received) {
+        if (state->callback != NULL)
+            state->callback(user, argv->mimetype, state->name, argv->buffer, state->data);
+    }
+
+    /* Notify that argument has been received */
+    state->received = 1;
+    pthread_cond_broadcast(&await_state.changed);
+
+    pthread_mutex_unlock(&await_state.lock);
+
+    free(argv);
+    return 0;
+
+}
+
+int guac_argv_received(guac_stream* stream, const char* mimetype, const char* name) {
+
+    pthread_mutex_lock(&await_state.lock);
+
+    for (int i = 0; i < await_state.num_registered; i++) {
+
+        /* Ignore any arguments that have already been received if they are
+         * declared as being acceptable only once */
+        guac_argv_state* state = &await_state.registered[i];
+        if ((state->options & GUAC_ARGV_OPTION_ONCE) && state->received)
+            continue;
+
+        /* Argument matched */
+        if (strcmp(state->name, name) == 0) {
+
+            guac_argv* argv = malloc(sizeof(guac_argv));
+            guac_strlcpy(argv->mimetype, mimetype, sizeof(argv->mimetype));
+            argv->state = state;
+            argv->length = 0;
+
+            stream->data = argv;
+            stream->blob_handler = guac_argv_blob_handler;
+            stream->end_handler = guac_argv_end_handler;
+
+            pthread_mutex_unlock(&await_state.lock);
+            return 0;
+
+        }
+
+    }
+
+    /* No such argument awaiting processing */
+    pthread_mutex_unlock(&await_state.lock);
+    return 1;
+
+}
+
+void guac_argv_stop() {
+    pthread_mutex_lock(&await_state.lock);
+
+    /* Signal any waiting threads that no further argument values will be
+     * received */
+    if (!await_state.stopped) {
+        await_state.stopped = 1;
+        pthread_cond_broadcast(&await_state.changed);
+
+    }
+
+    pthread_mutex_unlock(&await_state.lock);
+}
+
+int guac_argv_handler(guac_user* user, guac_stream* stream,
+        char* mimetype, char* name) {
+
+    /* Refuse stream if argument is not registered */
+    if (guac_argv_received(stream, mimetype, name)) {
+        guac_protocol_send_ack(user->socket, stream, "Not allowed.",
+                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
+        guac_socket_flush(user->socket);
+        return 0;
+    }
+
+    /* Signal stream is ready */
+    guac_protocol_send_ack(user->socket, stream, "Ready for updated "
+            "parameter.", GUAC_PROTOCOL_STATUS_SUCCESS);
+    guac_socket_flush(user->socket);
+    return 0;
+
+}
+

--- a/src/libguac/argv.c
+++ b/src/libguac/argv.c
@@ -165,7 +165,7 @@ static int guac_argv_is_received(const char** args) {
 
         /* Fail immediately for any matching non-received arguments */
         for (const char** arg = args; *arg != NULL; arg++) {
-            if (strcmp(state->name, *(arg++)) == 0)
+            if (strcmp(state->name, *arg) == 0)
                 return 0;
         }
 

--- a/src/libguac/guacamole/argv-constants.h
+++ b/src/libguac/guacamole/argv-constants.h
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_ARGV_CONSTANTS_H
+#define GUAC_ARGV_CONSTANTS_H
+
+/**
+ * Constants related to automatic handling of received "argv" instructions.
+ *
+ * @file argv-constants.h
+ */
+
+/**
+ * Option flag which declares to guac_argv_register() that the associated
+ * argument should be processed exactly once. If multiple "argv" streams are
+ * received for the argument, only the first such stream is processed.
+ * Additional streams will be rejected.
+ */
+#define GUAC_ARGV_OPTION_ONCE 1
+
+/**
+ * The maximum number of bytes to allow for any argument value received via an
+ * argv stream and processed using guac_argv_received(), including null
+ * terminator.
+ */
+#define GUAC_ARGV_MAX_LENGTH 16384
+
+/**
+ * The maximum number of bytes to allow within the name of any argument
+ * registered with guac_argv_register(), including null terminator.
+ */
+#define GUAC_ARGV_MAX_NAME_LENGTH 256 
+
+/**
+ * The maximum number of bytes to allow within the mimetype of any received
+ * argument value passed to a callback registered with guac_argv_register(),
+ * including null terminator.
+ */
+#define GUAC_ARGV_MAX_MIMETYPE_LENGTH 4096
+
+/**
+ * The maximum number of arguments that may be registered via guac_argv_await()
+ * or guac_argv_await_async() before further argument registrations will fail.
+ */
+#define GUAC_ARGV_MAX_REGISTERED 128
+
+#endif
+

--- a/src/libguac/guacamole/argv-constants.h
+++ b/src/libguac/guacamole/argv-constants.h
@@ -35,6 +35,13 @@
 #define GUAC_ARGV_OPTION_ONCE 1
 
 /**
+ * Option flag which declares to guac_argv_register() that the values received
+ * and accepted for the associated argument should be echoed to all connected
+ * users via outbound "argv" streams.
+ */
+#define GUAC_ARGV_OPTION_ECHO 2
+
+/**
  * The maximum number of bytes to allow for any argument value received via an
  * argv stream and processed using guac_argv_received(), including null
  * terminator.

--- a/src/libguac/guacamole/argv-fntypes.h
+++ b/src/libguac/guacamole/argv-fntypes.h
@@ -50,8 +50,12 @@
  * @param data
  *     Any arbitrary data that was provided when the received argument was
  *     registered with guac_argv_register().
+ *
+ * @return
+ *     Zero if the received argument value has been accepted and has either
+ *     taken effect or is being intentionally ignored, non-zero otherwise.
  */
-typedef void guac_argv_callback(guac_user* user, const char* mimetype,
+typedef int guac_argv_callback(guac_user* user, const char* mimetype,
         const char* name, const char* value, void* data);
 
 #endif

--- a/src/libguac/guacamole/argv-fntypes.h
+++ b/src/libguac/guacamole/argv-fntypes.h
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_ARGV_FNTYPES_H
+#define GUAC_ARGV_FNTYPES_H
+
+/**
+ * Function type definitions related to automatic handling of received "argv"
+ * instructions.
+ *
+ * @file argv-fntypes.h
+ */
+
+#include "user-types.h"
+
+/**
+ * Callback which is invoked by the automatic "argv" handling when the full
+ * value of a received argument has been received.
+ *
+ * @param user
+ *     The user that opened the argument value stream.
+ *
+ * @param mimetype
+ *     The mimetype of the data that will be sent along the stream.
+ *
+ * @param name
+ *     The name of the connection parameter being updated. It is up to the
+ *     implementation of this handler to decide whether and how to update a
+ *     connection parameter.
+ *
+ * @param value
+ *     The value of the received argument.
+ *
+ * @param data
+ *     Any arbitrary data that was provided when the received argument was
+ *     registered with guac_argv_register().
+ */
+typedef void guac_argv_callback(guac_user* user, const char* mimetype,
+        const char* name, const char* value, void* data);
+
+#endif
+

--- a/src/libguac/guacamole/argv.h
+++ b/src/libguac/guacamole/argv.h
@@ -43,6 +43,7 @@
  * @see GUAC_ARGV_MAX_REGISTERED
  *
  * @see GUAC_ARGV_OPTION_ONCE
+ * @see GUAC_ARGV_OPTION_ECHO
  *
  * @param name
  *     The name of the argument that should be handled by the given callback.
@@ -57,7 +58,7 @@
  *
  * @param options
  *     Bitwise OR of all option flags that should affect processing of this
- *     argument. The only current flag is GUAC_ARGV_OPTION_ONCE.
+ *     argument.
  *
  * @return
  *     Zero if the callback was successfully registered, non-zero if the

--- a/src/libguac/guacamole/argv.h
+++ b/src/libguac/guacamole/argv.h
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_ARGV_H
+#define GUAC_ARGV_H
+
+/**
+ * Convenience functions for processing parameter values that are submitted
+ * dynamically using "argv" instructions.
+ *
+ * @file argv.h
+ */
+
+#include "argv-constants.h"
+#include "argv-fntypes.h"
+#include "stream-types.h"
+#include "user-fntypes.h"
+
+/**
+ * Registers the given callback such that it is automatically invoked when an
+ * "argv" stream for an argument having the given name is processed using
+ * guac_argv_received(). The maximum number of arguments that may be registered
+ * in this way is limited by GUAC_ARGV_MAX_REGISTERED. The maximum length of
+ * any provided argument name is limited by GUAC_ARGV_MAX_NAME_LENGTH.
+ *
+ * @see GUAC_ARGV_MAX_NAME_LENGTH
+ * @see GUAC_ARGV_MAX_REGISTERED
+ *
+ * @see GUAC_ARGV_OPTION_ONCE
+ *
+ * @param name
+ *     The name of the argument that should be handled by the given callback.
+ *
+ * @param callback
+ *     The callback to invoke when the value of an argument having the given
+ *     name has finished being received.
+ *
+ * @param data
+ *     Arbitrary data to be passed to the given callback when a value is
+ *     received for the given argument.
+ *
+ * @param options
+ *     Bitwise OR of all option flags that should affect processing of this
+ *     argument. The only current flag is GUAC_ARGV_OPTION_ONCE.
+ *
+ * @return
+ *     Zero if the callback was successfully registered, non-zero if the
+ *     maximum number of registered callbacks has already been reached.
+ */
+int guac_argv_register(const char* name, guac_argv_callback* callback, void* data, int options);
+
+/**
+ * Waits for receipt of each of the given arguments via guac_argv_received().
+ * This function will block until either ALL of the given arguments have been
+ * received via guac_argv_received() or until automatic processing of received
+ * arguments is stopped with guac_argv_stop().
+ *
+ * @param args
+ *     A NULL-terminated array of the names of all arguments that this function
+ *     should wait for.
+ *
+ * @return
+ *     Zero if all of the specified arguments were received, non-zero if
+ *     guac_argv_stop() was called before all arguments were received.
+ */
+int guac_argv_await(const char** args);
+
+/**
+ * Hands off management of the given guac_stream, automatically processing data
+ * received over that stream as the value of the argument having the given
+ * name. The argument must have already been registered with
+ * guac_argv_register(). The blob_handler and end_handler of the given stream,
+ * if already set, will be overridden without regard to their current value.
+ *
+ * It is the responsibility of the caller to properly send any required "ack"
+ * instructions to accept or reject the received stream.
+ *
+ * @param stream
+ *     The guac_stream that will receive the value of the argument having the
+ *     given name.
+ *
+ * @param mimetype
+ *     The mimetype of the data that will be received over the stream.
+ *
+ * @param name
+ *     The name of the argument being received.
+ *
+ * @return
+ *     Zero if handling of the guac_stream has been successfully handed off,
+ *     non-zero if the provided argument has not yet been registered with
+ *     guac_argv_register().
+ */
+int guac_argv_received(guac_stream* stream, const char* mimetype, const char* name);
+
+/**
+ * Stops further automatic processing of received "argv" streams. Any call to
+ * guac_argv_await() that is currently blocking will return, and any future
+ * calls to guac_argv_await() will return immediately without blocking.
+ */
+void guac_argv_stop();
+
+/**
+ * Convenience implementation of the "argv" instruction handler which
+ * automatically sends any required "ack" instructions and invokes
+ * guac_argv_received(). Only arguments that are registered with
+ * guac_argv_register() will be processed.
+ */
+guac_user_argv_handler guac_argv_handler;
+
+#endif
+

--- a/src/protocols/kubernetes/argv.c
+++ b/src/protocols/kubernetes/argv.c
@@ -29,172 +29,33 @@
 #include <stdlib.h>
 #include <string.h>
 
-/**
- * All Kubernetes connection settings which may be updated by unprivileged
- * users through "argv" streams.
- */
-typedef enum guac_kubernetes_argv_setting {
-
-    /**
-     * The color scheme of the terminal.
-     */
-    GUAC_KUBERNETES_ARGV_SETTING_COLOR_SCHEME,
-
-    /**
-     * The name of the font family used by the terminal.
-     */
-    GUAC_KUBERNETES_ARGV_SETTING_FONT_NAME,
-
-    /**
-     * The size of the font used by the terminal, in points.
-     */
-    GUAC_KUBERNETES_ARGV_SETTING_FONT_SIZE
-
-} guac_kubernetes_argv_setting;
-
-/**
- * The value or current status of a connection parameter received over an
- * "argv" stream.
- */
-typedef struct guac_kubernetes_argv {
-
-    /**
-     * The specific setting being updated.
-     */
-    guac_kubernetes_argv_setting setting;
-
-    /**
-     * Buffer space for containing the received argument value.
-     */
-    char buffer[GUAC_KUBERNETES_ARGV_MAX_LENGTH];
-
-    /**
-     * The number of bytes received so far.
-     */
-    int length;
-
-} guac_kubernetes_argv;
-
-/**
- * Handler for "blob" instructions which appends the data from received blobs
- * to the end of the in-progress argument value buffer.
- *
- * @see guac_user_blob_handler
- */
-static int guac_kubernetes_argv_blob_handler(guac_user* user,
-        guac_stream* stream, void* data, int length) {
-
-    guac_kubernetes_argv* argv = (guac_kubernetes_argv*) stream->data;
-
-    /* Calculate buffer size remaining, including space for null terminator,
-     * adjusting received length accordingly */
-    int remaining = sizeof(argv->buffer) - argv->length - 1;
-    if (length > remaining)
-        length = remaining;
-
-    /* Append received data to end of buffer */
-    memcpy(argv->buffer + argv->length, data, length);
-    argv->length += length;
-
-    return 0;
-
-}
-
-/**
- * Handler for "end" instructions which applies the changes specified by the
- * argument value buffer associated with the stream.
- *
- * @see guac_user_end_handler
- */
-static int guac_kubernetes_argv_end_handler(guac_user* user,
-        guac_stream* stream) {
-
-    int size;
+int guac_kubernetes_argv_callback(guac_user* user, const char* mimetype,
+        const char* name, const char* value, void* data) {
 
     guac_client* client = user->client;
     guac_kubernetes_client* kubernetes_client = (guac_kubernetes_client*) client->data;
     guac_terminal* terminal = kubernetes_client->term;
 
-    /* Append null terminator to value */
-    guac_kubernetes_argv* argv = (guac_kubernetes_argv*) stream->data;
-    argv->buffer[argv->length] = '\0';
+    /* Update color scheme */
+    if (strcmp(name, GUAC_KUBERNETES_ARGV_COLOR_SCHEME) == 0)
+        guac_terminal_apply_color_scheme(terminal, value);
 
-    /* Apply changes to chosen setting */
-    switch (argv->setting) {
+    /* Update font name */
+    else if (strcmp(name, GUAC_KUBERNETES_ARGV_FONT_NAME) == 0)
+        guac_terminal_apply_font(terminal, value, -1, 0);
 
-        /* Update color scheme */
-        case GUAC_KUBERNETES_ARGV_SETTING_COLOR_SCHEME:
-            guac_terminal_apply_color_scheme(terminal, argv->buffer);
-            guac_client_stream_argv(client, client->socket, "text/plain",
-                    "color-scheme", argv->buffer);
-            break;
-
-        /* Update font name */
-        case GUAC_KUBERNETES_ARGV_SETTING_FONT_NAME:
-            guac_terminal_apply_font(terminal, argv->buffer, -1, 0);
-            guac_client_stream_argv(client, client->socket, "text/plain",
-                    "font-name", argv->buffer);
-            break;
-
-        /* Update font size */
-        case GUAC_KUBERNETES_ARGV_SETTING_FONT_SIZE:
-
-            /* Update only if font size is sane */
-            size = atoi(argv->buffer);
-            if (size > 0) {
-                guac_terminal_apply_font(terminal, NULL, size,
-                        kubernetes_client->settings->resolution);
-                guac_client_stream_argv(client, client->socket, "text/plain",
-                        "font-size", argv->buffer);
-            }
-
-            break;
-
+    /* Update only if font size is sane */
+    else if (strcmp(name, GUAC_KUBERNETES_ARGV_FONT_SIZE) == 0) {
+        int size = atoi(value);
+        if (size > 0)
+            guac_terminal_apply_font(terminal, NULL, size,
+                    kubernetes_client->settings->resolution);
     }
 
     /* Update Kubernetes terminal size */
     guac_kubernetes_resize(client, terminal->term_height,
             terminal->term_width);
 
-    free(argv);
-    return 0;
-
-}
-
-int guac_kubernetes_argv_handler(guac_user* user, guac_stream* stream,
-        char* mimetype, char* name) {
-
-    guac_kubernetes_argv_setting setting;
-
-    /* Allow users to update the color scheme and font details */
-    if (strcmp(name, "color-scheme") == 0)
-        setting = GUAC_KUBERNETES_ARGV_SETTING_COLOR_SCHEME;
-    else if (strcmp(name, "font-name") == 0)
-        setting = GUAC_KUBERNETES_ARGV_SETTING_FONT_NAME;
-    else if (strcmp(name, "font-size") == 0)
-        setting = GUAC_KUBERNETES_ARGV_SETTING_FONT_SIZE;
-
-    /* No other connection parameters may be updated */
-    else {
-        guac_protocol_send_ack(user->socket, stream, "Not allowed.",
-                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
-        guac_socket_flush(user->socket);
-        return 0;
-    }
-
-    guac_kubernetes_argv* argv = malloc(sizeof(guac_kubernetes_argv));
-    argv->setting = setting;
-    argv->length = 0;
-
-    /* Prepare stream to receive argument value */
-    stream->blob_handler = guac_kubernetes_argv_blob_handler;
-    stream->end_handler = guac_kubernetes_argv_end_handler;
-    stream->data = argv;
-
-    /* Signal stream is ready */
-    guac_protocol_send_ack(user->socket, stream, "Ready for updated "
-            "parameter.", GUAC_PROTOCOL_STATUS_SUCCESS);
-    guac_socket_flush(user->socket);
     return 0;
 
 }
@@ -205,20 +66,21 @@ void* guac_kubernetes_send_current_argv(guac_user* user, void* data) {
     guac_terminal* terminal = kubernetes_client->term;
 
     /* Send current color scheme */
-    guac_user_stream_argv(user, user->socket, "text/plain", "color-scheme",
-            terminal->color_scheme);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_KUBERNETES_ARGV_COLOR_SCHEME, terminal->color_scheme);
 
     /* Send current font name */
-    guac_user_stream_argv(user, user->socket, "text/plain", "font-name",
-            terminal->font_name);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_KUBERNETES_ARGV_FONT_NAME, terminal->font_name);
 
     /* Send current font size */
     char font_size[64];
     sprintf(font_size, "%i", terminal->font_size);
-    guac_user_stream_argv(user, user->socket, "text/plain", "font-size",
-            font_size);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_KUBERNETES_ARGV_FONT_SIZE, font_size);
 
     return NULL;
+
 
 }
 

--- a/src/protocols/kubernetes/argv.h
+++ b/src/protocols/kubernetes/argv.h
@@ -23,19 +23,32 @@
 
 #include "config.h"
 
+#include <guacamole/argv.h>
 #include <guacamole/user.h>
 
 /**
- * The maximum number of bytes to allow for any argument value received via an
- * argv stream, including null terminator.
+ * The name of the parameter that specifies/updates the color scheme used by
+ * the terminal emulator.
  */
-#define GUAC_KUBERNETES_ARGV_MAX_LENGTH 16384
+#define GUAC_KUBERNETES_ARGV_COLOR_SCHEME "color-scheme"
 
 /**
- * Handles an incoming stream from a Guacamole "argv" instruction, updating the
- * given connection parameter if that parameter is allowed to be updated.
+ * The name of the parameter that specifies/updates the name of the font used
+ * by the terminal emulator.
  */
-guac_user_argv_handler guac_kubernetes_argv_handler;
+#define GUAC_KUBERNETES_ARGV_FONT_NAME "font-name"
+
+/**
+ * The name of the parameter that specifies/updates the font size used by the
+ * terminal emulator.
+ */
+#define GUAC_KUBERNETES_ARGV_FONT_SIZE "font-size"
+
+/**
+ * Handles a received argument value from a Guacamole "argv" instruction,
+ * updating the given connection parameter.
+ */
+guac_argv_callback guac_kubernetes_argv_callback;
 
 /**
  * Sends the current values of all non-sensitive parameters which may be set

--- a/src/protocols/kubernetes/client.c
+++ b/src/protocols/kubernetes/client.c
@@ -17,12 +17,14 @@
  * under the License.
  */
 
+#include "argv.h"
 #include "client.h"
 #include "common/clipboard.h"
 #include "kubernetes.h"
 #include "settings.h"
 #include "user.h"
 
+#include <guacamole/argv.h>
 #include <guacamole/client.h>
 #include <libwebsockets.h>
 
@@ -99,6 +101,11 @@ int guac_client_init(guac_client* client) {
     /* Set handlers */
     client->join_handler = guac_kubernetes_user_join_handler;
     client->free_handler = guac_kubernetes_client_free_handler;
+
+    /* Register handlers for argument values that may be sent after the handshake */
+    guac_argv_register(GUAC_KUBERNETES_ARGV_COLOR_SCHEME, guac_kubernetes_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
+    guac_argv_register(GUAC_KUBERNETES_ARGV_FONT_NAME, guac_kubernetes_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
+    guac_argv_register(GUAC_KUBERNETES_ARGV_FONT_SIZE, guac_kubernetes_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
 
     /* Set locale and warn if not UTF-8 */
     setlocale(LC_CTYPE, "");

--- a/src/protocols/kubernetes/settings.c
+++ b/src/protocols/kubernetes/settings.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include "argv.h"
 #include "settings.h"
 
 #include <guacamole/user.h>
@@ -35,9 +36,9 @@ const char* GUAC_KUBERNETES_CLIENT_ARGS[] = {
     "client-key",
     "ca-cert",
     "ignore-cert",
-    "font-name",
-    "font-size",
-    "color-scheme",
+    GUAC_KUBERNETES_ARGV_FONT_NAME,
+    GUAC_KUBERNETES_ARGV_FONT_SIZE,
+    GUAC_KUBERNETES_ARGV_COLOR_SCHEME,
     "typescript-path",
     "typescript-name",
     "create-typescript-path",

--- a/src/protocols/kubernetes/user.c
+++ b/src/protocols/kubernetes/user.c
@@ -93,7 +93,7 @@ int guac_kubernetes_user_join_handler(guac_user* user, int argc, char** argv) {
         user->pipe_handler = guac_kubernetes_pipe_handler;
 
         /* Updates to connection parameters */
-        user->argv_handler = guac_kubernetes_argv_handler;
+        user->argv_handler = guac_argv_handler;
 
         /* Display size change events */
         user->size_handler = guac_kubernetes_user_size_handler;

--- a/src/protocols/ssh/argv.c
+++ b/src/protocols/ssh/argv.c
@@ -30,127 +30,27 @@
 #include <stdlib.h>
 #include <string.h>
 
-/**
- * All SSH connection settings which may be updated by unprivileged users
- * through "argv" streams.
- */
-typedef enum guac_ssh_argv_setting {
-
-    /**
-     * The color scheme of the terminal.
-     */
-    GUAC_SSH_ARGV_SETTING_COLOR_SCHEME,
-
-    /**
-     * The name of the font family used by the terminal.
-     */
-    GUAC_SSH_ARGV_SETTING_FONT_NAME,
-
-    /**
-     * The size of the font used by the terminal, in points.
-     */
-    GUAC_SSH_ARGV_SETTING_FONT_SIZE
-
-} guac_ssh_argv_setting;
-
-/**
- * The value or current status of a connection parameter received over an
- * "argv" stream.
- */
-typedef struct guac_ssh_argv {
-
-    /**
-     * The specific setting being updated.
-     */
-    guac_ssh_argv_setting setting;
-
-    /**
-     * Buffer space for containing the received argument value.
-     */
-    char buffer[GUAC_SSH_ARGV_MAX_LENGTH];
-
-    /**
-     * The number of bytes received so far.
-     */
-    int length;
-
-} guac_ssh_argv;
-
-/**
- * Handler for "blob" instructions which appends the data from received blobs
- * to the end of the in-progress argument value buffer.
- *
- * @see guac_user_blob_handler
- */
-static int guac_ssh_argv_blob_handler(guac_user* user,
-        guac_stream* stream, void* data, int length) {
-
-    guac_ssh_argv* argv = (guac_ssh_argv*) stream->data;
-
-    /* Calculate buffer size remaining, including space for null terminator,
-     * adjusting received length accordingly */
-    int remaining = sizeof(argv->buffer) - argv->length - 1;
-    if (length > remaining)
-        length = remaining;
-
-    /* Append received data to end of buffer */
-    memcpy(argv->buffer + argv->length, data, length);
-    argv->length += length;
-
-    return 0;
-
-}
-
-/**
- * Handler for "end" instructions which applies the changes specified by the
- * argument value buffer associated with the stream.
- *
- * @see guac_user_end_handler
- */
-static int guac_ssh_argv_end_handler(guac_user* user,
-        guac_stream* stream) {
-
-    int size;
+int guac_ssh_argv_callback(guac_user* user, const char* mimetype,
+        const char* name, const char* value, void* data) {
 
     guac_client* client = user->client;
     guac_ssh_client* ssh_client = (guac_ssh_client*) client->data;
     guac_terminal* terminal = ssh_client->term;
 
-    /* Append null terminator to value */
-    guac_ssh_argv* argv = (guac_ssh_argv*) stream->data;
-    argv->buffer[argv->length] = '\0';
+    /* Update color scheme */
+    if (strcmp(name, GUAC_SSH_ARGV_COLOR_SCHEME) == 0)
+        guac_terminal_apply_color_scheme(terminal, value);
 
-    /* Apply changes to chosen setting */
-    switch (argv->setting) {
+    /* Update font name */
+    else if (strcmp(name, GUAC_SSH_ARGV_FONT_NAME) == 0)
+        guac_terminal_apply_font(terminal, value, -1, 0);
 
-        /* Update color scheme */
-        case GUAC_SSH_ARGV_SETTING_COLOR_SCHEME:
-            guac_terminal_apply_color_scheme(terminal, argv->buffer);
-            guac_client_stream_argv(client, client->socket, "text/plain",
-                    "color-scheme", argv->buffer);
-            break;
-
-        /* Update font name */
-        case GUAC_SSH_ARGV_SETTING_FONT_NAME:
-            guac_terminal_apply_font(terminal, argv->buffer, -1, 0);
-            guac_client_stream_argv(client, client->socket, "text/plain",
-                    "font-name", argv->buffer);
-            break;
-
-        /* Update font size */
-        case GUAC_SSH_ARGV_SETTING_FONT_SIZE:
-
-            /* Update only if font size is sane */
-            size = atoi(argv->buffer);
-            if (size > 0) {
-                guac_terminal_apply_font(terminal, NULL, size,
-                        ssh_client->settings->resolution);
-                guac_client_stream_argv(client, client->socket, "text/plain",
-                        "font-size", argv->buffer);
-            }
-
-            break;
-
+    /* Update only if font size is sane */
+    else if (strcmp(name, GUAC_SSH_ARGV_FONT_SIZE) == 0) {
+        int size = atoi(value);
+        if (size > 0)
+            guac_terminal_apply_font(terminal, NULL, size,
+                    ssh_client->settings->resolution);
     }
 
     /* Update SSH pty size if connected */
@@ -161,45 +61,6 @@ static int guac_ssh_argv_end_handler(guac_user* user,
         pthread_mutex_unlock(&(ssh_client->term_channel_lock));
     }
 
-    free(argv);
-    return 0;
-
-}
-
-int guac_ssh_argv_handler(guac_user* user, guac_stream* stream,
-        char* mimetype, char* name) {
-
-    guac_ssh_argv_setting setting;
-
-    /* Allow users to update the color scheme and font details */
-    if (strcmp(name, "color-scheme") == 0)
-        setting = GUAC_SSH_ARGV_SETTING_COLOR_SCHEME;
-    else if (strcmp(name, "font-name") == 0)
-        setting = GUAC_SSH_ARGV_SETTING_FONT_NAME;
-    else if (strcmp(name, "font-size") == 0)
-        setting = GUAC_SSH_ARGV_SETTING_FONT_SIZE;
-
-    /* No other connection parameters may be updated */
-    else {
-        guac_protocol_send_ack(user->socket, stream, "Not allowed.",
-                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
-        guac_socket_flush(user->socket);
-        return 0;
-    }
-
-    guac_ssh_argv* argv = malloc(sizeof(guac_ssh_argv));
-    argv->setting = setting;
-    argv->length = 0;
-
-    /* Prepare stream to receive argument value */
-    stream->blob_handler = guac_ssh_argv_blob_handler;
-    stream->end_handler = guac_ssh_argv_end_handler;
-    stream->data = argv;
-
-    /* Signal stream is ready */
-    guac_protocol_send_ack(user->socket, stream, "Ready for updated "
-            "parameter.", GUAC_PROTOCOL_STATUS_SUCCESS);
-    guac_socket_flush(user->socket);
     return 0;
 
 }
@@ -210,18 +71,18 @@ void* guac_ssh_send_current_argv(guac_user* user, void* data) {
     guac_terminal* terminal = ssh_client->term;
 
     /* Send current color scheme */
-    guac_user_stream_argv(user, user->socket, "text/plain", "color-scheme",
-            terminal->color_scheme);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_SSH_ARGV_COLOR_SCHEME, terminal->color_scheme);
 
     /* Send current font name */
-    guac_user_stream_argv(user, user->socket, "text/plain", "font-name",
-            terminal->font_name);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_SSH_ARGV_FONT_NAME, terminal->font_name);
 
     /* Send current font size */
     char font_size[64];
     sprintf(font_size, "%i", terminal->font_size);
-    guac_user_stream_argv(user, user->socket, "text/plain", "font-size",
-            font_size);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_SSH_ARGV_FONT_SIZE, font_size);
 
     return NULL;
 

--- a/src/protocols/ssh/argv.h
+++ b/src/protocols/ssh/argv.h
@@ -23,19 +23,32 @@
 
 #include "config.h"
 
+#include <guacamole/argv.h>
 #include <guacamole/user.h>
 
 /**
- * The maximum number of bytes to allow for any argument value received via an
- * argv stream, including null terminator.
+ * The name of the parameter that specifies/updates the color scheme used by
+ * the terminal emulator.
  */
-#define GUAC_SSH_ARGV_MAX_LENGTH 16384
+#define GUAC_SSH_ARGV_COLOR_SCHEME "color-scheme"
 
 /**
- * Handles an incoming stream from a Guacamole "argv" instruction, updating the
- * given connection parameter if that parameter is allowed to be updated.
+ * The name of the parameter that specifies/updates the name of the font used
+ * by the terminal emulator.
  */
-guac_user_argv_handler guac_ssh_argv_handler;
+#define GUAC_SSH_ARGV_FONT_NAME "font-name"
+
+/**
+ * The name of the parameter that specifies/updates the font size used by the
+ * terminal emulator.
+ */
+#define GUAC_SSH_ARGV_FONT_SIZE "font-size"
+
+/**
+ * Handles a received argument value from a Guacamole "argv" instruction,
+ * updating the given connection parameter.
+ */
+guac_argv_callback guac_ssh_argv_callback;
 
 /**
  * Sends the current values of all non-sensitive parameters which may be set

--- a/src/protocols/ssh/client.c
+++ b/src/protocols/ssh/client.c
@@ -19,6 +19,7 @@
 
 #include "config.h"
 
+#include "argv.h"
 #include "client.h"
 #include "common/clipboard.h"
 #include "common/recording.h"
@@ -32,6 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <guacamole/argv.h>
 #include <guacamole/client.h>
 
 int guac_client_init(guac_client* client) {
@@ -49,6 +51,11 @@ int guac_client_init(guac_client* client) {
     /* Set handlers */
     client->join_handler = guac_ssh_user_join_handler;
     client->free_handler = guac_ssh_client_free_handler;
+
+    /* Register handlers for argument values that may be sent after the handshake */
+    guac_argv_register(GUAC_SSH_ARGV_COLOR_SCHEME, guac_ssh_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
+    guac_argv_register(GUAC_SSH_ARGV_FONT_NAME, guac_ssh_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
+    guac_argv_register(GUAC_SSH_ARGV_FONT_SIZE, guac_ssh_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
 
     /* Set locale and warn if not UTF-8 */
     setlocale(LC_CTYPE, "");

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -19,6 +19,7 @@
 
 #include "config.h"
 
+#include "argv.h"
 #include "client.h"
 #include "common/defaults.h"
 #include "settings.h"
@@ -37,8 +38,8 @@ const char* GUAC_SSH_CLIENT_ARGS[] = {
     "port",
     "username",
     "password",
-    "font-name",
-    "font-size",
+    GUAC_SSH_ARGV_FONT_NAME,
+    GUAC_SSH_ARGV_FONT_SIZE,
     "enable-sftp",
     "sftp-root-directory",
     "sftp-disable-download",
@@ -48,7 +49,7 @@ const char* GUAC_SSH_CLIENT_ARGS[] = {
 #ifdef ENABLE_SSH_AGENT
     "enable-agent",
 #endif
-    "color-scheme",
+    GUAC_SSH_ARGV_COLOR_SCHEME,
     "command",
     "typescript-path",
     "typescript-name",

--- a/src/protocols/ssh/user.c
+++ b/src/protocols/ssh/user.c
@@ -29,6 +29,7 @@
 #include "ssh.h"
 #include "settings.h"
 
+#include <guacamole/argv.h>
 #include <guacamole/client.h>
 #include <guacamole/socket.h>
 #include <guacamole/user.h>
@@ -93,7 +94,7 @@ int guac_ssh_user_join_handler(guac_user* user, int argc, char** argv) {
         user->pipe_handler = guac_ssh_pipe_handler;
 
         /* Updates to connection parameters */
-        user->argv_handler = guac_ssh_argv_handler;
+        user->argv_handler = guac_argv_handler;
 
         /* Display size change events */
         user->size_handler = guac_ssh_user_size_handler;

--- a/src/protocols/telnet/argv.c
+++ b/src/protocols/telnet/argv.c
@@ -29,127 +29,27 @@
 #include <stdlib.h>
 #include <string.h>
 
-/**
- * All telnet connection settings which may be updated by unprivileged users
- * through "argv" streams.
- */
-typedef enum guac_telnet_argv_setting {
-
-    /**
-     * The color scheme of the terminal.
-     */
-    GUAC_TELNET_ARGV_SETTING_COLOR_SCHEME,
-
-    /**
-     * The name of the font family used by the terminal.
-     */
-    GUAC_TELNET_ARGV_SETTING_FONT_NAME,
-
-    /**
-     * The size of the font used by the terminal, in points.
-     */
-    GUAC_TELNET_ARGV_SETTING_FONT_SIZE
-
-} guac_telnet_argv_setting;
-
-/**
- * The value or current status of a connection parameter received over an
- * "argv" stream.
- */
-typedef struct guac_telnet_argv {
-
-    /**
-     * The specific setting being updated.
-     */
-    guac_telnet_argv_setting setting;
-
-    /**
-     * Buffer space for containing the received argument value.
-     */
-    char buffer[GUAC_TELNET_ARGV_MAX_LENGTH];
-
-    /**
-     * The number of bytes received so far.
-     */
-    int length;
-
-} guac_telnet_argv;
-
-/**
- * Handler for "blob" instructions which appends the data from received blobs
- * to the end of the in-progress argument value buffer.
- *
- * @see guac_user_blob_handler
- */
-static int guac_telnet_argv_blob_handler(guac_user* user,
-        guac_stream* stream, void* data, int length) {
-
-    guac_telnet_argv* argv = (guac_telnet_argv*) stream->data;
-
-    /* Calculate buffer size remaining, including space for null terminator,
-     * adjusting received length accordingly */
-    int remaining = sizeof(argv->buffer) - argv->length - 1;
-    if (length > remaining)
-        length = remaining;
-
-    /* Append received data to end of buffer */
-    memcpy(argv->buffer + argv->length, data, length);
-    argv->length += length;
-
-    return 0;
-
-}
-
-/**
- * Handler for "end" instructions which applies the changes specified by the
- * argument value buffer associated with the stream.
- *
- * @see guac_user_end_handler
- */
-static int guac_telnet_argv_end_handler(guac_user* user,
-        guac_stream* stream) {
-
-    int size;
+int guac_telnet_argv_callback(guac_user* user, const char* mimetype,
+        const char* name, const char* value, void* data) {
 
     guac_client* client = user->client;
     guac_telnet_client* telnet_client = (guac_telnet_client*) client->data;
     guac_terminal* terminal = telnet_client->term;
 
-    /* Append null terminator to value */
-    guac_telnet_argv* argv = (guac_telnet_argv*) stream->data;
-    argv->buffer[argv->length] = '\0';
+    /* Update color scheme */
+    if (strcmp(name, GUAC_TELNET_ARGV_COLOR_SCHEME) == 0)
+        guac_terminal_apply_color_scheme(terminal, value);
 
-    /* Apply changes to chosen setting */
-    switch (argv->setting) {
+    /* Update font name */
+    else if (strcmp(name, GUAC_TELNET_ARGV_FONT_NAME) == 0)
+        guac_terminal_apply_font(terminal, value, -1, 0);
 
-        /* Update color scheme */
-        case GUAC_TELNET_ARGV_SETTING_COLOR_SCHEME:
-            guac_terminal_apply_color_scheme(terminal, argv->buffer);
-            guac_client_stream_argv(client, client->socket, "text/plain",
-                    "color-scheme", argv->buffer);
-            break;
-
-        /* Update font name */
-        case GUAC_TELNET_ARGV_SETTING_FONT_NAME:
-            guac_terminal_apply_font(terminal, argv->buffer, -1, 0);
-            guac_client_stream_argv(client, client->socket, "text/plain",
-                    "font-name", argv->buffer);
-            break;
-
-        /* Update font size */
-        case GUAC_TELNET_ARGV_SETTING_FONT_SIZE:
-
-            /* Update only if font size is sane */
-            size = atoi(argv->buffer);
-            if (size > 0) {
-                guac_terminal_apply_font(terminal, NULL, size,
-                        telnet_client->settings->resolution);
-                guac_client_stream_argv(client, client->socket, "text/plain",
-                        "font-size", argv->buffer);
-            }
-
-            break;
-
+    /* Update only if font size is sane */
+    else if (strcmp(name, GUAC_TELNET_ARGV_FONT_SIZE) == 0) {
+        int size = atoi(value);
+        if (size > 0)
+            guac_terminal_apply_font(terminal, NULL, size,
+                    telnet_client->settings->resolution);
     }
 
     /* Update terminal window size if connected */
@@ -157,45 +57,6 @@ static int guac_telnet_argv_end_handler(guac_user* user,
         guac_telnet_send_naws(telnet_client->telnet, terminal->term_width,
                 terminal->term_height);
 
-    free(argv);
-    return 0;
-
-}
-
-int guac_telnet_argv_handler(guac_user* user, guac_stream* stream,
-        char* mimetype, char* name) {
-
-    guac_telnet_argv_setting setting;
-
-    /* Allow users to update the color scheme and font details */
-    if (strcmp(name, "color-scheme") == 0)
-        setting = GUAC_TELNET_ARGV_SETTING_COLOR_SCHEME;
-    else if (strcmp(name, "font-name") == 0)
-        setting = GUAC_TELNET_ARGV_SETTING_FONT_NAME;
-    else if (strcmp(name, "font-size") == 0)
-        setting = GUAC_TELNET_ARGV_SETTING_FONT_SIZE;
-
-    /* No other connection parameters may be updated */
-    else {
-        guac_protocol_send_ack(user->socket, stream, "Not allowed.",
-                GUAC_PROTOCOL_STATUS_CLIENT_FORBIDDEN);
-        guac_socket_flush(user->socket);
-        return 0;
-    }
-
-    guac_telnet_argv* argv = malloc(sizeof(guac_telnet_argv));
-    argv->setting = setting;
-    argv->length = 0;
-
-    /* Prepare stream to receive argument value */
-    stream->blob_handler = guac_telnet_argv_blob_handler;
-    stream->end_handler = guac_telnet_argv_end_handler;
-    stream->data = argv;
-
-    /* Signal stream is ready */
-    guac_protocol_send_ack(user->socket, stream, "Ready for updated "
-            "parameter.", GUAC_PROTOCOL_STATUS_SUCCESS);
-    guac_socket_flush(user->socket);
     return 0;
 
 }
@@ -206,18 +67,18 @@ void* guac_telnet_send_current_argv(guac_user* user, void* data) {
     guac_terminal* terminal = telnet_client->term;
 
     /* Send current color scheme */
-    guac_user_stream_argv(user, user->socket, "text/plain", "color-scheme",
-            terminal->color_scheme);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_TELNET_ARGV_COLOR_SCHEME, terminal->color_scheme);
 
     /* Send current font name */
-    guac_user_stream_argv(user, user->socket, "text/plain", "font-name",
-            terminal->font_name);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_TELNET_ARGV_FONT_NAME, terminal->font_name);
 
     /* Send current font size */
     char font_size[64];
     sprintf(font_size, "%i", terminal->font_size);
-    guac_user_stream_argv(user, user->socket, "text/plain", "font-size",
-            font_size);
+    guac_user_stream_argv(user, user->socket, "text/plain",
+            GUAC_TELNET_ARGV_FONT_SIZE, font_size);
 
     return NULL;
 

--- a/src/protocols/telnet/argv.h
+++ b/src/protocols/telnet/argv.h
@@ -23,19 +23,32 @@
 
 #include "config.h"
 
+#include <guacamole/argv.h>
 #include <guacamole/user.h>
 
 /**
- * The maximum number of bytes to allow for any argument value received via an
- * argv stream, including null terminator.
+ * The name of the parameter that specifies/updates the color scheme used by
+ * the terminal emulator.
  */
-#define GUAC_TELNET_ARGV_MAX_LENGTH 16384
+#define GUAC_TELNET_ARGV_COLOR_SCHEME "color-scheme"
 
 /**
- * Handles an incoming stream from a Guacamole "argv" instruction, updating the
- * given connection parameter if that parameter is allowed to be updated.
+ * The name of the parameter that specifies/updates the name of the font used
+ * by the terminal emulator.
  */
-guac_user_argv_handler guac_telnet_argv_handler;
+#define GUAC_TELNET_ARGV_FONT_NAME "font-name"
+
+/**
+ * The name of the parameter that specifies/updates the font size used by the
+ * terminal emulator.
+ */
+#define GUAC_TELNET_ARGV_FONT_SIZE "font-size"
+
+/**
+ * Handles a received argument value from a Guacamole "argv" instruction,
+ * updating the given connection parameter.
+ */
+guac_argv_callback guac_telnet_argv_callback;
 
 /**
  * Sends the current values of all non-sensitive parameters which may be set

--- a/src/protocols/telnet/client.c
+++ b/src/protocols/telnet/client.c
@@ -18,6 +18,7 @@
  */
 
 #include "config.h"
+#include "argv.h"
 #include "client.h"
 #include "common/recording.h"
 #include "settings.h"
@@ -31,6 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <guacamole/argv.h>
 #include <guacamole/client.h>
 
 int guac_client_init(guac_client* client) {
@@ -53,6 +55,11 @@ int guac_client_init(guac_client* client) {
     /* Set handlers */
     client->join_handler = guac_telnet_user_join_handler;
     client->free_handler = guac_telnet_client_free_handler;
+
+    /* Register handlers for argument values that may be sent after the handshake */
+    guac_argv_register(GUAC_TELNET_ARGV_COLOR_SCHEME, guac_telnet_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
+    guac_argv_register(GUAC_TELNET_ARGV_FONT_NAME, guac_telnet_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
+    guac_argv_register(GUAC_TELNET_ARGV_FONT_SIZE, guac_telnet_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);
 
     /* Set locale and warn if not UTF-8 */
     setlocale(LC_CTYPE, "");

--- a/src/protocols/telnet/settings.c
+++ b/src/protocols/telnet/settings.c
@@ -19,6 +19,7 @@
 
 #include "config.h"
 
+#include "argv.h"
 #include "common/defaults.h"
 #include "settings.h"
 
@@ -39,9 +40,9 @@ const char* GUAC_TELNET_CLIENT_ARGS[] = {
     "username-regex",
     "password",
     "password-regex",
-    "font-name",
-    "font-size",
-    "color-scheme",
+    GUAC_TELNET_ARGV_FONT_NAME,
+    GUAC_TELNET_ARGV_FONT_SIZE,
+    GUAC_TELNET_ARGV_COLOR_SCHEME,
     "typescript-path",
     "typescript-name",
     "create-typescript-path",

--- a/src/protocols/telnet/user.c
+++ b/src/protocols/telnet/user.c
@@ -92,7 +92,7 @@ int guac_telnet_user_join_handler(guac_user* user, int argc, char** argv) {
         user->pipe_handler = guac_telnet_pipe_handler;
 
         /* Updates to connection parameters */
-        user->argv_handler = guac_telnet_argv_handler;
+        user->argv_handler = guac_argv_handler;
 
         /* Display size change events */
         user->size_handler = guac_telnet_user_size_handler;


### PR DESCRIPTION
This change adds a new header to libguac, `argv.h`, which provides a series of convenience functions for automatically handling "argv" streams:

* `guac_argv_register()` - Registers a callback which should be invoked when the full, updated value of an argument has been received via an "argv" stream. Option flags can be specified to declare that a particular callback should be invoked only once, or that received values should be echoed back to all users of the connection.
* `guac_argv_received()` - Hands over control of a received "argv" stream such that registered callbacks will automatically be invoked.
* `guac_argv_handler` - Convenient implementation of the "argv" instruction handler which automatically handles sending of "ack" instructions and invokes `guac_argv_received()` appropriately.

In general, `guac_argv_register()` and `guac_argv_handler` should be sufficient to replace all current usage of the "argv" stream. For handling of "argv" streams that must block the connection, two additional functions are provided:

* `guac_argv_await()` - Blocks until each of the provided NULL-terminated list of arguments has been received.
* `guac_argv_stop()` - Safely unblocks any `guac_argv_await()` that are currently blocked, and prevents any future calls from blocking.