### PR TITLE
GUACAMOLE-1185: Fixed one typo mistake.

### DIFF
--- a/src/protocols/rdp/channels/audio-input/audio-input.c
+++ b/src/protocols/rdp/channels/audio-input/audio-input.c
@@ -40,7 +40,7 @@
  * number of channels, and bytes per sample.
  *
  * @param mimetype
- *     The raw auduio mimetype to parse.
+ *     The raw audio mimetype to parse.
  *
  * @param rate
  *     A pointer to an int where the sample rate for the PCM format described


### PR DESCRIPTION
I have just fixed one typo mistake in the following path:
**src/protocols/rdp/channels/audio-input/audio-input.c**