### PR TITLE
GUACAMOLE-1538: Refactor libguac_terminal for easier extensibility, and migrate to shared library.

### DIFF
--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -239,12 +239,24 @@ void* guac_kubernetes_client_thread(void* data) {
                 settings->recording_include_keys);
     }
 
+    /* Create terminal options with required parameters */
+    guac_terminal_options* options = guac_terminal_options_create(
+            client, kubernetes_client->clipboard,
+            settings->width, settings->height, settings->resolution);
+
+    /* Set optional parameters */
+    options->disable_copy = settings->disable_copy;
+    options->max_scrollback = settings->max_scrollback;
+    options->font_name = settings->font_name;
+    options->font_size = settings->font_size;
+    options->color_scheme = settings->color_scheme;
+    options->backspace = settings->backspace;
+
     /* Create terminal */
-    kubernetes_client->term = guac_terminal_create(client,
-            kubernetes_client->clipboard, settings->disable_copy,
-            settings->max_scrollback, settings->font_name, settings->font_size,
-            settings->resolution, settings->width, settings->height,
-            settings->color_scheme, settings->backspace);
+    kubernetes_client->term = guac_terminal_create(options);
+
+    /* Free options struct now that it's been used */
+    free(options);
 
     /* Fail if terminal init failed */
     if (kubernetes_client->term == NULL) {

--- a/src/protocols/kubernetes/settings.c
+++ b/src/protocols/kubernetes/settings.c
@@ -19,6 +19,7 @@
 
 #include "argv.h"
 #include "settings.h"
+#include "terminal/terminal.h"
 
 #include <guacamole/user.h>
 
@@ -215,8 +216,8 @@ enum KUBERNETES_ARGS_IDX {
     IDX_READ_ONLY,
 
     /**
-     * ASCII code, as an integer to use for the backspace key, or 127
-     * if not specified.
+     * ASCII code, as an integer to use for the backspace key, or
+     * GUAC_TERMINAL_DEFAULT_BACKSPACE if not specified.
      */
     IDX_BACKSPACE,
 
@@ -320,22 +321,22 @@ guac_kubernetes_settings* guac_kubernetes_parse_args(guac_user* user,
     /* Read maximum scrollback size */
     settings->max_scrollback =
         guac_user_parse_args_int(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
-                IDX_SCROLLBACK, GUAC_KUBERNETES_DEFAULT_MAX_SCROLLBACK);
+                IDX_SCROLLBACK, GUAC_TERMINAL_DEFAULT_MAX_SCROLLBACK);
 
     /* Read font name */
     settings->font_name =
         guac_user_parse_args_string(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
-                IDX_FONT_NAME, GUAC_KUBERNETES_DEFAULT_FONT_NAME);
+                IDX_FONT_NAME, GUAC_TERMINAL_DEFAULT_FONT_NAME);
 
     /* Read font size */
     settings->font_size =
         guac_user_parse_args_int(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
-                IDX_FONT_SIZE, GUAC_KUBERNETES_DEFAULT_FONT_SIZE);
+                IDX_FONT_SIZE, GUAC_TERMINAL_DEFAULT_FONT_SIZE);
 
     /* Copy requested color scheme */
     settings->color_scheme =
         guac_user_parse_args_string(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
-                IDX_COLOR_SCHEME, "");
+                IDX_COLOR_SCHEME, GUAC_TERMINAL_DEFAULT_COLOR_SCHEME);
 
     /* Pull width/height/resolution directly from user */
     settings->width      = user->info.optimal_width;
@@ -390,7 +391,7 @@ guac_kubernetes_settings* guac_kubernetes_parse_args(guac_user* user,
     /* Parse backspace key code */
     settings->backspace =
         guac_user_parse_args_int(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
-                IDX_BACKSPACE, 127);
+                IDX_BACKSPACE, GUAC_TERMINAL_DEFAULT_BACKSPACE);
 
     /* Parse clipboard copy disable flag */
     settings->disable_copy =

