### PR TITLE
GUACAMOLE-1110: Create a proper dedicated service group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,9 @@ HEALTHCHECK --interval=5m --timeout=5s CMD nc -z 127.0.0.1 4822 || exit 1
 
 # Create a new user guacd
 ARG UID=1000
-RUN useradd --system --create-home --shell /usr/sbin/nologin --uid $UID --no-user-group guacd
+ARG GID=1000
+RUN groupadd --gid $GID guacd
+RUN useradd --system --create-home --shell /usr/sbin/nologin --uid $UID --gid $GID guacd
 
 # Run with user guacd
 USER guacd


### PR DESCRIPTION
Hi,

This PR is a slight modification to #292 which has been merged in `staging/1.3.0` (thus my PR against this branch).
It creates a dedicated group for the `guacd` service user.
So that it is not assigned to the default `users` group, among other possible users...

Thank you 👍