### PR TITLE
Adapt to const parameters of ffmpeg 5.0

### DIFF
--- a/src/guacenc/ffmpeg-compat.c
+++ b/src/guacenc/ffmpeg-compat.c
@@ -213,7 +213,7 @@ int guacenc_avcodec_encode_video(guacenc_video* video, AVFrame* frame) {
 #endif
 }
 
-AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, AVCodec* codec, 
+AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, const AVCodec* codec,
         int bitrate, int width, int height, int gop_size, int qmax, int qmin,
         int pix_fmt, AVRational time_base) {
 
@@ -249,7 +249,7 @@ AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, AVCodec* codec,
 }
 
 int guacenc_open_avcodec(AVCodecContext *avcodec_context,
-        AVCodec *codec, AVDictionary **options,
+        const AVCodec *codec, AVDictionary **options,
         AVStream* stream) {
 
     int ret = avcodec_open2(avcodec_context, codec, options);

--- a/src/guacenc/ffmpeg-compat.h
+++ b/src/guacenc/ffmpeg-compat.h
@@ -128,7 +128,7 @@ int guacenc_avcodec_encode_video(guacenc_video* video, AVFrame* frame);
  *     The pointer to the configured AVCodecContext.
  *
  */
-AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, AVCodec* codec,
+AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, const AVCodec* codec,
         int bitrate, int width, int height, int gop_size, int qmax, int qmin,
         int pix_fmt, AVRational time_base);
 
@@ -158,7 +158,7 @@ AVCodecContext* guacenc_build_avcodeccontext(AVStream* stream, AVCodec* codec,
  *     Zero on success, a negative value on error.
  */
 int guacenc_open_avcodec(AVCodecContext *avcodec_context,
-        AVCodec *codec, AVDictionary **options,
+        const AVCodec *codec, AVDictionary **options,
         AVStream* stream);
 
 #endif

--- a/src/guacenc/video.c
+++ b/src/guacenc/video.c
@@ -47,7 +47,7 @@
 guacenc_video* guacenc_video_alloc(const char* path, const char* codec_name,
         int width, int height, int bitrate) {
 
-    AVOutputFormat *container_format;
+    const AVOutputFormat *container_format;
     AVFormatContext *container_format_context;
     AVStream *video_stream;
     int ret;
@@ -63,7 +63,7 @@ guacenc_video* guacenc_video_alloc(const char* path, const char* codec_name,
     container_format = container_format_context->oformat;
 
     /* Pull codec based on name */
-    AVCodec* codec = avcodec_find_encoder_by_name(codec_name);
+    const AVCodec* codec = avcodec_find_encoder_by_name(codec_name);
     if (codec == NULL) {
         guacenc_log(GUAC_LOG_ERROR, "Failed to locate codec \"%s\".",
                 codec_name);


### PR DESCRIPTION
It seems that a few parameters are now const which guacamole treats as
non-const. Mark some variables and parameters as const to match. This
should be pretty safe and compatible. I've verified only that this now
compiles without error.