--- a/src/protocols/kubernetes/settings.h
+++ b/src/protocols/kubernetes/settings.h
@@ -25,17 +25,6 @@
 #include <stdbool.h>
 
 /**
- * The name of the font to use for the terminal if no name is specified.
- */
-#define GUAC_KUBERNETES_DEFAULT_FONT_NAME "monospace" 
-
-/**
- * The size of the font to use for the terminal if no font size is specified,
- * in points.
- */
-#define GUAC_KUBERNETES_DEFAULT_FONT_SIZE 12
-
-/**
  * The port to connect to when initiating any Kubernetes connection, if no
  * other port is specified.
  */
@@ -56,11 +45,6 @@
  * The filename to use for the screen recording, if not specified.
  */
 #define GUAC_KUBERNETES_DEFAULT_RECORDING_NAME "recording"
-
-/**
- * The default maximum scrollback size in rows.
- */
-#define GUAC_KUBERNETES_DEFAULT_MAX_SCROLLBACK 1000
 
 /**
  * Settings for the Kubernetes connection. The values for this structure are

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -23,6 +23,7 @@
 #include "client.h"
 #include "common/defaults.h"
 #include "settings.h"
+#include "terminal/terminal.h"
 
 #include <guacamole/user.h>
 #include <guacamole/wol-constants.h>
@@ -248,8 +249,8 @@ enum SSH_ARGS_IDX {
 
     /**
      * The ASCII code, as an integer, to send for the backspace key, as configured
-     * by the SSH connection from the client.  By default this will be 127,
-     * the ASCII DELETE code.
+     * by the SSH connection from the client.  By default this will be
+     * GUAC_TERMINAL_DEFAULT_BACKSPACE.
      */
     IDX_BACKSPACE,
 
@@ -375,22 +376,22 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
     /* Read maximum scrollback size */
     settings->max_scrollback =
         guac_user_parse_args_int(user, GUAC_SSH_CLIENT_ARGS, argv,
-                IDX_SCROLLBACK, GUAC_SSH_DEFAULT_MAX_SCROLLBACK);
+                IDX_SCROLLBACK, GUAC_TERMINAL_DEFAULT_MAX_SCROLLBACK);
 
     /* Read font name */
     settings->font_name =
         guac_user_parse_args_string(user, GUAC_SSH_CLIENT_ARGS, argv,
-                IDX_FONT_NAME, GUAC_SSH_DEFAULT_FONT_NAME);
+                IDX_FONT_NAME, GUAC_TERMINAL_DEFAULT_FONT_NAME);
 
     /* Read font size */
     settings->font_size =
         guac_user_parse_args_int(user, GUAC_SSH_CLIENT_ARGS, argv,
-                IDX_FONT_SIZE, GUAC_SSH_DEFAULT_FONT_SIZE);
+                IDX_FONT_SIZE, GUAC_TERMINAL_DEFAULT_FONT_SIZE);
 
     /* Copy requested color scheme */
     settings->color_scheme =
         guac_user_parse_args_string(user, GUAC_SSH_CLIENT_ARGS, argv,
-                IDX_COLOR_SCHEME, "");
+                IDX_COLOR_SCHEME, GUAC_TERMINAL_DEFAULT_COLOR_SCHEME);
 
     /* Pull width/height/resolution directly from user */
     settings->width      = user->info.optimal_width;
@@ -491,7 +492,7 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
     /* Parse backspace key setting */
     settings->backspace =
         guac_user_parse_args_int(user, GUAC_SSH_CLIENT_ARGS, argv,
-                IDX_BACKSPACE, 127);
+                IDX_BACKSPACE, GUAC_TERMINAL_DEFAULT_BACKSPACE);
 
     /* Read terminal emulator type. */
     settings->terminal_type =

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -27,17 +27,6 @@
 #include <stdbool.h>
 
 /**
- * The name of the font to use for the terminal if no name is specified.
- */
-#define GUAC_SSH_DEFAULT_FONT_NAME "monospace" 
-
-/**
- * The size of the font to use for the terminal if no font size is specified,
- * in points.
- */
-#define GUAC_SSH_DEFAULT_FONT_SIZE 12
-
-/**
  * The port to connect to when initiating any SSH connection, if no other port
  * is specified.
  */
