### PR TITLE
GUACAMOLE-1133: Add build check for headers when libvncserver includes gcrypt support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ ARG BUILD_DEPENDENCIES="              \
         freerdp2-dev                  \
         gcc                           \
         libcairo2-dev                 \
+        libgcrypt-dev                 \
         libjpeg62-turbo-dev           \
         libossp-uuid-dev              \
         libpango1.0-dev               \

--- a/configure.ac
+++ b/configure.ac
@@ -519,6 +519,27 @@ then
     AC_CHECK_LIB([vncclient], [rfbInitClient], [VNC_LIBS="$VNC_LIBS -lvncclient"], [have_libvncserver=no])
 fi
 
+#
+# Underlying libvncserver usage of gcrypt
+#
+
+if test "x${have_libvncserver}" = "xyes"
+then
+
+    # Whether libvncserver was built against libgcrypt
+    AC_CHECK_DECL([LIBVNCSERVER_WITH_CLIENT_GCRYPT],
+                         [AC_CHECK_HEADER(gcrypt.h,,
+                                          [AC_MSG_WARN([
+  --------------------------------------------
+   libvncserver appears to be built against
+   libgcrypt, but the libgcrypt headers
+   could not be found. VNC will be disabled.
+  --------------------------------------------])
+                                           have_libvncserver=no])],,
+                    [[#include <rfb/rfbconfig.h>]])
+
+fi
+
 AM_CONDITIONAL([ENABLE_VNC], [test "x${have_libvncserver}" = "xyes"])
 AC_SUBST(VNC_LIBS)
 


### PR DESCRIPTION
Copied the check from libssh2 for gcrypt support and adapted it for libvncserver. Should fix the current build issues, and I also added Dockerfile update to include `libgcrypt-dev` in the build requirements.