### PR TITLE
GUACAMOLE-1181: Rely on automatic freeing of wStream only for FreeRDP 2.0.0-rc3 through 2.0.0-rc4.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -623,7 +623,7 @@ then
 
 fi
 
-# Variation in memory internal allocation/free behavior
+# Variation in memory internal allocation/free behavior for bitmaps
 if test "x${have_freerdp2}" = "xyes"
 then
 
@@ -646,6 +646,29 @@ then
     [AC_MSG_RESULT([no])])
 
 fi
+
+# Variation in memory internal allocation/free behavior for channel streams
+if test "x${have_freerdp2}" = "xyes"
+then
+
+    # FreeRDP 2.0.0-rc3 through 2.0.0-rc4 automatically free the wStream
+    # provided to pVirtualChannelWriteEx(). This changed in commit 1b78b59, and
+    # implementations must manually free the wStream after it is no longer
+    # needed (after the write is complete or cancelled).
+    AC_MSG_CHECKING([whether pVirtualChannelWriteEx() frees the wStream upon completion])
+    AC_EGREP_CPP([\"2\\.0\\.0-(rc|dev)[3-4]\"], [
+
+        #include <freerdp/version.h>
+        FREERDP_VERSION_FULL
+
+    ],
+    [AC_MSG_RESULT([yes])]
+    [AC_DEFINE([FREERDP_SVC_CORE_FREES_WSTREAM],,
+               [Whether pVirtualChannelWriteEx() frees the wStream upon completion])],
+    [AC_MSG_RESULT([no])])
+
+fi
+
 
 # Glyph callback variants
 if test "x${have_freerdp2}" = "xyes"

--- a/configure.ac
+++ b/configure.ac
@@ -623,6 +623,34 @@ then
 
 fi
 
+# It is difficult or impossible to test for variations in FreeRDP behavior in
+# between releases, as the change in behavior may not (yet) be associated with
+# a corresponding change in version number and may not have any detectable
+# effect on the FreeRDP API
+if test "x${have_freerdp2}" = "xyes"
+then
+
+    AC_MSG_CHECKING([whether FreeRDP appears to be a development version])
+    AC_EGREP_CPP([\"[0-9]+\\.[0-9]+\\.[0-9]+(-rc[0-9]+)?\"], [
+
+        #include <freerdp/version.h>
+        FREERDP_VERSION_FULL
+
+    ],
+    [AC_MSG_RESULT([no])],
+    [AC_MSG_RESULT([yes])]
+    [AC_MSG_WARN([
+  --------------------------------------------
+   You are building against a development version of FreeRDP. Non-release
+   versions of FreeRDP may have differences in behavior that are impossible to
+   check for at build time. This may result in memory leaks or other strange
+   behavior.
+
+   *** PLEASE USE A RELEASED VERSION OF FREERDP IF POSSIBLE ***
+  --------------------------------------------])])
+
+fi
+
 # Variation in memory internal allocation/free behavior for bitmaps
 if test "x${have_freerdp2}" = "xyes"
 then

--- a/src/protocols/rdp/channels/common-svc.c
+++ b/src/protocols/rdp/channels/common-svc.c
@@ -89,10 +89,9 @@ void guac_rdp_common_svc_write(guac_rdp_common_svc* svc,
         return;
     }
 
-    /* NOTE: Data sent via pVirtualChannelWriteEx MUST always be dynamically
-     * allocated, as it will be automatically freed using free(). If provided,
-     * the last parameter (user data) MUST be a pointer to a wStream, as it
-     * will automatically be freed by FreeRDP using Stream_Free() */
+    /* NOTE: The wStream sent via pVirtualChannelWriteEx will automatically be
+     * freed later with a call to Stream_Free() when handling the
+     * corresponding write cancel/completion event. */
     svc->_entry_points.pVirtualChannelWriteEx(svc->_init_handle,
             svc->_open_handle, Stream_Buffer(output_stream),
             Stream_GetPosition(output_stream), output_stream);

