### PR TITLE
GUACAMOLE-478: Add clipboard line ending normalization option for RDP.

### DIFF
--- a/src/common/common/iconv.h
+++ b/src/common/common/iconv.h
@@ -77,6 +77,30 @@ guac_iconv_read GUAC_READ_CP1252;
 guac_iconv_read GUAC_READ_ISO8859_1;
 
 /**
+ * Read function for UTF-8 which normalizes newline character sequences like
+ * "\r\n" to Unix-style newlines ('\n').
+ */
+guac_iconv_read GUAC_READ_UTF8_NORMALIZED;
+
+/**
+ * Read function for UTF-16 which normalizes newline character sequences like
+ * "\r\n" to Unix-style newlines ('\n').
+ */
+guac_iconv_read GUAC_READ_UTF16_NORMALIZED;
+
+/**
+ * Read function for CP-1252 which normalizes newline character sequences like
+ * "\r\n" to Unix-style newlines ('\n').
+ */
+guac_iconv_read GUAC_READ_CP1252_NORMALIZED;
+
+/**
+ * Read function for ISO 8859-1 which normalizes newline character sequences
+ * like "\r\n" to Unix-style newlines ('\n').
+ */
+guac_iconv_read GUAC_READ_ISO8859_1_NORMALIZED;
+
+/**
  * Write function for UTF8.
  */
 guac_iconv_write GUAC_WRITE_UTF8;
@@ -95,6 +119,30 @@ guac_iconv_write GUAC_WRITE_CP1252;
  * Write function for ISO-8859-1
  */
 guac_iconv_write GUAC_WRITE_ISO8859_1;
+
+/**
+ * Write function for UTF-8 which writes newline characters ('\n') as
+ * Windows-style newlines ("\r\n").
+ */
+guac_iconv_write GUAC_WRITE_UTF8_CRLF;
+
+/**
+ * Write function for UTF-16 which writes newline characters ('\n') as
+ * Windows-style newlines ("\r\n").
+ */
+guac_iconv_write GUAC_WRITE_UTF16_CRLF;
+
+/**
+ * Write function for CP-1252 which writes newline characters ('\n') as
+ * Windows-style newlines ("\r\n").
+ */
+guac_iconv_write GUAC_WRITE_CP1252_CRLF;
+
+/**
+ * Write function for ISO 8859-1 which writes newline characters ('\n') as
+ * Windows-style newlines ("\r\n").
+ */
+guac_iconv_write GUAC_WRITE_ISO8859_1_CRLF;
 
 #endif
 

--- a/src/common/tests/Makefile.am
+++ b/src/common/tests/Makefile.am
@@ -33,8 +33,12 @@ ACLOCAL_AMFLAGS = -I m4
 check_PROGRAMS = test_common
 TESTS = $(check_PROGRAMS)
 
+noinst_HEADERS =               \
+    iconv/convert-test-data.h
+
 test_common_SOURCES =          \
     iconv/convert.c            \
+    iconv/convert-test-data.c  \
     rect/clip_and_split.c      \
     rect/constrain.c           \
     rect/expand_to_grid.c      \

