### PR TITLE
GUACAMOLE-141: Implement full support for keyboard-interactive authentication method.

### DIFF
--- a/src/common-ssh/common-ssh/ssh.h
+++ b/src/common-ssh/common-ssh/ssh.h
@@ -20,6 +20,8 @@
 #ifndef GUAC_COMMON_SSH_H
 #define GUAC_COMMON_SSH_H
 
+#include <stdbool.h>
+
 #include "user.h"
 
 #include <guacamole/client.h>
@@ -35,12 +37,15 @@
  * @param cred_name
  *     The name of the credential being requested, which will be shared
  *     with the client in order to generate a meaningful prompt.
+ *
+ * @param echo
+ *     Should echo be enabled?
  * 
  * @return
  *     A newly-allocated string containing the credentials provided by
  *     the user, which must be freed by a call to free().
  */
-typedef char* guac_ssh_credential_handler(guac_client* client, char* cred_name);
+typedef char* guac_ssh_credential_handler(guac_client* client, char* cred_name, bool echo);
 
 /**
  * An SSH session, backed by libssh2 and associated with a particular

--- a/src/common-ssh/ssh.c
+++ b/src/common-ssh/ssh.c
@@ -223,9 +223,8 @@ static int guac_common_ssh_sign_callback(LIBSSH2_SESSION* session,
 }
 
 /**
- * Callback for the keyboard-interactive authentication method. Currently
- * supports just one prompt for the password. This callback is invoked as
- * needed to fullfill a call to libssh2_userauth_keyboard_interactive().
+ * Callback for the keyboard-interactive authentication method. This callback is
+ * invoked as needed to fullfill a call to libssh2_userauth_keyboard_interactive().
  *
  * @param name
  *     An arbitrary name which should be printed to the terminal for the
@@ -243,8 +242,7 @@ static int guac_common_ssh_sign_callback(LIBSSH2_SESSION* session,
  *
  * @param num_prompts
  *     The number of keyboard-interactive prompts for which responses are
- *     requested. This callback currently only supports one prompt, and assumes
- *     that this prompt is requesting the password.
+ *     requested.
  *
  * @param prompts
  *     An array of all keyboard-interactive prompts for which responses are
@@ -267,22 +265,16 @@ static void guac_common_ssh_kbd_callback(const char *name, int name_len,
 
     guac_common_ssh_session* common_session =
         (guac_common_ssh_session*) *abstract;
-
     guac_client* client = common_session->client;
+    int i;
 
-    /* Send password if only one prompt */
-    if (num_prompts == 1) {
-        char* password = common_session->user->password;
-        responses[0].text = strdup(password);
-        responses[0].length = strlen(password);
+    for (i = 0; i < num_prompts; i++) {
+        char* response;
+
+        response = common_session->credential_handler(client, prompts[i].text, prompts[i].echo);
+        responses[i].text = response;
+        responses[i].length = strlen(response);
     }
-
-    /* If more than one prompt, a single password is not enough */
-    else
-        guac_client_log(client, GUAC_LOG_WARNING,
-                "Unsupported number of keyboard-interactive prompts: %i",
-                num_prompts);
-
 }
 
 /**
@@ -358,15 +350,39 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
 
     }
 
-    /* Attempt authentication with username + password. */
-    if (user->password == NULL && common_session->credential_handler)
-            user->password = common_session->credential_handler(client, "Password: ");
-    
-    /* Authenticate with password, if provided */
-    if (user->password != NULL) {
+    /* Check if keyboard-interactive auth is supported on the server */
+    if (strstr(user_authlist, "keyboard-interactive") != NULL &&
+        common_session->credential_handler != NULL) {
 
-        /* Check if password auth is supported on the server */
-        if (strstr(user_authlist, "password") != NULL) {
+        /* Attempt keyboard-interactive authentication */
+        if (libssh2_userauth_keyboard_interactive(session, user->username,
+                    &guac_common_ssh_kbd_callback)) {
+
+            /* Abort on failure */
+            char* error_message;
+            libssh2_session_last_error(session, &error_message, NULL, 0);
+            guac_client_abort(client,
+                    GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
+                    "Keyboard-interactive authentication failed: %s",
+                    error_message);
+
+            return 1;
+        }
+
+        /* Keyboard-interactive authentication succeeded */
+        return 0;
+
+    }
+
+    /* Check if password auth is supported on the server */
+    if (strstr(user_authlist, "password") != NULL) {
+
+        /* Attempt authentication with username + password. */
+        if (common_session->credential_handler)
+            user->password = common_session->credential_handler(client, "Password: ", false);
+
+        /* Authenticate with password, if provided */
+        if (user->password != NULL) {
 
             /* Attempt password authentication */
             if (libssh2_userauth_password(session, user->username, user->password)) {
@@ -385,41 +401,12 @@ static int guac_common_ssh_authenticate(guac_common_ssh_session* common_session)
             return 0;
 
         }
-
-        /* Check if keyboard-interactive auth is supported on the server */
-        if (strstr(user_authlist, "keyboard-interactive") != NULL) {
-
-            /* Attempt keyboard-interactive auth using provided password */
-            if (libssh2_userauth_keyboard_interactive(session, user->username,
-                        &guac_common_ssh_kbd_callback)) {
-
-                /* Abort on failure */
-                char* error_message;
-                libssh2_session_last_error(session, &error_message, NULL, 0);
-                guac_client_abort(client,
-                        GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
-                        "Keyboard-interactive authentication failed: %s",
-                        error_message);
-
-                return 1;
-            }
-
-            /* Keyboard-interactive authentication succeeded */
-            return 0;
-
-        }
-
-        /* No known authentication types available */
-        guac_client_abort(client, GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
-                "Password and keyboard-interactive authentication are not "
-                "supported by the SSH server");
-        return 1;
-
     }
 
-    /* No credentials provided */
+    /* No known authentication types available */
     guac_client_abort(client, GUAC_PROTOCOL_STATUS_CLIENT_UNAUTHORIZED,
-            "SSH authentication requires either a private key or a password.");
+            "Password and keyboard-interactive authentication methods are not "
+            "supported by the SSH server");
     return 1;
 
 }

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -156,14 +156,17 @@ static guac_common_ssh_user* guac_ssh_get_user(guac_client* client) {
  * @param cred_name
  *     The prompt text to display to the screen when prompting for the
  *     additional credentials.
+ *
+ * @param echo
+ *     Should echo be enabled?
  * 
  * @return 
  *     The string of credentials gathered from the user.
  */
-static char* guac_ssh_get_credential(guac_client *client, char* cred_name) {
+static char* guac_ssh_get_credential(guac_client *client, char* cred_name, bool echo) {
 
     guac_ssh_client* ssh_client = (guac_ssh_client*) client->data;
-    return guac_terminal_prompt(ssh_client->term, cred_name, false);
+    return guac_terminal_prompt(ssh_client->term, cred_name, echo);
     
 }
 


### PR DESCRIPTION
The support includes:
- Multiple prompts and responses within a single SSH_MSG_USERAUTH_INFO_REQUEST.
- Multiple SSH_MSG_USERAUTH_INFO_REQUEST / SSH_MSG_USERAUTH_INFO_RESPONSE
  exchanges.
- Echo-enabled prompts.

This change should allow guacamole to authenticate guacamole against SSH server that require multifactor authentication.