### PR TITLE
GUACAMOLE-1227: Build support for generic VNC credentials only if supported by libvncclient.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -573,6 +573,34 @@ then
 fi
 
 #
+# Generic credential support within libVNCServer (authentication beyond
+# basic, standard VNC passwords)
+#
+
+if test "x${have_libvncserver}" = "xyes"
+then
+
+    have_vnc_creds=yes
+    AC_CHECK_MEMBERS([rfbClient.GetCredential],
+                     [], [have_vnc_creds=no],
+                     [[#include <rfb/rfbclient.h>]])
+
+    if test "x${have_vnc_creds}" = "xno"
+    then
+        AC_MSG_WARN([
+      --------------------------------------------
+       No generic credential support found in libvncclient.
+       VNC authentication support will be limited to passwords.
+      --------------------------------------------])
+    else
+        AC_DEFINE([ENABLE_VNC_GENERIC_CREDENTIALS],,
+                  [Whether support for generic VNC credentials is available.])
+    fi
+
+fi
+
+
+#
 # FreeRDP 2 (libfreerdp2, libfreerdp-client2, and libwinpr2)
 #
 

--- a/src/protocols/vnc/auth.c
+++ b/src/protocols/vnc/auth.c
@@ -63,6 +63,7 @@ char* guac_vnc_get_password(rfbClient* client) {
     
 }
 
+#ifdef ENABLE_VNC_GENERIC_CREDENTIALS
 rfbCredential* guac_vnc_get_credentials(rfbClient* client, int credentialType) {
     
     guac_client* gc = rfbClientGetClientData(client, GUAC_VNC_CLIENT_KEY);
@@ -117,3 +118,4 @@ rfbCredential* guac_vnc_get_credentials(rfbClient* client, int credentialType) {
     return NULL;
     
 }
+#endif

--- a/src/protocols/vnc/auth.h
+++ b/src/protocols/vnc/auth.h
@@ -38,6 +38,7 @@
  */
 char* guac_vnc_get_password(rfbClient* client);
 
+#ifdef ENABLE_VNC_GENERIC_CREDENTIALS
 /**
  * Callback which is invoked by libVNCServer when it needs to read the user's
  * VNC credentials.  The credentials are stored in the connection settings,
@@ -55,6 +56,7 @@ char* guac_vnc_get_password(rfbClient* client);
  *     The rfbCredential object that contains the required credentials.
  */
 rfbCredential* guac_vnc_get_credentials(rfbClient* client, int credentialType);
+#endif
 
 #endif
 

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -154,8 +154,10 @@ rfbClient* guac_vnc_get_client(guac_client* client) {
 
     }
 
+#ifdef ENABLE_VNC_GENERIC_CREDENTIALS
     /* Authentication */
     rfb_client->GetCredential = guac_vnc_get_credentials;
+#endif
     
     /* Password */
     rfb_client->GetPassword = guac_vnc_get_password;


### PR DESCRIPTION
This change alters the VNC build such that support for additional authentication mechanisms is built only if libvncclient supports those mechanisms. If the necessary support is not present, only password authentication will be usable.