### PR TITLE
GUACAMOLE-1267: Add VNC setting 'disable-server-input'

### DIFF
--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -91,6 +91,7 @@ const char* GUAC_VNC_CLIENT_ARGS[] = {
     "wol-broadcast-addr",
     "wol-udp-port",
     "wol-wait-time",
+    "disable-server-input",
     NULL
 };
 
@@ -373,6 +374,11 @@ enum VNC_ARGS_IDX {
      */
     IDX_WOL_WAIT_TIME,
 
+    /*
+     * Whether or not to disable the input on the server side. The default is not to disable the input.
+     */
+    IDX_DISABLE_SERVER_INPUT,
+
     VNC_ARGS_COUNT
 };
 
@@ -426,6 +432,11 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
     settings->read_only =
         guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_READ_ONLY, false);
+
+    /* Disable server input */
+    settings->disable_server_input =
+            guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
+                                         IDX_DISABLE_SERVER_INPUT, false);
 
     /* Parse color depth */
     settings->color_depth =

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -300,6 +300,11 @@ typedef struct guac_vnc_settings {
      */
     int wol_wait_time;
 
+    /**
+     * Whether or not to disable the input on the server side.
+     */
+    bool disable_server_input;
+
 } guac_vnc_settings;
 
 /**

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -385,6 +385,17 @@ void* guac_vnc_client_thread(void* data) {
     }
 #endif
 
+    /* Disable remote console (Server input) */
+    if (settings->disable_server_input) {
+        rfbSetServerInputMsg msg;
+        msg.type = rfbSetServerInput;
+        msg.status = 1;
+        msg.pad = 0;
+
+        rfbBool success = WriteToRFBServer(rfb_client, (char*)&msg, sz_rfbSetServerInputMsg);
+        guac_client_log(client, GUAC_LOG_DEBUG, "%s send request to disable server input", success ? "Successfully" : "Failed to");
+    }
+
     /* Set remaining client data */
     vnc_client->rfb_client = rfb_client;
 


### PR DESCRIPTION
Add a new VNC setting 'disable-remote-input' which attempts to turn the remote input off when set to true.