### PR TITLE
GUACAMOLE-1543: Move recording functionality from common to libguac.

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -42,7 +42,6 @@ noinst_HEADERS =            \
     common/json.h           \
     common/list.h           \
     common/pointer_cursor.h \
-    common/recording.h      \
     common/rect.h           \
     common/string.h         \
     common/surface.h
@@ -59,7 +58,6 @@ libguac_common_la_SOURCES = \
     json.c                  \
     list.c                  \
     pointer_cursor.c        \
-    recording.c             \
     rect.c                  \
     string.c                \
     surface.c

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -59,6 +59,7 @@ libguacinc_HEADERS =                  \
     guacamole/protocol.h              \
     guacamole/protocol-constants.h    \
     guacamole/protocol-types.h        \
+    guacamole/recording.h             \
     guacamole/socket-constants.h      \
     guacamole/socket.h                \
     guacamole/socket-fntypes.h        \
@@ -99,6 +100,7 @@ libguac_la_SOURCES =   \
     pool.c             \
     protocol.c         \
     raw_encoder.c      \
+    recording.c             \
     socket.c           \
     socket-broadcast.c \
     socket-fd.c        \

--- a/src/libguac/guacamole/recording.h
+++ b/src/libguac/guacamole/recording.h
@@ -17,10 +17,16 @@
  * under the License.
  */
 
-#ifndef GUAC_COMMON_RECORDING_H
-#define GUAC_COMMON_RECORDING_H
+#ifndef GUAC_RECORDING_H
+#define GUAC_RECORDING_H
 
 #include <guacamole/client.h>
+
+/**
+ * Provides functions and structures to be use for session recording.
+ *
+ * @file recording.h
+ */
 
 /**
  * The maximum numeric value allowed for the .1, .2, .3, etc. suffix appended
@@ -47,7 +53,7 @@
  * that output Guacamole instructions may be dynamically intercepted and
  * written to a file.
  */
-typedef struct guac_common_recording {
+typedef struct guac_recording {
 
     /**
      * The guac_socket which writes directly to the recording file, rather than
@@ -89,7 +95,7 @@ typedef struct guac_common_recording {
      */
     int include_keys;
 
-} guac_common_recording;
+} guac_recording;
 
 /**
  * Replaces the socket of the given client such that all further Guacamole
@@ -143,11 +149,11 @@ typedef struct guac_common_recording {
  *     passwords, credit card numbers, etc.
  *
  * @return
- *     A new guac_common_recording structure representing the in-progress
+ *     A new guac_recording structure representing the in-progress
  *     recording if the recording file has been successfully created and a
  *     recording will be written, NULL otherwise.
  */
