### PR TITLE
GUACAMOLE-1115: Ensure RDP print process does not block itself from completing.

### DIFF
--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -199,6 +199,14 @@ int guac_rdp_client_free_handler(guac_client* client) {
     if (rdp_client->filesystem != NULL)
         guac_rdp_fs_free(rdp_client->filesystem);
 
+    /* End active print job, if any */
+    guac_rdp_print_job* job = (guac_rdp_print_job*) rdp_client->active_job;
+    if (job != NULL) {
+        guac_rdp_print_job_kill(job);
+        guac_rdp_print_job_free(job);
+        rdp_client->active_job = NULL;
+    }
+
 #ifdef ENABLE_COMMON_SSH
     /* Free SFTP filesystem, if loaded */
     if (rdp_client->sftp_filesystem)

--- a/src/protocols/rdp/print-job.c
+++ b/src/protocols/rdp/print-job.c
@@ -28,6 +28,7 @@
 
 #include <errno.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -665,6 +666,9 @@ void guac_rdp_print_job_free(guac_rdp_print_job* job) {
 }
 
 void guac_rdp_print_job_kill(guac_rdp_print_job* job) {
+
+    /* Forcibly kill filter process, if running */
+    kill(job->filter_pid, SIGKILL);
 
     /* Stop all handling of I/O */
     close(job->input_fd);

--- a/src/protocols/rdp/print-job.c
+++ b/src/protocols/rdp/print-job.c
@@ -18,6 +18,7 @@
  */
 
 #include "print-job.h"
+#include "rdp.h"
 
 #include <guacamole/client.h>
 #include <guacamole/protocol.h>
@@ -603,6 +604,9 @@ static void guac_rdp_print_job_read_filename(guac_rdp_print_job* job,
 int guac_rdp_print_job_write(guac_rdp_print_job* job,
         void* buffer, int length) {
 
+    guac_client* client = job->client;
+    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
+
     /* Create print job, if not yet created */
     if (job->bytes_received == 0) {
 
@@ -618,18 +622,39 @@ int guac_rdp_print_job_write(guac_rdp_print_job* job,
     /* Update counter of bytes received */
     job->bytes_received += length;
 
-    /* Write data to filter process */
-    return write(job->input_fd, buffer, length);
+    /* Write data to filter process, unblocking any threads waiting on the
+     * generic RDP message lock as this may be a lengthy operation that depends
+     * on other threads sending outstanding messages (resulting in deadlock if
+     * those messages are blocked) */
+    int unlock_status = pthread_mutex_unlock(&(rdp_client->message_lock));
+    int write_status = write(job->input_fd, buffer, length);
+
+    /* Restore RDP message lock state */
+    if (!unlock_status)
+        pthread_mutex_lock(&(rdp_client->message_lock));
+
+    return write_status;
 
 }
 
 void guac_rdp_print_job_free(guac_rdp_print_job* job) {
 
+    guac_client* client = job->client;
+    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
+
     /* No more input will be provided */
     close(job->input_fd);
 
-    /* Wait for job to terminate */
+    /* Wait for job to terminate, unblocking any threads waiting on the generic
+     * RDP message lock as this may be a lengthy operation that depends on
+     * other threads sending outstanding messages (resulting in deadlock if
+     * those messages are blocked) */
+    int unlock_status = pthread_mutex_unlock(&(rdp_client->message_lock));
     pthread_join(job->output_thread, NULL);
+
+    /* Restore RDP message lock state */
+    if (!unlock_status)
+        pthread_mutex_lock(&(rdp_client->message_lock));
 
     /* Destroy lock */
     pthread_mutex_destroy(&(job->state_lock));


### PR DESCRIPTION
As handling of inbound Guacamole messages for the RDP support is inherently tied to the overall RDP `message_lock` (this lock must be acquired before sending out the RDP versions of received mouse events, keyboard events, etc.), the RDP print process has the potential to deadlock if it needs to wait for an inbound "ack" message. The `message_lock` will be acquired before requesting that FreeRDP handle the RDP event queue (the part of the library that performs housekeeping functions around the print job), which may block handling of Guacamole events like "ack".

(See https://issues.apache.org/jira/browse/GUACAMOLE-1115?focusedCommentId=17508379&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17508379)

This change alters the print job handling to temporarily release the `message_lock` before entering a lengthy operation that may otherwise get blocked. The lock is only released if the current thread actually holds the lock, and the lock is reacquired after the lengthy operation is completed.

This change also adds an explicit `kill()` around the filter process to ensure the print job is entirely cleaned up, avoiding having guacd's automatic child process termination failsafe kick in.

I've set the merge base of this to `staging/1.5.0` as this seems an important thing to correct, but let me know if this should be kept out of scope for 1.5.0.