### PR TITLE
GUACAMOLE-1263: Mark freed memory as freed prior to calling rfbClientCleanup().

### DIFF
--- a/src/protocols/vnc/client.c
+++ b/src/protocols/vnc/client.c
@@ -77,12 +77,27 @@ int guac_vnc_client_free_handler(guac_client* client) {
         /* Wait for client thread to finish */
         pthread_join(vnc_client->client_thread, NULL);
 
-        /* Free memory not free'd by libvncclient's rfbClientCleanup() */
-        if (rfb_client->frameBuffer != NULL) free(rfb_client->frameBuffer);
-        if (rfb_client->raw_buffer != NULL) free(rfb_client->raw_buffer);
-        if (rfb_client->rcSource != NULL) free(rfb_client->rcSource);
+        /* Free memory that may not be free'd by libvncclient's
+         * rfbClientCleanup() prior to libvncclient 0.9.12 */
 
-        /* Free VNC rfbClientData linked list (not free'd by rfbClientCleanup()) */
+        if (rfb_client->frameBuffer != NULL) {
+            free(rfb_client->frameBuffer);
+            rfb_client->frameBuffer = NULL;
+        }
+
+        if (rfb_client->raw_buffer != NULL) {
+            free(rfb_client->raw_buffer);
+            rfb_client->raw_buffer = NULL;
+        }
+
+        if (rfb_client->rcSource != NULL) {
+            free(rfb_client->rcSource);
+            rfb_client->rcSource = NULL;
+        }
+
+        /* Free VNC rfbClientData linked list (may not be free'd by
+         * rfbClientCleanup(), depending on libvncclient version) */
+
         while (rfb_client->clientData != NULL) {
             rfbClientData* next = rfb_client->clientData->next;
             free(rfb_client->clientData);


### PR DESCRIPTION
Older versions of libvncclient did not free all memory within `rfbClientCleanup()`, but this has been corrected as of their 0.9.12
release. As guacamole-server may well be built against older versions of libvncclient, we can't simply remove the manual `free()` calls, but we should be sure to set any memory that we free ourselves to `NULL` so that `rfbClientCleanup()` does not attempt to free it again.