-guac_common_recording* guac_common_recording_create(guac_client* client,
+guac_recording* guac_recording_create(guac_client* client,
         const char* path, const char* name, int create_path,
         int include_output, int include_mouse, int include_touch,
         int include_keys);
@@ -159,15 +165,15 @@ guac_common_recording* guac_common_recording_create(guac_client* client,
  * freed when the guac_client is freed.
  *
  * @param recording
- *     The guac_common_recording to free.
+ *     The guac_recording to free.
  */
-void guac_common_recording_free(guac_common_recording* recording);
+void guac_recording_free(guac_recording* recording);
 
 /**
  * Reports the current mouse position and button state within the recording.
  *
  * @param recording
- *     The guac_common_recording associated with the mouse that has moved.
+ *     The guac_recording associated with the mouse that has moved.
  *
  * @param x
  *     The new X coordinate of the mouse cursor, in pixels.
@@ -188,14 +194,14 @@ void guac_common_recording_free(guac_common_recording* recording);
  *     @see GUAC_CLIENT_MOUSE_SCROLL_UP
  *     @see GUAC_CLIENT_MOUSE_SCROLL_DOWN
  */
-void guac_common_recording_report_mouse(guac_common_recording* recording,
+void guac_recording_report_mouse(guac_recording* recording,
         int x, int y, int button_mask);
 
 /**
  * Reports the current state of a touch contact within the recording.
  *
  * @param recording
- *     The guac_common_recording associated with the touch contact that
+ *     The guac_recording associated with the touch contact that
  *     has changed state.
  *
  * @param id
@@ -225,7 +231,7 @@ void guac_common_recording_report_mouse(guac_common_recording* recording,
  *     (the touch has been lifted) and 1 is maximum force (the maximum amount
  *     of force representable by the device).
  */
-void guac_common_recording_report_touch(guac_common_recording* recording,
+void guac_recording_report_touch(guac_recording* recording,
         int id, int x, int y, int x_radius, int y_radius,
         double angle, double force);
 
@@ -233,7 +239,7 @@ void guac_common_recording_report_touch(guac_common_recording* recording,
  * Reports a change in the state of an individual key within the recording.
  *
  * @param recording
- *     The guac_common_recording associated with the key that was pressed or
+ *     The guac_recording associated with the key that was pressed or
  *     released.
  *
  * @param keysym
@@ -243,7 +249,7 @@ void guac_common_recording_report_touch(guac_common_recording* recording,
  *     Non-zero if the key represented by the given keysym is currently
  *     pressed, zero if it is released.
  */
-void guac_common_recording_report_key(guac_common_recording* recording,
+void guac_recording_report_key(guac_recording* recording,
         int keysym, int pressed);
 
 #endif

--- a/src/libguac/recording.c
+++ b/src/libguac/recording.c
@@ -17,12 +17,11 @@
  * under the License.
  */
 
-#include "common/recording.h"
-
-#include <guacamole/client.h>
-#include <guacamole/protocol.h>
-#include <guacamole/socket.h>
-#include <guacamole/timestamp.h>
+#include "guacamole/client.h"
+#include "guacamole/protocol.h"
+#include "guacamole/recording.h"
+#include "guacamole/socket.h"
+#include "guacamole/timestamp.h"
 
 #ifdef __MINGW32__
 #include <direct.h>
@@ -64,7 +63,7 @@
  *     The file descriptor of the open data file if open succeeded, or -1 on
  *     failure.
  */
-static int guac_common_recording_open(const char* path,
+static int guac_recording_open(const char* path,
         const char* name, char* basename, int basename_size) {
 
     int i;
@@ -135,7 +134,7 @@ static int guac_common_recording_open(const char* path,
 
 }
 
-guac_common_recording* guac_common_recording_create(guac_client* client,
+guac_recording* guac_recording_create(guac_client* client,
         const char* path, const char* name, int create_path,
         int include_output, int include_mouse, int include_touch,
         int include_keys) {
@@ -155,7 +154,7 @@ guac_common_recording* guac_common_recording_create(guac_client* client,
     }
 
     /* Attempt to open recording file */
-    int fd = guac_common_recording_open(path, name, filename, sizeof(filename));
+    int fd = guac_recording_open(path, name, filename, sizeof(filename));
     if (fd == -1) {
         guac_client_log(client, GUAC_LOG_ERROR,
                 "Creation of recording failed: %s", strerror(errno));
@@ -163,7 +162,7 @@ guac_common_recording* guac_common_recording_create(guac_client* client,
     }
 
     /* Create recording structure with reference to underlying socket */
-    guac_common_recording* recording = malloc(sizeof(guac_common_recording));
+    guac_recording* recording = malloc(sizeof(guac_recording));
     recording->socket = guac_socket_open(fd);
     recording->include_output = include_output;
     recording->include_mouse = include_mouse;
@@ -184,7 +183,7 @@ guac_common_recording* guac_common_recording_create(guac_client* client,
 
 }
 
-void guac_common_recording_free(guac_common_recording* recording) {
+void guac_recording_free(guac_recording* recording) {
 
     /* If not including broadcast output, the output socket is not associated
      * with the client, and must be freed manually */
@@ -196,7 +195,7 @@ void guac_common_recording_free(guac_common_recording* recording) {
 
 }
 
-void guac_common_recording_report_mouse(guac_common_recording* recording,
+void guac_recording_report_mouse(guac_recording* recording,
         int x, int y, int button_mask) {
 
     /* Report mouse location only if recording should contain mouse events */
@@ -206,7 +205,7 @@ void guac_common_recording_report_mouse(guac_common_recording* recording,
 
 }
 
-void guac_common_recording_report_touch(guac_common_recording* recording,
+void guac_recording_report_touch(guac_recording* recording,
         int id, int x, int y, int x_radius, int y_radius,
         double angle, double force) {
 
@@ -217,7 +216,7 @@ void guac_common_recording_report_touch(guac_common_recording* recording,
 
 }
 
-void guac_common_recording_report_key(guac_common_recording* recording,
+void guac_recording_report_key(guac_recording* recording,
         int keysym, int pressed) {
 
     /* Report key state only if recording should contain key events */

--- a/src/protocols/kubernetes/input.c
+++ b/src/protocols/kubernetes/input.c
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-#include "common/recording.h"
 #include "input.h"
 #include "kubernetes.h"
 #include "terminal/terminal.h"
 
 #include <guacamole/client.h>
+#include <guacamole/recording.h>
 #include <guacamole/user.h>
 
 #include <stdlib.h>
@@ -41,7 +41,7 @@ int guac_kubernetes_user_mouse_handler(guac_user* user,
 
     /* Report mouse position within recording */
     if (kubernetes_client->recording != NULL)
-        guac_common_recording_report_mouse(kubernetes_client->recording, x, y,
+        guac_recording_report_mouse(kubernetes_client->recording, x, y,
                 mask);
 
     guac_terminal_send_mouse(term, user, x, y, mask);
@@ -57,7 +57,7 @@ int guac_kubernetes_user_key_handler(guac_user* user, int keysym, int pressed) {
 
     /* Report key state within recording */
     if (kubernetes_client->recording != NULL)
-        guac_common_recording_report_key(kubernetes_client->recording,
+        guac_recording_report_key(kubernetes_client->recording,
                 keysym, pressed);
 
     /* Skip if terminal not yet ready */

--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -21,7 +21,6 @@
 
 #include "argv.h"
 #include "client.h"
-#include "common/recording.h"
 #include "io.h"
 #include "kubernetes.h"
 #include "ssl.h"
@@ -30,6 +29,7 @@
 
 #include <guacamole/client.h>
 #include <guacamole/protocol.h>
+#include <guacamole/recording.h>
 #include <libwebsockets.h>
 
 #include <pthread.h>
@@ -229,7 +229,7 @@ void* guac_kubernetes_client_thread(void* data) {
 
     /* Set up screen recording, if requested */
     if (settings->recording_path != NULL) {
-        kubernetes_client->recording = guac_common_recording_create(client,
+        kubernetes_client->recording = guac_recording_create(client,
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path,
@@ -369,7 +369,7 @@ fail:
 
     /* Clean up recording, if in progress */
     if (kubernetes_client->recording != NULL)
-        guac_common_recording_free(kubernetes_client->recording);
+        guac_recording_free(kubernetes_client->recording);
 
     /* Free WebSocket context if successfully allocated */
     if (kubernetes_client->context != NULL)

--- a/src/protocols/kubernetes/kubernetes.h
+++ b/src/protocols/kubernetes/kubernetes.h
@@ -21,12 +21,12 @@
 #define GUAC_KUBERNETES_H
 
 #include "common/clipboard.h"
-#include "common/recording.h"
 #include "io.h"
 #include "settings.h"
 #include "terminal/terminal.h"
 
 #include <guacamole/client.h>
+#include <guacamole/recording.h>
 #include <libwebsockets.h>
 
 #include <pthread.h>
@@ -123,7 +123,7 @@ typedef struct guac_kubernetes_client {
      * The in-progress session recording, or NULL if no recording is in
      * progress.
      */
-    guac_common_recording* recording;
+    guac_recording* recording;
 
 } guac_kubernetes_client;
 

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -21,7 +21,6 @@
 #include "channels/audio-input/audio-buffer.h"
 #include "channels/cliprdr.h"
 #include "channels/disp.h"
-#include "common/recording.h"
 #include "config.h"
 #include "fs.h"
 #include "log.h"
@@ -37,6 +36,7 @@
 
 #include <guacamole/audio.h>
 #include <guacamole/client.h>
+#include <guacamole/recording.h>
 
 #include <dirent.h>
 #include <errno.h>
@@ -217,7 +217,7 @@ int guac_rdp_client_free_handler(guac_client* client) {
 
     /* Clean up recording, if in progress */
     if (rdp_client->recording != NULL)
-        guac_common_recording_free(rdp_client->recording);
+        guac_recording_free(rdp_client->recording);
 
     /* Clean up audio stream, if allocated */
     if (rdp_client->audio != NULL)

--- a/src/protocols/rdp/input.c
+++ b/src/protocols/rdp/input.c
@@ -21,7 +21,6 @@
 #include "channels/rdpei.h"
 #include "common/cursor.h"
 #include "common/display.h"
-#include "common/recording.h"
 #include "input.h"
 #include "keyboard.h"
 #include "rdp.h"
@@ -30,6 +29,7 @@
 #include <freerdp/freerdp.h>
 #include <freerdp/input.h>
 #include <guacamole/client.h>
+#include <guacamole/recording.h>
 #include <guacamole/user.h>
 
 #include <stdlib.h>
@@ -51,7 +51,7 @@ int guac_rdp_user_mouse_handler(guac_user* user, int x, int y, int mask) {
 
     /* Report mouse position within recording */
     if (rdp_client->recording != NULL)
-        guac_common_recording_report_mouse(rdp_client->recording, x, y, mask);
+        guac_recording_report_mouse(rdp_client->recording, x, y, mask);
 
     /* If button mask unchanged, just send move event */
     if (mask == rdp_client->mouse_button_mask) {
@@ -145,7 +145,7 @@ int guac_rdp_user_touch_handler(guac_user* user, int id, int x, int y,
 
     /* Report touch event within recording */
     if (rdp_client->recording != NULL)
-        guac_common_recording_report_touch(rdp_client->recording, id, x, y,
+        guac_recording_report_touch(rdp_client->recording, id, x, y,
                 x_radius, y_radius, angle, force);
 
     /* Forward touch event along RDPEI channel */
@@ -167,7 +167,7 @@ int guac_rdp_user_key_handler(guac_user* user, int keysym, int pressed) {
 
     /* Report key state within recording */
     if (rdp_client->recording != NULL)
-        guac_common_recording_report_key(rdp_client->recording,
+        guac_recording_report_key(rdp_client->recording,
                 keysym, pressed);
 
     /* Skip if keyboard not yet ready */

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -33,7 +33,6 @@
 #include "color.h"
 #include "common/cursor.h"
 #include "common/display.h"
-#include "common/recording.h"
 #include "config.h"
 #include "error.h"
 #include "fs.h"
@@ -71,6 +70,7 @@
 #include <guacamole/audio.h>
 #include <guacamole/client.h>
 #include <guacamole/protocol.h>
+#include <guacamole/recording.h>
 #include <guacamole/socket.h>
 #include <guacamole/string.h>
 #include <guacamole/timestamp.h>
@@ -806,7 +806,7 @@ void* guac_rdp_client_thread(void* data) {
 
     /* Set up screen recording, if requested */
     if (settings->recording_path != NULL) {
-        rdp_client->recording = guac_common_recording_create(client,
+        rdp_client->recording = guac_recording_create(client,
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path,

--- a/src/protocols/rdp/rdp.h
+++ b/src/protocols/rdp/rdp.h
@@ -27,7 +27,6 @@
 #include "common/clipboard.h"
 #include "common/display.h"
 #include "common/list.h"
-#include "common/recording.h"
 #include "common/surface.h"
 #include "config.h"
 #include "fs.h"
@@ -45,6 +44,7 @@
 #include <freerdp/freerdp.h>
 #include <guacamole/audio.h>
 #include <guacamole/client.h>
+#include <guacamole/recording.h>
 #include <winpr/wtypes.h>
 
 #include <pthread.h>
@@ -142,7 +142,7 @@ typedef struct guac_rdp_client {
      * The in-progress session recording, or NULL if no recording is in
      * progress.
      */
-    guac_common_recording* recording;
+    guac_recording* recording;
 
     /**
      * Display size update module.

--- a/src/protocols/ssh/client.c
+++ b/src/protocols/ssh/client.c
@@ -21,7 +21,6 @@
 
 #include "argv.h"
 #include "client.h"
-#include "common/recording.h"
 #include "common-ssh/sftp.h"
 #include "ssh.h"
 #include "terminal/terminal.h"
@@ -34,6 +33,7 @@
 
 #include <guacamole/argv.h>
 #include <guacamole/client.h>
+#include <guacamole/recording.h>
 
 int guac_client_init(guac_client* client) {
 
@@ -99,7 +99,7 @@ int guac_ssh_client_free_handler(guac_client* client) {
 
     /* Clean up recording, if in progress */
     if (ssh_client->recording != NULL)
-        guac_common_recording_free(ssh_client->recording);
+        guac_recording_free(ssh_client->recording);
 
     /* Free interactive SSH session */
     if (ssh_client->session != NULL)

--- a/src/protocols/ssh/input.c
+++ b/src/protocols/ssh/input.c
@@ -21,11 +21,11 @@
 
 #include "common/cursor.h"
 #include "common/display.h"
-#include "common/recording.h"
 #include "ssh.h"
 #include "terminal/terminal.h"
 
 #include <guacamole/client.h>
+#include <guacamole/recording.h>
 #include <guacamole/user.h>
 #include <libssh2.h>
 
@@ -43,7 +43,7 @@ int guac_ssh_user_mouse_handler(guac_user* user, int x, int y, int mask) {
 
     /* Report mouse position within recording */
     if (ssh_client->recording != NULL)
-        guac_common_recording_report_mouse(ssh_client->recording, x, y, mask);
+        guac_recording_report_mouse(ssh_client->recording, x, y, mask);
 
     /* Send mouse event */
     guac_terminal_send_mouse(term, user, x, y, mask);
@@ -58,7 +58,7 @@ int guac_ssh_user_key_handler(guac_user* user, int keysym, int pressed) {
 
     /* Report key state within recording */
     if (ssh_client->recording != NULL)
-        guac_common_recording_report_key(ssh_client->recording,
+        guac_recording_report_key(ssh_client->recording,
                 keysym, pressed);
 
     /* Skip if terminal not yet ready */

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -20,7 +20,6 @@
 #include "config.h"
 
 #include "argv.h"
-#include "common/recording.h"
 #include "common-ssh/sftp.h"
 #include "common-ssh/ssh.h"
 #include "settings.h"
@@ -36,6 +35,7 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 #include <guacamole/client.h>
+#include <guacamole/recording.h>
 #include <guacamole/socket.h>
 #include <guacamole/timestamp.h>
 #include <guacamole/wol.h>
@@ -230,7 +230,7 @@ void* ssh_client_thread(void* data) {
 
     /* Set up screen recording, if requested */
     if (settings->recording_path != NULL) {
-        ssh_client->recording = guac_common_recording_create(client,
+        ssh_client->recording = guac_recording_create(client,
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path,

--- a/src/protocols/ssh/ssh.h
+++ b/src/protocols/ssh/ssh.h
@@ -23,7 +23,6 @@
 #include "config.h"
 
 #include "common/clipboard.h"
-#include "common/recording.h"
 #include "common-ssh/sftp.h"
 #include "common-ssh/ssh.h"
 #include "common-ssh/user.h"
@@ -35,6 +34,7 @@
 #endif
 
 #include <guacamole/client.h>
+#include <guacamole/recording.h>
 
 #include <pthread.h>
 
@@ -99,7 +99,7 @@ typedef struct guac_ssh_client {
      * The in-progress session recording, or NULL if no recording is in
      * progress.
      */
-    guac_common_recording* recording;
+    guac_recording* recording;
 
 } guac_ssh_client ;
 

--- a/src/protocols/telnet/client.c
+++ b/src/protocols/telnet/client.c
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "argv.h"
 #include "client.h"
-#include "common/recording.h"
 #include "settings.h"
 #include "telnet.h"
 #include "user.h"
@@ -34,6 +33,7 @@
 
 #include <guacamole/argv.h>
 #include <guacamole/client.h>
+#include <guacamole/recording.h>
 
 int guac_client_init(guac_client* client) {
 
@@ -82,7 +82,7 @@ int guac_telnet_client_free_handler(guac_client* client) {
 
     /* Clean up recording, if in progress */
     if (telnet_client->recording != NULL)
-        guac_common_recording_free(telnet_client->recording);
+        guac_recording_free(telnet_client->recording);
 
     /* Kill terminal */
     guac_terminal_free(telnet_client->term);

--- a/src/protocols/telnet/input.c
+++ b/src/protocols/telnet/input.c
@@ -18,12 +18,12 @@
  */
 
 #include "config.h"
-#include "common/recording.h"
 #include "input.h"
 #include "terminal/terminal.h"
 #include "telnet.h"
 
 #include <guacamole/client.h>
+#include <guacamole/recording.h>
 #include <guacamole/user.h>
 #include <libtelnet.h>
 
@@ -45,7 +45,7 @@ int guac_telnet_user_mouse_handler(guac_user* user, int x, int y, int mask) {
 
     /* Report mouse position within recording */
     if (telnet_client->recording != NULL)
-        guac_common_recording_report_mouse(telnet_client->recording, x, y,
+        guac_recording_report_mouse(telnet_client->recording, x, y,
                 mask);
 
     /* Send mouse if not searching for password or username */
@@ -65,7 +65,7 @@ int guac_telnet_user_key_handler(guac_user* user, int keysym, int pressed) {
 
     /* Report key state within recording */
     if (telnet_client->recording != NULL)
-        guac_common_recording_report_key(telnet_client->recording,
+        guac_recording_report_key(telnet_client->recording,
                 keysym, pressed);
 
     /* Skip if terminal not yet ready */

--- a/src/protocols/telnet/telnet.c
+++ b/src/protocols/telnet/telnet.c
@@ -20,12 +20,12 @@
 #include "config.h"
 
 #include "argv.h"
-#include "common/recording.h"
 #include "telnet.h"
 #include "terminal/terminal.h"
 
 #include <guacamole/client.h>
 #include <guacamole/protocol.h>
+#include <guacamole/recording.h>
 #include <guacamole/timestamp.h>
 #include <guacamole/wol.h>
 #include <libtelnet.h>
@@ -578,7 +578,7 @@ void* guac_telnet_client_thread(void* data) {
 
     /* Set up screen recording, if requested */
     if (settings->recording_path != NULL) {
-        telnet_client->recording = guac_common_recording_create(client,
+        telnet_client->recording = guac_recording_create(client,
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path,

--- a/src/protocols/telnet/telnet.h
+++ b/src/protocols/telnet/telnet.h
@@ -21,10 +21,10 @@
 #define GUAC_TELNET_H
 
 #include "config.h"
-#include "common/recording.h"
 #include "settings.h"
 #include "terminal/terminal.h"
 
+#include <guacamole/recording.h>
 #include <libtelnet.h>
 
 #include <stdint.h>
@@ -75,7 +75,7 @@ typedef struct guac_telnet_client {
      * The in-progress session recording, or NULL if no recording is in
      * progress.
      */
-    guac_common_recording* recording;
+    guac_recording* recording;
 
 } guac_telnet_client;
 

--- a/src/protocols/vnc/client.c
+++ b/src/protocols/vnc/client.c
@@ -19,7 +19,6 @@
 
 #include "config.h"
 
-#include "common/recording.h"
 #include "client.h"
 #include "user.h"
 #include "vnc.h"
@@ -35,6 +34,7 @@
 #endif
 
 #include <guacamole/client.h>
+#include <guacamole/recording.h>
 
 #include <pthread.h>
 #include <stdlib.h>
@@ -126,7 +126,7 @@ int guac_vnc_client_free_handler(guac_client* client) {
 
     /* Clean up recording, if in progress */
     if (vnc_client->recording != NULL)
-        guac_common_recording_free(vnc_client->recording);
+        guac_recording_free(vnc_client->recording);
 
     /* Free clipboard */
     if (vnc_client->clipboard != NULL)

--- a/src/protocols/vnc/input.c
+++ b/src/protocols/vnc/input.c
@@ -21,9 +21,9 @@
 
 #include "common/cursor.h"
 #include "common/display.h"
-#include "common/recording.h"
 #include "vnc.h"
 
+#include <guacamole/recording.h>
 #include <guacamole/user.h>
 #include <rfb/rfbclient.h>
 
@@ -38,7 +38,7 @@ int guac_vnc_user_mouse_handler(guac_user* user, int x, int y, int mask) {
 
     /* Report mouse position within recording */
     if (vnc_client->recording != NULL)
-        guac_common_recording_report_mouse(vnc_client->recording, x, y, mask);
+        guac_recording_report_mouse(vnc_client->recording, x, y, mask);
 
     /* Send VNC event only if finished connecting */
     if (rfb_client != NULL)
@@ -54,7 +54,7 @@ int guac_vnc_user_key_handler(guac_user* user, int keysym, int pressed) {
 
     /* Report key state within recording */
     if (vnc_client->recording != NULL)
-        guac_common_recording_report_key(vnc_client->recording,
+        guac_recording_report_key(vnc_client->recording,
                 keysym, pressed);
 
     /* Send VNC event only if finished connecting */

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -25,7 +25,6 @@
 #include "common/clipboard.h"
 #include "common/cursor.h"
 #include "common/display.h"
-#include "common/recording.h"
 #include "cursor.h"
 #include "display.h"
 #include "log.h"
@@ -44,6 +43,7 @@
 
 #include <guacamole/client.h>
 #include <guacamole/protocol.h>
+#include <guacamole/recording.h>
 #include <guacamole/socket.h>
 #include <guacamole/timestamp.h>
 #include <guacamole/wol.h>
@@ -421,7 +421,7 @@ void* guac_vnc_client_thread(void* data) {
 
     /* Set up screen recording, if requested */
     if (settings->recording_path != NULL) {
-        vnc_client->recording = guac_common_recording_create(client,
+        vnc_client->recording = guac_recording_create(client,
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path,

--- a/src/protocols/vnc/vnc.h
+++ b/src/protocols/vnc/vnc.h
@@ -25,7 +25,6 @@
 #include "common/clipboard.h"
 #include "common/display.h"
 #include "common/iconv.h"
-#include "common/recording.h"
 #include "common/surface.h"
 #include "settings.h"
 
@@ -42,6 +41,8 @@
 #include "common-ssh/ssh.h"
 #include "common-ssh/user.h"
 #endif
+
+#include <guacamole/recording.h>
 
 #include <pthread.h>
 
@@ -122,7 +123,7 @@ typedef struct guac_vnc_client {
      * The in-progress session recording, or NULL if no recording is in
      * progress.
      */
-    guac_common_recording* recording;
+    guac_recording* recording;
 
     /**
      * Clipboard encoding-specific reader.


### PR DESCRIPTION
From https://issues.apache.org/jira/browse/GUACAMOLE-1543:

Session recording functionality, such as guac_common_recording, is used within every protocol library that supports session recording.

Everything needed to support session recording should be moved to a public library so that new protocols can be developed to support session recording without having to be build inside the guacamole-server build.