### PR TITLE
GUACAMOLE-1276: Correct file upload offset type.

### DIFF
--- a/src/protocols/rdp/upload.h
+++ b/src/protocols/rdp/upload.h
@@ -37,7 +37,7 @@ typedef struct guac_rdp_upload_status {
      * The overall offset within the file that the next write should
      * occur at.
      */
-    int offset;
+    uint64_t offset;
 
     /**
      * The ID of the file being written to.


### PR DESCRIPTION
Fixes the regression introduced by GUACAMOLE-249 where the file upload offset gets set to a 32-bit integer instead of a 64-bit unsigned integer.