### PR TITLE
GUACAMOLE-1302: Add support for forcing lossless compression on VNC/RDP connections.

### DIFF
--- a/src/common/common/display.h
+++ b/src/common/common/display.h
@@ -100,6 +100,13 @@ typedef struct guac_common_display {
     guac_common_display_layer* buffers;
 
     /**
+     * Non-zero if all graphical updates for this display should use lossless
+     * compression, 0 otherwise. By default, newly-created displays will use
+     * lossy compression when heuristics determine it is appropriate.
+     */
+    int lossless;
+
+    /**
      * Mutex which is locked internally when access to the display must be
      * synchronized. All public functions of guac_common_display should be
      * considered threadsafe.
@@ -227,6 +234,28 @@ void guac_common_display_free_layer(guac_common_display* display,
  */
 void guac_common_display_free_buffer(guac_common_display* display,
         guac_common_display_layer* display_buffer);
+
+/**
+ * Sets the overall lossless compression policy of the given display to the
+ * given value, affecting all current and future layers/buffers maintained by
+ * the display. By default, newly-created displays will use lossy compression
+ * for graphical updates when heuristics determine that doing so is
+ * appropriate. Specifying a non-zero value here will force all graphical
+ * updates to always use lossless compression, whereas specifying zero will
+ * restore the default policy.
+ *
+ * Note that this can also be adjusted on a per-layer / per-buffer basis with
+ * guac_common_surface_set_lossless().
+ *
+ * @param display
+ *     The display to modify.
+ *
+ * @param lossless
+ *     Non-zero if all graphical updates for this display should use lossless
+ *     compression, 0 otherwise.
+ */
+void guac_common_display_set_lossless(guac_common_display* display,
+        int lossless);
 
 #endif
 

--- a/src/common/common/surface.h
+++ b/src/common/common/surface.h
@@ -127,6 +127,13 @@ typedef struct guac_common_surface {
     int touches;
 
     /**
+     * Non-zero if all graphical updates for this surface should use lossless
+     * compression, 0 otherwise. By default, newly-created surfaces will use
+     * lossy compression when heuristics determine it is appropriate.
+     */
+    int lossless;
+
+    /**
      * The X coordinate of the upper-left corner of this layer, in pixels,
      * relative to its parent layer. This is only applicable to visible
      * (non-buffer) layers which are not the default layer.
@@ -509,6 +516,24 @@ void guac_common_surface_dup(guac_common_surface* surface, guac_user* user,
  */
 void guac_common_surface_set_multitouch(guac_common_surface* surface,
         int touches);
+
+/**
+ * Sets the lossless compression policy of the given surface to the given
+ * value. By default, newly-created surfaces will use lossy compression for
+ * graphical updates when heuristics determine that doing so is appropriate.
+ * Specifying a non-zero value here will force all graphical updates to always
+ * use lossless compression, whereas specifying zero will restore the default
+ * policy.
+ *
+ * @param surface
+ *     The surface to modify.
+ *
+ * @param lossless
+ *     Non-zero if all graphical updates for this surface should use lossless
+ *     compression, 0 otherwise.
+ */
+void guac_common_surface_set_lossless(guac_common_surface* surface,
+        int lossless);
 
 #endif
 

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -435,6 +435,10 @@ static int guac_rdp_handle_connection(guac_client* client) {
             rdp_client->settings->width,
             rdp_client->settings->height);
 
+    /* Use lossless compression only if requested (otherwise, use default
+     * heuristics) */
+    guac_common_display_set_lossless(rdp_client->display, settings->lossless);
+
     rdp_client->current_surface = rdp_client->display->default_surface;
 
     rdp_client->available_svc = guac_common_list_alloc();

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -128,6 +128,8 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
     "wol-broadcast-addr",
     "wol-udp-port",
     "wol-wait-time",
+
+    "force-lossless",
     NULL
 };
 
@@ -639,6 +641,12 @@ enum RDP_ARGS_IDX {
      */
     IDX_WOL_WAIT_TIME,
 
+    /**
+     * "true" if all graphical updates for this connection should use lossless
+     * compresion only, "false" or blank otherwise.
+     */
+    IDX_FORCE_LOSSLESS,
+
     RDP_ARGS_COUNT
 };
 
@@ -778,6 +786,11 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
             settings->width,
             settings->height,
             settings->resolution);
+
+    /* Lossless compression */
+    settings->lossless =
+        guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_FORCE_LOSSLESS, 0);
 
     /* Domain */
     settings->domain =

--- a/src/protocols/rdp/settings.h
+++ b/src/protocols/rdp/settings.h
@@ -193,6 +193,12 @@ typedef struct guac_rdp_settings {
     int resolution;
 
     /**
+     * Whether all graphical updates for this connection should use lossless
+     * compression only.
+     */
+    int lossless;
+
+    /**
      * Whether audio is enabled.
      */
     int audio_enabled;

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -91,6 +91,8 @@ const char* GUAC_VNC_CLIENT_ARGS[] = {
     "wol-broadcast-addr",
     "wol-udp-port",
     "wol-wait-time",
+
+    "force-lossless",
     NULL
 };
 
@@ -373,6 +375,12 @@ enum VNC_ARGS_IDX {
      */
     IDX_WOL_WAIT_TIME,
 
+    /**
+     * "true" if all graphical updates for this connection should use lossless
+     * compresion only, "false" or blank otherwise.
+     */
+    IDX_FORCE_LOSSLESS,
+
     VNC_ARGS_COUNT
 };
 
@@ -431,6 +439,11 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
     settings->color_depth =
         guac_user_parse_args_int(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_COLOR_DEPTH, 0);
+
+    /* Lossless compression */
+    settings->lossless =
+        guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_FORCE_LOSSLESS, false);
 
 #ifdef ENABLE_VNC_REPEATER
     /* Set repeater parameters if specified */

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -77,6 +77,12 @@ typedef struct guac_vnc_settings {
      */
     bool read_only;
 
+    /**
+     * Whether all graphical updates for this connection should use lossless
+     * compression only.
+     */
+    bool lossless;
+
 #ifdef ENABLE_VNC_REPEATER
     /**
      * The VNC host to connect to, if using a repeater.

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -435,6 +435,10 @@ void* guac_vnc_client_thread(void* data) {
     vnc_client->display = guac_common_display_alloc(client,
             rfb_client->width, rfb_client->height);
 
+    /* Use lossless compression only if requested (otherwise, use default
+     * heuristics) */
+    guac_common_display_set_lossless(vnc_client->display, settings->lossless);
+
     /* If not read-only, set an appropriate cursor */
     if (settings->read_only == 0) {
         if (settings->remote_cursor)

--- a/src/terminal/display.c
+++ b/src/terminal/display.c
@@ -221,6 +221,9 @@ guac_terminal_display* guac_terminal_display_alloc(guac_client* client,
     display->display_surface = guac_common_surface_alloc(client,
             client->socket, display->display_layer, 0, 0);
 
+    /* Never use lossy compression for terminal contents */
+    guac_common_surface_set_lossless(display->display_surface, 1);
+
     /* Select layer is a child of the display layer */
     guac_protocol_send_move(client->socket, display->select_layer,
             display->display_layer, 0, 0, 0);


### PR DESCRIPTION
This change adds a new `force-lossless` parameter to the VNC and RDP support, allowing the default lossy compression heuristics to be overridden. The default "use lossy compression if it looks appropriate" behavior of connections remains the same unless overridden with this new parameter.