### PR TITLE
GUACAMOLE-1268 rename recordings after the session has finished

### DIFF
--- a/src/common/recording.c
+++ b/src/common/recording.c
@@ -167,6 +167,8 @@ guac_common_recording* guac_common_recording_create(guac_client* client,
     recording->include_mouse = include_mouse;
     recording->include_keys = include_keys;
 
+    guac_socket_set_filename(recording->socket, filename);
+
     /* Replace client socket with wrapped recording socket only if including
      * output within the recording */
     if (include_output)

--- a/src/libguac/guacamole/socket.h
+++ b/src/libguac/guacamole/socket.h
@@ -173,6 +173,14 @@ void guac_socket_instruction_end(guac_socket* socket);
 guac_socket* guac_socket_open(int fd);
 
 /**
+ * Sets the filename of the recording associated with this socket.
+ *
+ * @param socket the socket of which to set the filename on
+ * @param filename the filename of the recording
+ */
+void guac_socket_set_filename(guac_socket* socket, char* filename);
+
+/**
  * Allocates and initializes a new guac_socket which writes all data via
  * nest instructions to the given existing, open guac_socket. Freeing the
  * returned guac_socket has no effect on the underlying, nested guac_socket.


### PR DESCRIPTION
Apply the suffix ".guac" to the recording files so that scripts can pick up finished session recordings.