### PR TITLE
GUACAMOLE-1350: Add code to join leave_handler when connecting

### DIFF
--- a/src/protocols/kubernetes/client.c
+++ b/src/protocols/kubernetes/client.c
@@ -101,6 +101,7 @@ int guac_client_init(guac_client* client) {
     /* Set handlers */
     client->join_handler = guac_kubernetes_user_join_handler;
     client->free_handler = guac_kubernetes_client_free_handler;
+    client->leave_handler = guac_kubernetes_user_leave_handler;
 
     /* Register handlers for argument values that may be sent after the handshake */
     guac_argv_register(GUAC_KUBERNETES_ARGV_COLOR_SCHEME, guac_kubernetes_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -165,6 +165,7 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
     /* Set handlers */
     client->join_handler = guac_rdp_user_join_handler;
     client->free_handler = guac_rdp_client_free_handler;
+    client->leave_handler = guac_rdp_user_leave_handler;
 
 #ifdef ENABLE_COMMON_SSH
     guac_common_ssh_init(client);

--- a/src/protocols/ssh/client.c
+++ b/src/protocols/ssh/client.c
@@ -51,6 +51,7 @@ int guac_client_init(guac_client* client) {
     /* Set handlers */
     client->join_handler = guac_ssh_user_join_handler;
     client->free_handler = guac_ssh_client_free_handler;
+    client->leave_handler = guac_ssh_user_leave_handler;
 
     /* Register handlers for argument values that may be sent after the handshake */
     guac_argv_register(GUAC_SSH_ARGV_COLOR_SCHEME, guac_ssh_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);

--- a/src/protocols/telnet/client.c
+++ b/src/protocols/telnet/client.c
@@ -55,6 +55,7 @@ int guac_client_init(guac_client* client) {
     /* Set handlers */
     client->join_handler = guac_telnet_user_join_handler;
     client->free_handler = guac_telnet_client_free_handler;
+    client->leave_handler = guac_telnet_user_leave_handler;
 
     /* Register handlers for argument values that may be sent after the handshake */
     guac_argv_register(GUAC_TELNET_ARGV_COLOR_SCHEME, guac_telnet_argv_callback, NULL, GUAC_ARGV_OPTION_ECHO);


### PR DESCRIPTION
When the shared users enters by using Share feature in rdp, `guac_rdp_parse_args()` is called.
But, when they leaves, `guac_rdp_settings_free()` isn't called.
We can `guac_rdp_user_leave_handler()` to fix this issue.