--- a/src/common/tests/iconv/convert-test-data.c
+++ b/src/common/tests/iconv/convert-test-data.c
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "common/iconv.h"
+#include "convert-test-data.h"
+
+encoding_test_parameters test_params[NUM_SUPPORTED_ENCODINGS] = {
+
+    /*
+     * UTF-8
+     */
+
+    {
+        "UTF-8",
+        GUAC_READ_UTF8,  GUAC_READ_UTF8_NORMALIZED,
+        GUAC_WRITE_UTF8, GUAC_WRITE_UTF8_CRLF,
+        .test_mixed = TEST_STRING(
+            "pap\xC3\xA0 \xC3\xA8 bello\n"
+            "pap\xC3\xA0 \xC3\xA8 bello\r\n"
+            "pap\xC3\xA0 \xC3\xA8 bello\n"
+            "pap\xC3\xA0 \xC3\xA8 bello\r\n"
+            "pap\xC3\xA0 \xC3\xA8 bello"
+        ),
+        .test_unix = TEST_STRING(
+            "pap\xC3\xA0 \xC3\xA8 bello\n"
+            "pap\xC3\xA0 \xC3\xA8 bello\n"
+            "pap\xC3\xA0 \xC3\xA8 bello\n"
+            "pap\xC3\xA0 \xC3\xA8 bello\n"
+            "pap\xC3\xA0 \xC3\xA8 bello"
+        ),
+        .test_windows = TEST_STRING(
+            "pap\xC3\xA0 \xC3\xA8 bello\r\n"
+            "pap\xC3\xA0 \xC3\xA8 bello\r\n"
+            "pap\xC3\xA0 \xC3\xA8 bello\r\n"
+            "pap\xC3\xA0 \xC3\xA8 bello\r\n"
+            "pap\xC3\xA0 \xC3\xA8 bello"
+        )
+    },
+
+    /*
+     * UTF-16
+     */
+
+    {
+        "UTF-16",
+        GUAC_READ_UTF16,  GUAC_READ_UTF16_NORMALIZED,
+        GUAC_WRITE_UTF16, GUAC_WRITE_UTF16_CRLF,
+        .test_mixed = TEST_STRING(
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00" "\n\x00"
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00" "\r\x00" "\n\x00"
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00" "\n\x00"
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00" "\r\x00" "\n\x00"
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00"
+            "\x00"
+        ),
+        .test_unix = TEST_STRING(
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00" "\n\x00"
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00" "\n\x00"
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00" "\n\x00"
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00" "\n\x00"
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00"
+            "\x00"
+        ),
+        .test_windows = TEST_STRING(
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00" "\r\x00" "\n\x00"
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00" "\r\x00" "\n\x00"
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00" "\r\x00" "\n\x00"
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00" "\r\x00" "\n\x00"
+            "p\x00" "a\x00" "p\x00" "\xE0\x00" " \x00" "\xE8\x00" " \x00" "b\x00" "e\x00" "l\x00" "l\x00" "o\x00"
+            "\x00"
+        )
+    },
+
+    /*
+     * ISO 8859-1
+     */
+
+    {
+        "ISO 8859-1",
+        GUAC_READ_ISO8859_1,  GUAC_READ_ISO8859_1_NORMALIZED,
+        GUAC_WRITE_ISO8859_1, GUAC_WRITE_ISO8859_1_CRLF,
+        .test_mixed = TEST_STRING(
+            "pap\xE0 \xE8 bello\n"
+            "pap\xE0 \xE8 bello\r\n"
+            "pap\xE0 \xE8 bello\n"
+            "pap\xE0 \xE8 bello\r\n"
+            "pap\xE0 \xE8 bello"
+        ),
+        .test_unix = TEST_STRING(
+            "pap\xE0 \xE8 bello\n"
+            "pap\xE0 \xE8 bello\n"
+            "pap\xE0 \xE8 bello\n"
+            "pap\xE0 \xE8 bello\n"
+            "pap\xE0 \xE8 bello"
+        ),
+        .test_windows = TEST_STRING(
+            "pap\xE0 \xE8 bello\r\n"
+            "pap\xE0 \xE8 bello\r\n"
+            "pap\xE0 \xE8 bello\r\n"
+            "pap\xE0 \xE8 bello\r\n"
+            "pap\xE0 \xE8 bello"
+        )
+    },
+
+    /*
+     * CP-1252
+     */
+
+    {
+        "CP-1252",
+        GUAC_READ_CP1252,  GUAC_READ_CP1252_NORMALIZED,
+        GUAC_WRITE_CP1252, GUAC_WRITE_CP1252_CRLF,
+        .test_mixed = TEST_STRING(
+            "pap\xE0 \xE8 bello\n"
+            "pap\xE0 \xE8 bello\r\n"
+            "pap\xE0 \xE8 bello\n"
+            "pap\xE0 \xE8 bello\r\n"
+            "pap\xE0 \xE8 bello"
+        ),
+        .test_unix = TEST_STRING(
+            "pap\xE0 \xE8 bello\n"
+            "pap\xE0 \xE8 bello\n"
+            "pap\xE0 \xE8 bello\n"
+            "pap\xE0 \xE8 bello\n"
+            "pap\xE0 \xE8 bello"
+        ),
+        .test_windows = TEST_STRING(
+            "pap\xE0 \xE8 bello\r\n"
+            "pap\xE0 \xE8 bello\r\n"
+            "pap\xE0 \xE8 bello\r\n"
+            "pap\xE0 \xE8 bello\r\n"
+            "pap\xE0 \xE8 bello"
+        )
+    }
+
+};
+

