### PR TITLE
GUACAMOLE-1411: Bump version numbers to 1.4.0.

### DIFF
--- a/bin/guacctl
+++ b/bin/guacctl
@@ -117,7 +117,7 @@ error() {
 ##
 usage() {
     cat >&2 <<END
-guacctl 1.3.0, Apache Guacamole terminal session control utility.
+guacctl 1.4.0, Apache Guacamole terminal session control utility.
 Usage: guacctl [OPTION] [FILE or NAME]...
 
     -d, --download         download each of the files listed.

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@
 #
 
 AC_PREREQ([2.61])
-AC_INIT([guacamole-server], [1.3.0])
+AC_INIT([guacamole-server], [1.4.0])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AM_SILENT_RULES([yes])

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -135,7 +135,7 @@ libguac_la_CFLAGS = \
     -Werror -Wall -pedantic
 
 libguac_la_LDFLAGS =     \
-    -version-info 19:0:0 \
+    -version-info 20:0:0 \
     -no-undefined        \
     @CAIRO_LIBS@         \
     @DL_LIBS@            \


### PR DESCRIPTION
The libtool version info also needs a full bump, as at least one interface was modified since 1.3.0 (the new `touch_handler` member of `guac_user`).