### PR TITLE
set client rcMask to NULL after freeing

### DIFF
--- a/src/protocols/vnc/cursor.c
+++ b/src/protocols/vnc/cursor.c
@@ -124,5 +124,6 @@ void guac_vnc_cursor(rfbClient* client, int x, int y, int w, int h, int bpp) {
 
     /* libvncclient does not free rcMask as it does rcSource */
     free(client->rcMask);
+    client->rcMask = NULL;
 }
 


### PR DESCRIPTION
libvncclient does not currently free rcMask, but if it ever does, the current code would trigger a double free. Set client->rcMask to NULL after freeing to prevent this scenario.