### PR TITLE
GUACAMOLE-1225: fix simple typo, verfying -> verifying, in code documentation

### DIFF
--- a/src/libguac/tests/parser/read.c
+++ b/src/libguac/tests/parser/read.c
@@ -72,7 +72,7 @@ static void write_instructions(int fd) {
 
 /**
  * Reads and parses instructions from the given file descriptor using a
- * guac_socket and guac_parser, verfying that those instructions match the
+ * guac_socket and guac_parser, verifying that those instructions match the
  * series of Guacamole instructions expected to be written by
  * write_instructions(). The given file descriptor is automatically closed as a
  * result of calling this function.

--- a/src/libguac/tests/socket/fd_send_instruction.c
+++ b/src/libguac/tests/socket/fd_send_instruction.c
@@ -64,7 +64,7 @@ static void write_instructions(int fd) {
 
 /**
  * Reads raw bytes from the given file descriptor until no further bytes
- * remain, verfying that those bytes represent the series of Guacamole
+ * remain, verifying that those bytes represent the series of Guacamole
  * instructions expected to be written by write_instructions(). The given
  * file descriptor is automatically closed as a result of calling this
  * function.

--- a/src/libguac/tests/socket/nested_send_instruction.c
+++ b/src/libguac/tests/socket/nested_send_instruction.c
@@ -75,7 +75,7 @@ static void write_instructions(int fd) {
 
 /**
  * Reads raw bytes from the given file descriptor until no further bytes
- * remain, verfying that those bytes represent the series of Guacamole
+ * remain, verifying that those bytes represent the series of Guacamole
  * instructions expected to be written by write_instructions(). The given
  * file descriptor is automatically closed as a result of calling this
  * function.


### PR DESCRIPTION
There is a small typo in src/libguac/tests/parser/read.c, src/libguac/tests/socket/fd_send_instruction.c, src/libguac/tests/socket/nested_send_instruction.c.

Should read `verifying` rather than `verfying`.

Fixes https://issues.apache.org/jira/browse/GUACAMOLE-1225