### PR TITLE
GUACAMOLE-1495: Add keymap for Polish keyboard layout for RDP

### DIFF
--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -241,6 +241,7 @@ rdp_keymaps =                                \
     $(srcdir)/keymaps/it_it_qwerty.keymap    \
     $(srcdir)/keymaps/ja_jp_qwerty.keymap    \
     $(srcdir)/keymaps/no_no_qwerty.keymap    \
+    $(srcdir)/keymaps/pl_pl_qwerty.keymap    \
     $(srcdir)/keymaps/pt_br_qwerty.keymap    \
     $(srcdir)/keymaps/sv_se_qwerty.keymap    \
     $(srcdir)/keymaps/da_dk_qwerty.keymap    \

--- a/src/protocols/rdp/keymaps/pl_pl_qwerty.keymap
+++ b/src/protocols/rdp/keymaps/pl_pl_qwerty.keymap
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+parent  "base"
+name    "pl-pl-qwerty"
+freerdp "KBD_POLISH_PROGRAMMERS"
+
+map -caps -shift 0x29 0x02..0x0D      ~ "`1234567890-="
+map -caps -shift      0x10..0x1B 0x2B ~ "qwertyuiop[]\"
+map -caps -shift      0x1E..0x28      ~ "asdfghjkl;'"
+map -caps -shift      0x2C..0x35      ~ "zxcvbnm,./"
+
+map -caps +shift 0x29 0x02..0x0D      ~ "~!@#$%^&*()_+"
+map -caps +shift      0x10..0x1B 0x2B ~ "QWERTYUIOP{}|"
+map -caps +shift      0x1E..0x28      ~ "ASDFGHJKL:""
+map -caps +shift      0x2C..0x35      ~ "ZXCVBNM<>?"
+
+map +caps -shift 0x29 0x02..0x0D      ~ "`1234567890-="
+map +caps -shift      0x10..0x1B 0x2B ~ "QWERTYUIOP[]\"
+map +caps -shift      0x1E..0x28      ~ "ASDFGHJKL;'"
+map +caps -shift      0x2C..0x35      ~ "ZXCVBNM,./"
+
+map +caps +shift 0x29 0x02..0x0D      ~ "~!@#$%^&*()_+"
+map +caps +shift      0x10..0x1B 0x2B ~ "qwertyuiop{}|"
+map +caps +shift      0x1E..0x28      ~ "asdfghjkl:""
+map +caps +shift      0x2C..0x35      ~ "zxcvbnm<>?"
+
+#
+# Keys requiring AltGr
+#
+
+map +altgr -shift 0x16      ~ "€"
+
+map -caps -shift +altgr 0x12 0x18           ~ "ęó"
+map -caps -shift +altgr 0x1E 0x1F 0x26      ~ "ąśł"
+map -caps -shift +altgr 0x2C 0x2D 0x2E 0x31 ~ "żźćń"
+
+map -caps +shift +altgr 0x12 0x18           ~ "ĘÓ"
+map -caps +shift +altgr 0x1E 0x1F 0x26      ~ "ĄŚŁ"
+map -caps +shift +altgr 0x2C 0x2D 0x2E 0x31 ~ "ŻŹĆŃ"
+
+map +caps -shift +altgr 0x12 0x18           ~ "ĘÓ"
+map +caps -shift +altgr 0x1E 0x1F 0x26      ~ "ĄŚŁ"
+map +caps -shift +altgr 0x2C 0x2D 0x2E 0x31 ~ "ŻŹĆŃ"
+
+map +caps +shift +altgr 0x12 0x18           ~ "ęó"
+map +caps +shift +altgr 0x1E 0x1F 0x26      ~ "ąśł"
+map +caps +shift +altgr 0x2C 0x2D 0x2E 0x31 ~ "żźćń"


### PR DESCRIPTION
This PR adds pl_pl_qwerty.keymap file with Polish keyboard layout for RDP and updates Makefile.am to include aforementioned file. I've tested those changes locally as per contribution guidelines and they work as expected. 