### PR TITLE
GUACAMOLE-1241: Avoid double-free when building against FreeRDP development snapshot.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -627,7 +627,13 @@ fi
 # between releases, as the change in behavior may not (yet) be associated with
 # a corresponding change in version number and may not have any detectable
 # effect on the FreeRDP API
-if test "x${have_freerdp2}" = "xyes"
+
+AC_ARG_ENABLE(allow_freerdp_snapshots,
+              [AS_HELP_STRING([--enable-allow-freerdp-snapshots],
+                              [allow building against unknown development snapshots of FreeRDP])
+              ],allow_freerdp_snapshots=yes)
+
+if test "x${have_freerdp2}" = "xyes" -a "x${allow_freerdp_snapshots}" != "xyes"
 then
 
     AC_MSG_CHECKING([whether FreeRDP appears to be a development version])
@@ -639,7 +645,7 @@ then
     ],
     [AC_MSG_RESULT([no])],
     [AC_MSG_RESULT([yes])]
-    [AC_MSG_WARN([
+    [AC_MSG_ERROR([
   --------------------------------------------
    You are building against a development version of FreeRDP. Non-release
    versions of FreeRDP may have differences in behavior that are impossible to
@@ -647,6 +653,9 @@ then
    behavior.
 
    *** PLEASE USE A RELEASED VERSION OF FREERDP IF POSSIBLE ***
+
+   If you are ABSOLUTELY CERTAIN that building against this version of FreeRDP
+   is OK, rerun configure with the --enable-allow-freerdp-snapshots
   --------------------------------------------])])
 
 fi


### PR DESCRIPTION
Currently, the Docker image for guacd built from the `staging/1.3.0` branch produces the following double-free error:

```
...
guacd[24698]: INFO:	Loading keymap "base"
guacd[24698]: INFO:	Loading keymap "en-us-qwerty"
guacd[24698]: INFO:	Connected to RDPDR 1.13 as client 0x0005
free(): double free detected in tcache 2
guacd[6]: INFO:	Connection "$e6955582-c6f2-4912-a4bd-a3ffee002cd1" removed.
```

This is because the Docker image is built from Debian stable, and the version of FreeRDP currently packaged by Debian stable is not a FreeRDP release but rather a development snapshot ([commit 2693389](https://github.com/FreeRDP/FreeRDP/commit/2693389a103394e035edc2a01055ca2c9ccccb21)) from after 2.0.0-rc4 but before 2.0.0. In that span of time, the handling of memory within FreeRDP changed, and while the behavior of 2.0.0 and 2.0.0-rc4 are known, there is no way for Guacamole to know the behavior of an arbitrary commit _between_ those versions.

To correct this, these changes:

* Change the build warning regarding FreeRDP development snapshots to a fatal error, requiring the user to specify `--enable-allow-freerdp-snapshots` if they are _absolutely certain_ that using a development snapshot is OK.
* Switch over to the Debian "stable-backports" repository (which has a more recent version of the FreeRDP package that is cut from the 2.2.0 release).

🎄 