@@ -57,11 +46,6 @@
  * The default polling timeout for SSH activity in milliseconds.
  */
 #define GUAC_SSH_DEFAULT_POLL_TIMEOUT 1000
-
-/**
- * The default maximum scrollback size in rows.
- */
-#define GUAC_SSH_DEFAULT_MAX_SCROLLBACK 1000
 
 /**
  * Settings for the SSH connection. The values for this structure are parsed

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -238,12 +238,24 @@ void* ssh_client_thread(void* data) {
                 settings->recording_include_keys);
     }
 
+    /* Create terminal options with required parameters */
+    guac_terminal_options* options = guac_terminal_options_create(
+            client, ssh_client->clipboard,
+            settings->width, settings->height, settings->resolution);
+
+    /* Set optional parameters */
+    options->disable_copy = settings->disable_copy;
+    options->max_scrollback = settings->max_scrollback;
+    options->font_name = settings->font_name;
+    options->font_size = settings->font_size;
+    options->color_scheme = settings->color_scheme;
+    options->backspace = settings->backspace;
+
     /* Create terminal */
-    ssh_client->term = guac_terminal_create(client, ssh_client->clipboard,
-            settings->disable_copy, settings->max_scrollback,
-            settings->font_name, settings->font_size, settings->resolution,
-            settings->width, settings->height, settings->color_scheme,
-            settings->backspace);
+    ssh_client->term = guac_terminal_create(options);
+
+    /* Free options struct now that it's been used */
+    free(options);
 
     /* Fail if terminal init failed */
     if (ssh_client->term == NULL) {

--- a/src/protocols/telnet/settings.c
+++ b/src/protocols/telnet/settings.c
@@ -22,6 +22,7 @@
 #include "argv.h"
 #include "common/defaults.h"
 #include "settings.h"
+#include "terminal/terminal.h"
 
 #include <guacamole/user.h>
 #include <guacamole/wol-constants.h>
@@ -192,8 +193,8 @@ enum TELNET_ARGS_IDX {
     IDX_READ_ONLY,
 
     /**
-     * ASCII code, as an integer to use for the backspace key, or 127
-     * if not specified.
+     * ASCII code, as an integer to use for the backspace key, or
+     * GUAC_TERMINAL_DEFAULT_BACKSPACE if not specified.
      */
     IDX_BACKSPACE,
 
@@ -401,22 +402,22 @@ guac_telnet_settings* guac_telnet_parse_args(guac_user* user,
     /* Read maximum scrollback size */
     settings->max_scrollback =
         guac_user_parse_args_int(user, GUAC_TELNET_CLIENT_ARGS, argv,
-                IDX_SCROLLBACK, GUAC_TELNET_DEFAULT_MAX_SCROLLBACK);
+                IDX_SCROLLBACK, GUAC_TERMINAL_DEFAULT_MAX_SCROLLBACK);
 
     /* Read font name */
     settings->font_name =
         guac_user_parse_args_string(user, GUAC_TELNET_CLIENT_ARGS, argv,
-                IDX_FONT_NAME, GUAC_TELNET_DEFAULT_FONT_NAME);
+                IDX_FONT_NAME, GUAC_TERMINAL_DEFAULT_FONT_NAME);
 
     /* Read font size */
     settings->font_size =
         guac_user_parse_args_int(user, GUAC_TELNET_CLIENT_ARGS, argv,
-                IDX_FONT_SIZE, GUAC_TELNET_DEFAULT_FONT_SIZE);
+                IDX_FONT_SIZE, GUAC_TERMINAL_DEFAULT_FONT_SIZE);
 
     /* Copy requested color scheme */
     settings->color_scheme =
         guac_user_parse_args_string(user, GUAC_TELNET_CLIENT_ARGS, argv,
-                IDX_COLOR_SCHEME, "");
+                IDX_COLOR_SCHEME, GUAC_TERMINAL_DEFAULT_COLOR_SCHEME);
 
     /* Pull width/height/resolution directly from user */
     settings->width      = user->info.optimal_width;
