### PR TITLE
GUACAMOLE-1447: bump docker base image to Debian Bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,8 @@ RUN apt-get update                                                              
 
 # Link FreeRDP plugins into proper path
 RUN ${PREFIX_DIR}/bin/link-freerdp-plugins.sh \
-        ${PREFIX_DIR}/lib/freerdp2/libguac*.so
+        ${PREFIX_DIR}                         \
+        /lib/freerdp2/libguac*.so
 
 # Checks the operating status every 5 minutes with a timeout of 5 seconds
 HEALTHCHECK --interval=5m --timeout=5s CMD nc -z 127.0.0.1 4822 || exit 1
@@ -158,8 +159,6 @@ ARG UID=1000
 ARG GID=1000
 RUN groupadd --gid $GID guacd
 RUN useradd --system --create-home --shell /usr/sbin/nologin --uid $UID --gid $GID guacd
-RUN cp -r /usr/local/guacamole/lib/* /usr/lib/x86_64-linux-gnu/freerdp2/
-RUN cp -r /usr/local/guacamole/lib/freerdp2/* /usr/lib/x86_64-linux-gnu/freerdp2/
 
 # Run with user guacd
 USER guacd

--- a/Dockerfile
+++ b/Dockerfile
@@ -158,6 +158,8 @@ ARG UID=1000
 ARG GID=1000
 RUN groupadd --gid $GID guacd
 RUN useradd --system --create-home --shell /usr/sbin/nologin --uid $UID --gid $GID guacd
+RUN cp -r /usr/local/guacamole/lib/* /usr/lib/x86_64-linux-gnu/freerdp2/
+RUN cp -r /usr/local/guacamole/lib/freerdp2/* /usr/lib/x86_64-linux-gnu/freerdp2/
 
 # Run with user guacd
 USER guacd

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 #
 
 # The Debian image that should be used as the basis for the guacd image
-ARG DEBIAN_BASE_IMAGE=buster-slim
+ARG DEBIAN_BASE_IMAGE=bullseye-slim
 
 # Use Debian as base for the build
 FROM debian:${DEBIAN_BASE_IMAGE} AS builder
@@ -34,7 +34,7 @@ FROM debian:${DEBIAN_BASE_IMAGE} AS builder
 # NOTE: Due to limitations of the Docker image build process, this value is
 # duplicated in an ARG in the second stage of the build.
 #
-ARG DEBIAN_RELEASE=buster-backports
+ARG DEBIAN_RELEASE=bullseye-backports
 
 # Add repository for specified Debian release if not already present in
 # sources.list
@@ -105,7 +105,7 @@ FROM debian:${DEBIAN_BASE_IMAGE}
 # NOTE: Due to limitations of the Docker image build process, this value is
 # duplicated in an ARG in the first stage of the build.
 #
-ARG DEBIAN_RELEASE=buster-backports
+ARG DEBIAN_RELEASE=bullseye-backports
 
 # Add repository for specified Debian release if not already present in
 # sources.list

--- a/src/guacd-docker/bin/link-freerdp-plugins.sh
+++ b/src/guacd-docker/bin/link-freerdp-plugins.sh
@@ -40,15 +40,14 @@
 ##
 where_is_freerdp() {
 
-    PLUGIN_FILE="$1"
+    PREFIX_DIR="$1"
 
     # Determine the location of all libfreerdp* libraries explicitly linked
-    # to given file
-    PATHS="$(ldd "$PLUGIN_FILE"              \
-                 | awk '/=>/{print $(NF-1)}' \
-                 | grep 'libfreerdp'         \
-                 | xargs -r dirname          \
-                 | xargs -r realpath         \
+    PATHS="$(ldd ${PREFIX_DIR}/lib/libguac-client-rdp.so   \
+                 | awk '/=>/{print $(NF-1)}'               \
+                 | grep 'libfreerdp'                       \
+                 | xargs -r dirname                        \
+                 | xargs -r realpath                       \
                  | sort -u)"
 
     # Verify that exactly one location was found
@@ -58,7 +57,6 @@ where_is_freerdp() {
     fi
 
     echo "$PATHS"
-
 }
 
 #
@@ -66,18 +64,18 @@ where_is_freerdp() {
 # search path of FreeRDP
 #
 
-while [ -n "$1" ]; do
+GUAC_PLUGIN="$1$2"
+FREERDP_DIR="$(where_is_freerdp "$1")"
+FREERDP_PLUGIN_DIR="${FREERDP_DIR}/freerdp2"
 
-    # Determine correct install location for FreeRDP plugins
-    FREERDP_DIR="$(where_is_freerdp "$1")"
-    FREERDP_PLUGIN_DIR="${FREERDP_DIR}/freerdp2"
+for value in $GUAC_PLUGIN; do
 
     # Add symbolic link if necessary
-    if [ ! -e "$FREERDP_PLUGIN_DIR/$(basename "$1")" ]; then
+    if [ ! -e "$FREERDP_PLUGIN_DIR/$(basename $value)" ]; then
         mkdir -p "$FREERDP_PLUGIN_DIR"
-        ln -s "$1" "$FREERDP_PLUGIN_DIR"
+        ln -s "$value" "$FREERDP_PLUGIN_DIR"
     else
-        echo "$1: Already in correct directory." >&2
+        echo "$value: Already in correct directory." >&2
     fi
 
     shift


### PR DESCRIPTION
Bumping Docker base image to Debian latest stable `Debian Bullseye`.

* https://issues.apache.org/jira/browse/GUACAMOLE-1447
* https://www.debian.org/releases/

What I tested on Guacamole version `1.3.0`:

:heavy_check_mark: Connection to a RDP host
:heavy_check_mark: Connection to a SSH target + verifying the remote-server key (known host key)
:heavy_check_mark: Connection to a SSH target with user/pass authentication
:heavy_check_mark: Connection to a SSH target with pubkey authentication (with an un-encrypted private key)
:heavy_check_mark: Connection to a SSH target with pubkey authentication (with an un-encrypted private key)