### PR TITLE
GUACAMOLE-1242: Move "connection closed" log message to debug level.

### DIFF
--- a/src/guacd/log.c
+++ b/src/guacd/log.c
@@ -133,7 +133,7 @@ void guacd_log_guac_error(guac_client_log_level level, const char* message) {
 void guacd_log_handshake_failure() {
 
     if (guac_error == GUAC_STATUS_CLOSED)
-        guacd_log(GUAC_LOG_INFO,
+        guacd_log(GUAC_LOG_DEBUG,
                 "Guacamole connection closed during handshake");
     else if (guac_error == GUAC_STATUS_PROTOCOL_ERROR)
         guacd_log(GUAC_LOG_ERROR,

--- a/src/libguac/user-handshake.c
+++ b/src/libguac/user-handshake.c
@@ -100,7 +100,7 @@ static void guac_user_log_guac_error(guac_user* user,
 static void guac_user_log_handshake_failure(guac_user* user) {
 
     if (guac_error == GUAC_STATUS_CLOSED)
-        guac_user_log(user, GUAC_LOG_INFO,
+        guac_user_log(user, GUAC_LOG_DEBUG,
                 "Guacamole connection closed during handshake");
     else if (guac_error == GUAC_STATUS_PROTOCOL_ERROR)
         guac_user_log(user, GUAC_LOG_ERROR,


### PR DESCRIPTION
It is expected under normal circumstances that the connection may be abruptly closed, including during the handshake. For example, this will commonly occur when a TCP load balancer is performing a simple service health check.

An message noting that the connection has been closed during the Guacamole protocol handshake is really only of benefit when debugging, where that information may provide useful context. If not debugging, the message amounts to log noise.