### PR TITLE
GUACAMOLE-1174: Added exec call implementation for kubernetes protocol

### DIFF
--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -217,7 +217,6 @@ void* guac_kubernetes_client_thread(void* data) {
                 settings->kubernetes_namespace,
                 settings->kubernetes_pod,
                 settings->kubernetes_container,
-                settings->use_exec,
                 settings->exec_command)) {
         guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
                 "Unable to generate path for Kubernetes API endpoint: "

--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -213,10 +213,12 @@ void* guac_kubernetes_client_thread(void* data) {
     }
 
     /* Generate endpoint for attachment URL */
-    if (guac_kubernetes_endpoint_attach(endpoint_path, sizeof(endpoint_path),
+    if (guac_kubernetes_endpoint_uri(endpoint_path, sizeof(endpoint_path),
                 settings->kubernetes_namespace,
                 settings->kubernetes_pod,
-                settings->kubernetes_container)) {
+                settings->kubernetes_container,
+                settings->use_exec,
+                settings->exec_command)) {
         guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
                 "Unable to generate path for Kubernetes API endpoint: "
                 "Resulting path too long");

--- a/src/protocols/kubernetes/settings.c
+++ b/src/protocols/kubernetes/settings.c
@@ -31,6 +31,8 @@ const char* GUAC_KUBERNETES_CLIENT_ARGS[] = {
     "namespace",
     "pod",
     "container",
+    "use-exec",
+    "exec-command",
     "use-ssl",
     "client-cert",
     "client-key",
@@ -85,6 +87,16 @@ enum KUBERNETES_ARGS_IDX {
      * in the pod will be used.
      */
     IDX_CONTAINER,
+
+    /**
+     * Whether exec call should be used. If omitted, attach call will be used.
+     */
+    IDX_USE_EXEC,
+
+    /**
+     * The command used by exec call.
+     */
+    IDX_EXEC_COMMAND,
 
     /**
      * Whether SSL/TLS should be used. If omitted, SSL/TLS will not be used.
@@ -274,6 +286,16 @@ guac_kubernetes_settings* guac_kubernetes_parse_args(guac_user* user,
     settings->kubernetes_container =
         guac_user_parse_args_string(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
                 IDX_CONTAINER, NULL);
+
+    /* Parse whether exec call should be used */
+    settings->use_exec =
+        guac_user_parse_args_boolean(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
+                IDX_USE_EXEC, false);
+
+    /* Read exec command (optional) */
+    settings->exec_command =
+        guac_user_parse_args_string(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
+                IDX_EXEC_COMMAND, GUAC_KUBERNETES_DEFAULT_EXEC_COMMAND);
 
     /* Parse whether SSL should be used */
     settings->use_ssl =

--- a/src/protocols/kubernetes/settings.c
+++ b/src/protocols/kubernetes/settings.c
@@ -31,7 +31,6 @@ const char* GUAC_KUBERNETES_CLIENT_ARGS[] = {
     "namespace",
     "pod",
     "container",
-    "use-exec",
     "exec-command",
     "use-ssl",
     "client-cert",
@@ -89,12 +88,7 @@ enum KUBERNETES_ARGS_IDX {
     IDX_CONTAINER,
 
     /**
-     * Whether exec call should be used. If omitted, attach call will be used.
-     */
-    IDX_USE_EXEC,
-
-    /**
-     * The command used by exec call.
+     * The command used by exec call. If omitted, attach call will be used.
      */
     IDX_EXEC_COMMAND,
 
@@ -287,15 +281,10 @@ guac_kubernetes_settings* guac_kubernetes_parse_args(guac_user* user,
         guac_user_parse_args_string(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
                 IDX_CONTAINER, NULL);
 
-    /* Parse whether exec call should be used */
-    settings->use_exec =
-        guac_user_parse_args_boolean(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
-                IDX_USE_EXEC, false);
-
     /* Read exec command (optional) */
     settings->exec_command =
         guac_user_parse_args_string(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
-                IDX_EXEC_COMMAND, GUAC_KUBERNETES_DEFAULT_EXEC_COMMAND);
+                IDX_EXEC_COMMAND, NULL);
 
     /* Parse whether SSL should be used */
     settings->use_ssl =

--- a/src/protocols/kubernetes/settings.c
+++ b/src/protocols/kubernetes/settings.c
@@ -417,6 +417,9 @@ void guac_kubernetes_settings_free(guac_kubernetes_settings* settings) {
     free(settings->kubernetes_pod);
     free(settings->kubernetes_container);
 
+    /* Free Kubernetes exec command */
+    free(settings->exec_command);
+
     /* Free SSL/TLS details */
     free(settings->client_cert);
     free(settings->client_key);

--- a/src/protocols/kubernetes/settings.h
+++ b/src/protocols/kubernetes/settings.h
@@ -48,6 +48,12 @@
 #define GUAC_KUBERNETES_DEFAULT_NAMESPACE "default"
 
 /**
+ * The command that should be used by default for exec call if no
+ * specific command is provided.
+ */
+#define GUAC_KUBERNETES_DEFAULT_EXEC_COMMAND "/bin/sh"
+
+/**
  * The filename to use for the typescript, if not specified.
  */
 #define GUAC_KUBERNETES_DEFAULT_TYPESCRIPT_NAME "typescript" 
@@ -96,6 +102,16 @@ typedef struct guac_kubernetes_settings {
      * the first container in the pod.
      */
     char* kubernetes_container;
+
+    /**
+     * Whether exec call should be used, default attach.
+     */
+    bool use_exec;
+
+    /**
+     * Exec command, default /bin/sh.
+     */
+    char* exec_command;
 
     /**
      * Whether SSL/TLS should be used.

--- a/src/protocols/kubernetes/settings.h
+++ b/src/protocols/kubernetes/settings.h
@@ -48,12 +48,6 @@
 #define GUAC_KUBERNETES_DEFAULT_NAMESPACE "default"
 
 /**
- * The command that should be used by default for exec call if no
- * specific command is provided.
- */
-#define GUAC_KUBERNETES_DEFAULT_EXEC_COMMAND "/bin/sh"
-
-/**
  * The filename to use for the typescript, if not specified.
  */
 #define GUAC_KUBERNETES_DEFAULT_TYPESCRIPT_NAME "typescript" 
@@ -104,12 +98,8 @@ typedef struct guac_kubernetes_settings {
     char* kubernetes_container;
 
     /**
-     * Whether exec call should be used, default attach.
-     */
-    bool use_exec;
-
-    /**
-     * Exec command, default /bin/sh.
+     * The command to generate api endpoint for call exec. 
+     * If omitted call attach will be used.
      */
     char* exec_command;
 

--- a/src/protocols/kubernetes/url.c
+++ b/src/protocols/kubernetes/url.c
@@ -99,10 +99,37 @@ int guac_kubernetes_append_endpoint_param(char* buffer, int length,
                     sizeof(escaped_param_value), param_value))
             return 1;
     
-    int written;
-    written = snprintf(buffer + strlen(buffer), length - strlen(buffer), 
-            "%s=%s&", param_name, escaped_param_value);
+    char* str = buffer;
 
+    int str_len = 0;
+    int qmark = 0;
+
+    while (*str != '\0') {
+
+        /* Look for a question mark */
+        if (*str=='?') qmark = 1;
+
+        /* Compute the buffer string length */
+        str_len++;
+
+        /* Verify the buffer null terminated */
+        if (str_len >= length) return 1;
+
+        /* Next character */
+        str++;
+    }
+
+    /* Determine the parameter delimiter */
+    char delimiter = '?';
+    if (qmark) delimiter = '&';
+
+    /* Write the parameter to the buffer */
+    int written;
+    written = snprintf(buffer + str_len, length - str_len,
+            "%c%s=%s", delimiter, param_name, escaped_param_value);
+
+    /* The parameter was successfully added if it was written to the given
+     * buffer without truncation */
     return (written < 0 || written >= length);
 }
 

--- a/src/protocols/kubernetes/url.h
+++ b/src/protocols/kubernetes/url.h
@@ -72,13 +72,10 @@ int guac_kubernetes_escape_url_component(char* output, int length,
  * @param kubernetes_container
  *     The name of the container to attach to, or NULL to arbitrarily attach
  *     to the first container in the pod.
- * 
- * @param use_exec
- *     Whether use call exec.
- *     Execute a command in a container and attach to it instead of main container process.
- * 
+ *  
  * @param exec_command
- *     The command used in conjunction with exec call.
+ *     The command used to run a new process and attach to it,
+ *     instead of the main container process.
  *
  * @return
  *     Zero if the endpoint path was successfully written to the provided
@@ -86,7 +83,7 @@ int guac_kubernetes_escape_url_component(char* output, int length,
  */
 int guac_kubernetes_endpoint_uri(char* buffer, int length,
         const char* kubernetes_namespace, const char* kubernetes_pod,
-        const char* kubernetes_container, int use_exec, const char* exec_command);
+        const char* kubernetes_container, const char* exec_command);
 
 #endif
 

--- a/src/protocols/kubernetes/url.h
+++ b/src/protocols/kubernetes/url.h
@@ -72,14 +72,21 @@ int guac_kubernetes_escape_url_component(char* output, int length,
  * @param kubernetes_container
  *     The name of the container to attach to, or NULL to arbitrarily attach
  *     to the first container in the pod.
+ * 
+ * @param use_exec
+ *     Whether use call exec.
+ *     Execute a command in a container and attach to it instead of main container process.
+ * 
+ * @param exec_command
+ *     The command used in conjunction with exec call.
  *
  * @return
  *     Zero if the endpoint path was successfully written to the provided
  *     buffer, non-zero if insufficient space exists within the buffer.
  */
-int guac_kubernetes_endpoint_attach(char* buffer, int length,
+int guac_kubernetes_endpoint_uri(char* buffer, int length,
         const char* kubernetes_namespace, const char* kubernetes_pod,
-        const char* kubernetes_container);
+        const char* kubernetes_container, int use_exec, const char* exec_command);
 
 #endif
 

--- a/src/protocols/kubernetes/url.h
+++ b/src/protocols/kubernetes/url.h
@@ -50,6 +50,31 @@ int guac_kubernetes_escape_url_component(char* output, int length,
         const char* str);
 
 /**
+ * Append the parameter to the endpoint path.
+ * Value within the path will be URL-escaped as necessary.
+ *
+ * @param buffer
+ *     The buffer which should receive the parameter. It could contain the endpoint path.
+ *     The parameter will be written to the end of the buffer.
+ *
+ * @param length
+ *     The number of bytes available in the given buffer.
+ *
+ * @param param_name
+ *     The name of the parameter.
+ *
+ * @param param_value
+ *     The value of the parameter.
+ *
+ * @return
+ *     Zero if the parameter was successfully attached to the buffer,
+ *     non-zero if insufficient space exists within the buffer or
+ *     buffer not null terminated.
+ */
+int guac_kubernetes_append_endpoint_param(char* buffer, int length,
+        const char* param_name, const char* param_value);
+
+/**
  * Generates the full path to the Kubernetes API endpoint which handles
  * attaching to running containers within specific pods. Values within the path
  * will be URL-escaped as necessary.


### PR DESCRIPTION
Added support for using `exec` for attaching to kubernetes pods.
Modified generation of Kubernetes API endpoint.

Added connection argument  _exec-command_.
 
**exec_command:**
 The command used by exec call. If omitted, attach call will be used.
 Used to run a new process and attach to it, instead of the main container process.