### PR TITLE
GUACAMOLE-876: Test for open files only if filesystem has been allocated.

### DIFF
--- a/src/protocols/rdp/channels/disp.c
+++ b/src/protocols/rdp/channels/disp.c
@@ -281,7 +281,8 @@ int guac_rdp_disp_reconnect_needed(guac_rdp_disp* disp) {
     guac_rdp_client* rdp_client = (guac_rdp_client*) disp->client->data;
 
     /* Do not reconnect if files are open. */
-    if (rdp_client->filesystem->open_files > 0)
+    if (rdp_client->filesystem != NULL
+            && rdp_client->filesystem->open_files > 0)
         return 0;
 
     /* Do not reconnect if an active print job is present */


### PR DESCRIPTION
This should fix the following:

```
...
Thread 2.4 "guacd" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffe90c9700 (LWP 3015513)]
0x00007ffff6746b72 in guac_rdp_disp_reconnect_needed (disp=0x7ffff0052d80)
    at channels/disp.c:284
284	    if (rdp_client->filesystem->open_files > 0)
(gdb) print rdp_client
$1 = (guac_rdp_client *) 0x7ffff0052c40
(gdb) print rdp_client->filesystem
$2 = (guac_rdp_fs *) 0x0
(gdb) 
```