### PR TITLE
GUACAMOLE-1190: Explicitly use "localhost" as guacd default bind host, matching default of webapp.

### DIFF
--- a/src/guacd/conf-file.c
+++ b/src/guacd/conf-file.c
@@ -176,8 +176,8 @@ guacd_config* guacd_conf_load() {
         return NULL;
 
     /* Load defaults */
-    conf->bind_host = NULL;
-    conf->bind_port = strdup("4822");
+    conf->bind_host = strdup(GUACD_DEFAULT_BIND_HOST);
+    conf->bind_port = strdup(GUACD_DEFAULT_BIND_PORT);
     conf->pidfile = NULL;
     conf->foreground = 0;
     conf->print_version = 0;

--- a/src/guacd/conf.h
+++ b/src/guacd/conf.h
@@ -25,6 +25,18 @@
 #include <guacamole/client.h>
 
 /**
+ * The default host that guacd should bind to, if no other host is explicitly
+ * specified.
+ */
+#define GUACD_DEFAULT_BIND_HOST "localhost"
+
+/**
+ * The default port that guacd should bind to, if no other port is explicitly
+ * specified.
+ */
+#define GUACD_DEFAULT_BIND_PORT "4822"
+
+/**
  * The contents of a guacd configuration file.
  */
 typedef struct guacd_config {


### PR DESCRIPTION
This change explicitly uses the hostname "localhost" as the default guacd bind host, matching the default used by the webapp:

https://github.com/apache/guacamole-client/blob/841b659a20e0b72f3b548ece5bde5556b1dc4ce1/guacamole-ext/src/main/java/org/apache/guacamole/environment/LocalEnvironment.java#L67-L71

This should ensure:

* Both guacd and the webapp have the same default behavior (the old `NULL` behavior for address info lookups is not necessarily the same as a lookup for "localhost").
* The new behavior is compatible with the expectations of deployments of past releases (the webapp has always defaulted to attempting to connect to "localhost").