### PR TITLE
GUACAMOLE-1215: Add backslash to list of JSON-escaped characters.

### DIFF
--- a/src/common/json.c
+++ b/src/common/json.c
@@ -97,15 +97,15 @@ int guac_common_json_write_string(guac_user* user,
     const char* current = str;
     for (; *current != '\0'; current++) {
 
-        /* Escape all quotes */
-        if (*current == '"') {
+        /* Escape all quotes and back-slashes */
+        if (*current == '"' || *current == '\\') {
 
             /* Write any string content up to current character */
             if (current != str)
                 blob_written |= guac_common_json_write(user, stream,
                         json_state, str, current - str);
 
-            /* Escape the quote that was just read */
+            /* Escape the character that was just read */
             blob_written |= guac_common_json_write(user, stream,
                     json_state, "\\", 1);
 


### PR DESCRIPTION
Looks like this should resolve the issue with correcting the escape of back-slashes in SFTP code. I just did it at the raw JSON level, as it's a character that should be escaped universally in JSON strings.

Verified that this works by creating a file with a backslash on an SFTP location and verifying that it lists correctly in the hidden menu.