### PR TITLE
GUACAMOLE-462: Create recordings/typescripts with group read permission.

### DIFF
--- a/src/common/recording.c
+++ b/src/common/recording.c
@@ -84,7 +84,7 @@ static int guac_common_recording_open(const char* path,
     /* Attempt to open recording */
     int fd = open(basename,
             O_CREAT | O_EXCL | O_WRONLY,
-            S_IRUSR | S_IWUSR);
+            S_IRUSR | S_IWUSR | S_IRGRP);
 
     /* Continuously retry with alternate names on failure */
     if (fd == -1) {
@@ -103,7 +103,7 @@ static int guac_common_recording_open(const char* path,
             /* Retry with newly-suffixed filename */
             fd = open(basename,
                     O_CREAT | O_EXCL | O_WRONLY,
-                    S_IRUSR | S_IWUSR);
+                    S_IRUSR | S_IWUSR | S_IRGRP);
 
         }
 
@@ -144,7 +144,8 @@ guac_common_recording* guac_common_recording_create(guac_client* client,
 
     /* Create path if it does not exist, fail if impossible */
 #ifndef __MINGW32__
-    if (create_path && mkdir(path, S_IRWXU) && errno != EEXIST) {
+    if (create_path && mkdir(path, S_IRWXU | S_IRGRP | S_IXGRP)
+            && errno != EEXIST) {
 #else
     if (create_path && _mkdir(path) && errno != EEXIST) {
 #endif

--- a/src/terminal/typescript.c
+++ b/src/terminal/typescript.c
@@ -79,7 +79,7 @@ static int guac_terminal_typescript_open_data_file(const char* path,
     /* Attempt to open typescript data file */
     int data_fd = open(basename,
             O_CREAT | O_EXCL | O_WRONLY,
-            S_IRUSR | S_IWUSR);
+            S_IRUSR | S_IWUSR | S_IRGRP);
 
     /* Continuously retry with alternate names on failure */
     if (data_fd == -1) {
@@ -98,7 +98,7 @@ static int guac_terminal_typescript_open_data_file(const char* path,
             /* Retry with newly-suffixed filename */
             data_fd = open(basename,
                     O_CREAT | O_EXCL | O_WRONLY,
-                    S_IRUSR | S_IWUSR);
+                    S_IRUSR | S_IWUSR | S_IRGRP);
 
         }
 
@@ -112,7 +112,8 @@ guac_terminal_typescript* guac_terminal_typescript_alloc(const char* path,
         const char* name, int create_path) {
 
     /* Create path if it does not exist, fail if impossible */
-    if (create_path && mkdir(path, S_IRWXU) && errno != EEXIST)
+    if (create_path && mkdir(path, S_IRWXU | S_IRGRP | S_IXGRP)
+            && errno != EEXIST)
         return NULL;
 
     /* Allocate space for new typescript */
@@ -141,7 +142,7 @@ guac_terminal_typescript* guac_terminal_typescript_alloc(const char* path,
     /* Attempt to open typescript timing file */
     typescript->timing_fd = open(typescript->timing_filename,
             O_CREAT | O_EXCL | O_WRONLY,
-            S_IRUSR | S_IWUSR);
+            S_IRUSR | S_IWUSR | S_IRGRP);
     if (typescript->timing_fd == -1) {
         close(typescript->data_fd);
         free(typescript);


### PR DESCRIPTION
To allow reading by separate services like the Guacamole web application, recordings/typescripts created by guacd should be group-readable. Without group read permission, the service user running guacd would also need to be the user running the web application, which would not be an ideal separation of privileges.