@@ -476,7 +477,7 @@ guac_telnet_settings* guac_telnet_parse_args(guac_user* user,
     /* Parse backspace key code */
     settings->backspace =
         guac_user_parse_args_int(user, GUAC_TELNET_CLIENT_ARGS, argv,
-                IDX_BACKSPACE, 127);
+                IDX_BACKSPACE, GUAC_TERMINAL_DEFAULT_BACKSPACE);
 
     /* Read terminal emulator type. */
     settings->terminal_type =

--- a/src/protocols/telnet/settings.h
+++ b/src/protocols/telnet/settings.h
@@ -27,18 +27,6 @@
 #include <sys/types.h>
 #include <regex.h>
 #include <stdbool.h>
-
-/**
- * The name of the font to use for the terminal if no name is specified.
- */
-#define GUAC_TELNET_DEFAULT_FONT_NAME "monospace" 
-
-/**
- * The size of the font to use for the terminal if no font size is specified,
- * in points.
- */
-#define GUAC_TELNET_DEFAULT_FONT_SIZE 12
-
 /**
  * The port to connect to when initiating any telnet connection, if no other
  * port is specified.
@@ -66,11 +54,6 @@
  * other regular expression is specified.
  */
 #define GUAC_TELNET_DEFAULT_PASSWORD_REGEX "[Pp]assword:"
-
-/**
- * The default maximum scrollback size in rows.
- */
-#define GUAC_TELNET_DEFAULT_MAX_SCROLLBACK 1000
 
 /**
  * Settings for the telnet connection. The values for this structure are parsed

--- a/src/protocols/telnet/telnet.c
+++ b/src/protocols/telnet/telnet.c
@@ -585,12 +585,24 @@ void* guac_telnet_client_thread(void* data) {
                 settings->recording_include_keys);
     }
 
+    /* Create terminal options with required parameters */
+    guac_terminal_options* options = guac_terminal_options_create(
+            client, telnet_client->clipboard,
+            settings->width, settings->height, settings->resolution);
+
+    /* Set optional parameters */
+    options->disable_copy = settings->disable_copy;
+    options->max_scrollback = settings->max_scrollback;
+    options->font_name = settings->font_name;
+    options->font_size = settings->font_size;
+    options->color_scheme = settings->color_scheme;
+    options->backspace = settings->backspace;
+
     /* Create terminal */
-    telnet_client->term = guac_terminal_create(client,
-            telnet_client->clipboard, settings->disable_copy,
-            settings->max_scrollback, settings->font_name, settings->font_size,
-            settings->resolution, settings->width, settings->height,
-            settings->color_scheme, settings->backspace);
+    telnet_client->term = guac_terminal_create(options);
+
+    /* Free options struct now that it's been used */
+    free(options);
 
     /* Fail if terminal init failed */
     if (telnet_client->term == NULL) {

--- a/src/terminal/Makefile.am
+++ b/src/terminal/Makefile.am
@@ -26,9 +26,11 @@
 AUTOMAKE_OPTIONS = foreign 
 ACLOCAL_AMFLAGS = -I m4
 
-noinst_LTLIBRARIES = libguac_terminal.la
+lib_LTLIBRARIES = libguac_terminal.la
 
-noinst_HEADERS =                 \
+libguac_terminalincdir = $(includedir)/guacamole/terminal
+
+libguac_terminalinc_HEADERS =    \
     terminal/buffer.h            \
     terminal/char_mappings.h     \
     terminal/common.h            \


### PR DESCRIPTION
As described in [GUACAMOLE-1538](https://issues.apache.org/jira/projects/GUACAMOLE/issues/GUACAMOLE-1538), this change modifies the `libguac_terminal` library to be a shared library, instead of being duplicated into each of the three existing terminal-based libaries (ssh, telnet, and kubernetes).

In addition, this change also refactors the way that the `guac_terminal` is created - rather than including every possible parameter into `guac_terminal_create`, there is now an `guac_terminal_options` struct, which only requires that a few required parameters be specified (client, clipboard, width, height, and dpi).

All other parameters can be set directly if needed. This should allow new parameters to be added without having to modify the call to `guac_terminal_create` for every user of this library.