### PR TITLE
GUACAMOLE-1259: Include missing config.h header for sake of conditional Stream_Free().

### DIFF
--- a/src/protocols/rdp/plugins/guac-common-svc/guac-common-svc.c
+++ b/src/protocols/rdp/plugins/guac-common-svc/guac-common-svc.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include "config.h"
 #include "channels/common-svc.h"
 
 #include <freerdp/svc.h>


### PR DESCRIPTION
The changes introduced by GUACAMOLE-1181 (commit 2c86e20) were made conditional as older versions of FreeRDP will automatically free the `wStream`, resulting in a double-free if we attempt to do so ourselves.

The macro controlling that conditional code is defined within `config.h`, which is missing here. Without that macro, the call to `Stream_Free()` always occurs, and we get a double-free with older FreeRDP.