### PR TITLE
Force fast WebP compression

### DIFF
--- a/src/common/surface.c
+++ b/src/common/surface.c
@@ -557,14 +557,8 @@ static int __guac_common_surface_should_use_webp(guac_common_surface* surface,
     if (!guac_client_supports_webp(surface->client))
         return 0;
 
-    /* Calculate the average framerate for the given rect */
-    int framerate = __guac_common_surface_calculate_framerate(surface, rect);
-
-    /* WebP is preferred if:
-     * - frame rate is high enough
-     * - PNG is not more optimal based on image contents */
-    return framerate >= GUAC_COMMON_SURFACE_JPEG_FRAMERATE
-        && __guac_common_surface_png_optimality(surface, rect) < 0;
+    /* Prefer always WebP */
+    return 1;
 
 }
 

--- a/src/libguac/encode-webp.c
+++ b/src/libguac/encode-webp.c
@@ -192,10 +192,10 @@ int guac_webp_write(guac_socket* socket, guac_stream* stream,
         return -1;
 
     /* Add additional tuning */
-    config.lossless = lossless;
-    config.quality = quality;
-    config.thread_level = 1; /* Multi threaded */
-    config.method = 2; /* Compression method (0=fast/larger, 6=slow/smaller) */
+    config.lossless = 1; /* force lossless */
+    config.quality = 30.f; /* prefer fast encoding over size */
+    config.thread_level = 0; /* Disable Multi thread */
+    config.method = 0; /* Compression method (0=fast/larger, 6=slow/smaller) */
 
     /* Validate configuration */
     WebPValidateConfig(&config);


### PR DESCRIPTION
This PR is based on re-evaluating WebP lossless and is meant for testing and opening a discussion. The background is the question and response (by @mike-jumper  and @necouchman ) here: http://mail-archives.apache.org/mod_mbox/guacamole-dev/202008.mbox/browser

Based on our testing, using a very-fast WebP lossless compression significantly improves the responsiveness (e.g. scrolling, moving windows around) of Guacamole compared to the default settings. This was tested using libwebp > 0.6.1. 

In our configuration there is little latency between the Remote Desktop server and the Guacamole gateway, so most of the latency was due to the compression time for PNG. With using fast WebP this is much improved. 

It might be possible that our results differ from the original evaluation of WebP due to network bandwith improving faster than compute speed over the last few years. 

Caveat: It might also be the case that if there is much latency between the Remote Desktop server and the Gateway, then this change doesn't have a beneficial effect.

This PR is of course just a suggestion, feel free to discard, however it might be worthwhile to test in different scenarios as per our testing the UX is much improved.