--- a/src/common/tests/iconv/convert-test-data.h
+++ b/src/common/tests/iconv/convert-test-data.h
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "common/iconv.h"
+
+/**
+ * Representation of test string data and its length in bytes.
+ */
+typedef struct test_string {
+
+    /**
+     * The raw content of the test string.
+     */
+    unsigned char* buffer;
+
+    /**
+     * The number of bytes within the test string, including null terminator.
+     */
+    int size;
+
+} test_string;
+
+/**
+ * Convenience macro which statically-initializes a test_string with the given
+ * string value, automatically calculating its size in bytes.
+ *
+ * @param value
+ *     The string value.
+ */
+#define TEST_STRING(value) {            \
+    .buffer = (unsigned char*) (value), \
+    .size = sizeof(value)               \
+}
+
+/**
+ * The parameters applicable to a unit test for a particular encoding supported
+ * by guac_iconv().
+ */
+typedef struct encoding_test_parameters {
+
+    /**
+     * The human-readable name of this encoding. This will be logged to the
+     * test suite log to assist with debugging test failures.
+     */
+    const char* name;
+
+    /**
+     * Reader function which reads using this encoding and does not perform any
+     * transformation on newline characters.
+     */
+    guac_iconv_read* reader;
+
+    /**
+     * Reader function which reads using this encoding and automatically
+     * normalizes newline sequences to Unix-style newline characters.
+     */
+    guac_iconv_read* reader_normalized;
+
+    /**
+     * Writer function which writes using this encoding and does not perform
+     * any transformation on newline characters.
+     */
+    guac_iconv_write* writer;
+
+    /**
+     * Writer function which writes using this encoding, but writes newline
+     * characters as CRLF sequences.
+     */
+    guac_iconv_write* writer_crlf;
+
+    /**
+     * A test string having both Windows- and Unix-style line endings. Except
+     * for the line endings, the characters represented within this test string
+     * must be identical to all other test strings.
+     */
+    test_string test_mixed;
+
+    /**
+     * A test string having only Unix-style line endings. Except for the line
+     * endings, the characters represented within this test string must be
+     * identical to all other test strings.
+     */
+    test_string test_unix;
+
+    /**
+     * A test string having only Windows-style line endings. Except for the
+     * line endings, the characters represented within this test string must be
+     * identical to all other test strings.
+     */
+    test_string test_windows;
+
+} encoding_test_parameters;
+
+/**
+ * The total number of encodings supported by guac_iconv().
+ */
+#define NUM_SUPPORTED_ENCODINGS 4
+
+/**
+ * Test parameters for each supported encoding. The test strings included each
+ * consist of five repeated lines of "papà è bello", omitting the line ending
+ * of the final line.
+ */
+extern encoding_test_parameters test_params[NUM_SUPPORTED_ENCODINGS];
+

--- a/src/protocols/rdp/settings.h
+++ b/src/protocols/rdp/settings.h
@@ -324,6 +324,19 @@ typedef struct guac_rdp_settings {
     int disable_paste;
 
     /**
+     * Whether line endings within the clipboard should be automatically
+     * normalized to Unix-style newline characters.
+     */
+    int normalize_clipboard;
+
+    /**
+     * Whether Unix-style newline characters within the clipboard should be
+     * automatically translated to CRLF sequences before transmission to the
+     * RDP server.
+     */
+    int clipboard_crlf;
+
+    /**
      * Whether the desktop wallpaper should be visible. If unset, the desktop
      * wallpaper will be hidden, reducing the amount of bandwidth required.
      */


### PR DESCRIPTION
This change adds a new connection parameter for RDP, `normalize-clipboard`, that allows the line endings within clipboard data to be normalized to a particular format, such as Windows (CRLF) or Unix (LF).

By default, no normalization is performed.