--- a/src/protocols/rdp/plugins/guac-common-svc/guac-common-svc.c
+++ b/src/protocols/rdp/plugins/guac-common-svc/guac-common-svc.c
@@ -28,10 +28,8 @@
 #include <stdlib.h>
 
 /**
- * Event handler for events which deal with data transmitted over an open SVC.
- * This specific implementation of the event handler currently handles only the
- * CHANNEL_EVENT_DATA_RECEIVED event, delegating actual handling of that event
- * to guac_rdp_common_svc_process_receive().
+ * Event handler for events which deal with data transmitted over an open SVC,
+ * including receipt of inbound data and completion of outbound writes.
  *
  * The FreeRDP requirements for this function follow those of the
  * VirtualChannelOpenEventEx callback defined within Microsoft's RDP API:
@@ -82,6 +80,13 @@
 static VOID guac_rdp_common_svc_handle_open_event(LPVOID user_param,
         DWORD open_handle, UINT event, LPVOID data, UINT32 data_length,
         UINT32 total_length, UINT32 data_flags) {
+
+    /* Free stream data after send is complete */
+    if ((event == CHANNEL_EVENT_WRITE_CANCELLED
+            || event == CHANNEL_EVENT_WRITE_COMPLETE) && data != NULL) {
+        Stream_Free((wStream*) data, TRUE);
+        return;
+    }
 
     /* Ignore all events except for received data */
     if (event != CHANNEL_EVENT_DATA_RECEIVED)

--- a/src/protocols/rdp/plugins/guac-common-svc/guac-common-svc.c
+++ b/src/protocols/rdp/plugins/guac-common-svc/guac-common-svc.c
@@ -81,12 +81,14 @@ static VOID guac_rdp_common_svc_handle_open_event(LPVOID user_param,
         DWORD open_handle, UINT event, LPVOID data, UINT32 data_length,
         UINT32 total_length, UINT32 data_flags) {
 
+#ifndef FREERDP_SVC_CORE_FREES_WSTREAM
     /* Free stream data after send is complete */
     if ((event == CHANNEL_EVENT_WRITE_CANCELLED
             || event == CHANNEL_EVENT_WRITE_COMPLETE) && data != NULL) {
         Stream_Free((wStream*) data, TRUE);
         return;
     }
+#endif
 
     /* Ignore all events except for received data */
     if (event != CHANNEL_EVENT_DATA_RECEIVED)


### PR DESCRIPTION
This change automatically frees a sent `wStream` after the corresponding write has been completed or cancelled. As FreeRDP will automatically free this `wStream` for us from 2.0.0-rc3 through 2.0.0-rc4 (and manually doing so would result in a double-free), this behavior is controlled by a macro and compile-time checks.

Since the internal behavior of FreeRDP generally cannot be detected outside version number checks, and version number checks are only a reliable indication of behavior for actual releases and RCs, I have also added a warning that will be displayed at build time if a development version of FreeRDP is being used:

```
checking whether FreeRDP appears to be a development version... yes
configure: WARNING:
  --------------------------------------------
   You are building against a development version of FreeRDP. Non-release
   versions of FreeRDP may have differences in behavior that are impossible to
   check for at build time. This may result in memory leaks or other strange
   behavior.

   *** PLEASE USE A RELEASED VERSION OF FREERDP IF POSSIBLE ***
  --------------------------------------------
```

Testing with various versions of FreeRDP:

| Version tag | **Without** manual `Stream_Free()` | **With** manual `Stream_Free()`   |
| ----------- | ---------------------------------- | --------------------------------- |
| `2.0.0-rc0` | Leaks `wStream`                    | **No leaks** 👍                   |
| `2.0.0-rc1` | Leaks `wStream`                    | **No leaks** 👍                   |
| `2.0.0-rc2` | Leaks `wStream`                    | **No leaks** 👍                   |
| `2.0.0-rc3` | Unable to test (fails to connect)  | Unable to test (fails to connect) |
| `2.0.0-rc4` | **No leaks** 👍                    | Segfault / double-free            |
| `2.0.0`     | Leaks `wStream`                    | **No leaks** 👍                   |
| `2.1.0`     | Leaks `wStream`                    | **No leaks** 👍                   |
| `2.2.0`     | Leaks `wStream`                    | **No leaks** 👍                    |

With `configure` automatically selecting between manually freeing streams and relying on FreeRDP to automatically free them, it should be no leaks and no errors across the board.