### PR TITLE
GUACAMOLE-1503: Japanese Character input cannot be switched By full-width half-width key.

### DIFF
--- a/src/protocols/rdp/keymaps/ja_jp_qwerty.keymap
+++ b/src/protocols/rdp/keymaps/ja_jp_qwerty.keymap
@@ -32,5 +32,4 @@ map +shift      0x1E..0x28 0x2B ~ "ASDFGHJKL+*}"
 map +shift      0x2C..0x35 0x73 ~ "ZXCVBNM<>?_"
 
 map -shift      0x29            ~ 0xFF28
-map -shift      0x29            ~ 0xFF2A
-map +shift      0x29            ~ 0xFF29
+map -shift      0x29            ~ 0xFF29

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -1393,6 +1393,11 @@ void guac_rdp_push_settings(guac_client* client,
     rdp_settings->AlternateShell = guac_strdup(guac_settings->initial_program);
     rdp_settings->KeyboardLayout = guac_settings->server_layout->freerdp_keyboard_layout;
 
+    /* Add GUACAMOLE-1503: Fixed so that full-width and half-width keys work correctly and Japanese input switching works. */
+    rdp_settings->KeyboardType = 7;
+    rdp_settings->KeyboardSubType = 2;
+    rdp_settings->KeyboardFunctionKey = 12;
+
     /* Performance flags */
     /* Explicitly set flag value */
     rdp_settings->PerformanceFlags = guac_rdp_get_performance_flags(guac_settings);


### PR DESCRIPTION
Fixed so that full-width and half-width keys work correctly and Japanese input switching works.
Hope to include it in the next release. Thank you.