### PR TITLE
GUACAMOLE-1133: initialize GCrypt in VNC protocol prior to client start-up

### DIFF
--- a/src/common-ssh/ssh.c
+++ b/src/common-ssh/ssh.c
@@ -140,11 +140,21 @@ static void guac_common_ssh_openssl_free_locks(int count) {
 int guac_common_ssh_init(guac_client* client) {
 
 #ifdef LIBSSH2_USES_GCRYPT
-    /* Init threadsafety in libgcrypt */
-    gcry_control(GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
-    if (!gcry_check_version(GCRYPT_VERSION)) {
-        guac_client_log(client, GUAC_LOG_ERROR, "libgcrypt version mismatch.");
-        return 1;
+    
+    if (!gcry_control(GCRYCTL_INITIALIZATION_FINISHED_P)) {
+    
+        /* Init threadsafety in libgcrypt */
+        gcry_control(GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
+        
+        /* Initialize GCrypt */
+        if (!gcry_check_version(GCRYPT_VERSION)) {
+            guac_client_log(client, GUAC_LOG_ERROR, "libgcrypt version mismatch.");
+            return 1;
+        }
+
+        /* Mark initialization as completed. */
+        gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
+    
     }
 #endif
 

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -48,11 +48,21 @@
 #include <guacamole/timestamp.h>
 #include <guacamole/wol.h>
 #include <rfb/rfbclient.h>
+#include <rfb/rfbconfig.h>
 #include <rfb/rfbproto.h>
+
+#ifdef LIBVNCSERVER_WITH_CLIENT_GCRYPT
+#include <errno.h>
+#include <gcrypt.h>
+#endif
 
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+
+#ifdef LIBVNCSERVER_WITH_CLIENT_GCRYPT
+GCRY_THREAD_OPTION_PTHREAD_IMPL;
+#endif
 
 char* GUAC_VNC_CLIENT_KEY = "GUAC_VNC";
 
@@ -133,6 +143,27 @@ rfbClient* guac_vnc_get_client(guac_client* client) {
     /* TLS Locking and Unlocking */
     rfb_client->LockWriteToTLS = guac_vnc_lock_write_to_tls;
     rfb_client->UnlockWriteToTLS = guac_vnc_unlock_write_to_tls;
+#endif
+    
+#ifdef LIBVNCSERVER_WITH_CLIENT_GCRYPT
+    
+    /* Check if GCrypt is initialized, do it if not. */
+    if (!gcry_control(GCRYCTL_INITIALIZATION_FINISHED_P)) {
+    
+        guac_client_log(client, GUAC_LOG_DEBUG, "GCrypt initialization started.");
+
+        /* Initialize thread control. */
+        gcry_control(GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
+
+        /* Basic GCrypt library initialization. */
+        gcry_check_version(NULL);
+
+        /* Mark initialization as completed. */
+        gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
+        guac_client_log(client, GUAC_LOG_DEBUG, "GCrypt initialization completed.");
+    
+    }
+    
 #endif
 
     /* Do not handle clipboard and local cursor if read-only */


### PR DESCRIPTION
This small change does some initialization on the GCrypt library used by libvncclient prior to the VNC client start-up. In my testing this looks to resolve the GUACAMOLE-1133 issue, which deals with failures to connect to Apple Remote Desktop systems. Further testing would be greatly appreciated. I'm also not 100% sure what options we should be using to initialize GCrypt - this is a very basic initialization of the library and then some secure memory.