### PR TITLE
Fix segfault when display is null

### DIFF
--- a/src/protocols/rdp/user.c
+++ b/src/protocols/rdp/user.c
@@ -166,7 +166,9 @@ int guac_rdp_user_leave_handler(guac_user* user) {
     guac_rdp_client* rdp_client = (guac_rdp_client*) user->client->data;
 
     /* Update shared cursor state */
-    guac_common_cursor_remove_user(rdp_client->display->cursor, user);
+    if (rdp_client->display) {
+        guac_common_cursor_remove_user(rdp_client->display->cursor, user);
+    }
 
     /* Free settings if not owner (owner settings will be freed with client) */
     if (!user->owner) {


### PR DESCRIPTION
It fixes the issue
ASAN:DEADLYSIGNAL
=================================================================
==13504==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000010 (pc 0x7fbe5f49767c bp 0x7fbe5c514c00 sp 0x7fbe5c514be0 T3)
==13504==The signal is caused by a READ memory access.
==13504==Hint: address points to the zero page.
    #0 0x7fbe5f49767b in guac_rdp_user_leave_handler /home/ddoe/devel/guacamole/guacamole-server/src/protocols/rdp/user.c:170
    #1 0x7fbe67889803 in guac_client_remove_user /home/ddoe/devel/guacamole/guacamole-server/src/libguac/client.c:340
    #2 0x7fbe6789bfe9 in guac_user_handle_connection /home/ddoe/devel/guacamole/guacamole-server/src/libguac/user-handshake.c:364
    #3 0x5650b8977d8a in guacd_user_thread /home/ddoe/devel/guacamole/guacamole-server/src/guacd/proc.c:100
    #4 0x7fbe676636da in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76da)
    #5 0x7fbe66a5c61e in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x12161e)