### PR TITLE
GUACAMOLE-1589: To apt install software  using ubuntu repository is too slow  in  China 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,21 @@ FROM ubuntu:${UBUNTU_BASE_IMAGE} AS builder
 # NOTE: Due to limitations of the Docker image build process, this value is
 # duplicated in an ARG in the second stage of the build.
 #
-ARG UBUNTU_RELEASE=impish-backports
+ARG UBUNTU_RELEASE=impish
+
+ARG USE_DEFAULT_REPO=false
+
+ARG PREFIX_DIR=/usr/local/guacamole
+
+COPY src/guacd-docker/bin "${PREFIX_DIR}/bin/"
+
+RUN $USE_DEFAULT_REPO || $PREFIX_DIR/bin/add-apt-mirror.sh $UBUNTU_RELEASE
+
 
 # Add repository for specified Ubuntu release if not already present in
 # sources.list
-RUN grep " ${UBUNTU_RELEASE} " /etc/apt/sources.list || echo >> /etc/apt/sources.list \
-    "deb http://archive.ubuntu.com/ubuntu/ ${UBUNTU_RELEASE} main contrib non-free"
+RUN grep "${UBUNTU_RELEASE}-backports" /etc/apt/sources.list || echo >> /etc/apt/sources.list \
+    "deb http://archive.ubuntu.com/ubuntu/ ${UBUNTU_RELEASE}-backports main restricted universe multiverse"
 
 #
 # Base directory for installed build artifacts.
@@ -47,7 +56,6 @@ RUN grep " ${UBUNTU_RELEASE} " /etc/apt/sources.list || echo >> /etc/apt/sources
 # NOTE: Due to limitations of the Docker image build process, this value is
 # duplicated in an ARG in the second stage of the build.
 #
-ARG PREFIX_DIR=/usr/local/guacamole
 
 # Build arguments
 ARG BUILD_DIR=/tmp/guacd-docker-BUILD
@@ -80,7 +88,7 @@ RUN apt-get update                                              && \
     rm -rf /var/lib/apt/lists/*
 
 # Add configuration scripts
-COPY src/guacd-docker/bin "${PREFIX_DIR}/bin/"
+
 
 # Copy source to container for sake of build
 COPY . "$BUILD_DIR"
@@ -105,12 +113,18 @@ FROM ubuntu:${UBUNTU_BASE_IMAGE}
 # NOTE: Due to limitations of the Docker image build process, this value is
 # duplicated in an ARG in the first stage of the build.
 #
-ARG UBUNTU_RELEASE=impish-backports
+ARG UBUNTU_RELEASE=impish
+
+ARG USE_DEFAULT_REPO=false
+
+COPY src/guacd-docker/bin/add-apt-mirror.sh /tmp
+
+RUN $USE_DEFAULT_REPO ||/tmp/add-apt-mirror.sh $UBUNTU_RELEASE
 
 # Add repository for specified Ubuntu release if not already present in
 # sources.list
-RUN grep " ${UBUNTU_RELEASE} " /etc/apt/sources.list || echo >> /etc/apt/sources.list \
-    "deb http://archive.ubuntu.com/ubuntu/ ${UBUNTU_RELEASE} main contrib non-free"
+RUN grep "${UBUNTU_RELEASE}-backports" /etc/apt/sources.list || echo >> /etc/apt/sources.list \
+    "deb http://archive.ubuntu.com/ubuntu/ ${UBUNTU_RELEASE}-backports main restricted universe multiverse "
 
 #
 # Base directory for installed build artifacts. See also the

--- a/src/guacd-docker/bin/add-apt-mirror.sh
+++ b/src/guacd-docker/bin/add-apt-mirror.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+UBUNTU_RELEASE=$1
+APT_SOURCE="http://mirrors.tuna.tsinghua.edu.cn/ubuntu/"
+APT_SECURITY_SOURCE="http://mirrors.tuna.tsinghua.edu.cn/ubuntu/"
+test -n "$APT_SOURCE" && test -n "$APT_SECURITY_SOURCE"  || ( echo "Please set mirror repo location when you set USE_DEFAULT_REPO to false" && exit 1)
+echo "Add apt mirror $APT_SOURCE $APT_SECURITY_SOURCE"
+cp /etc/apt/sources.list  /etc/apt/sources.list.bak
+cat <<EOF > /etc/apt/sources.list  
+    deb ${APT_SOURCE} ${UBUNTU_RELEASE} main restricted universe multiverse 
+    deb ${APT_SOURCE}  ${UBUNTU_RELEASE}-updates main restricted universe multiverse
+    deb ${APT_SECURITY_SOURCE}  ${UBUNTU_RELEASE}-security main restricted universe multiverse 
+    deb ${APT_SOURCE}  ${UBUNTU_RELEASE}-backports main restricted universe multiverse 
+EOF

--- a/src/guacd-docker/bin/add-apt-mirror.sh
+++ b/src/guacd-docker/bin/add-apt-mirror.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 UBUNTU_RELEASE=$1
-APT_SOURCE="http://mirrors.tuna.tsinghua.edu.cn/ubuntu/"
-APT_SECURITY_SOURCE="http://mirrors.tuna.tsinghua.edu.cn/ubuntu/"
+APT_SOURCE=""
+APT_SECURITY_SOURCE=""
 test -n "$APT_SOURCE" && test -n "$APT_SECURITY_SOURCE"  || ( echo "Please set mirror repo location when you set USE_DEFAULT_REPO to false" && exit 1)
 echo "Add apt mirror $APT_SOURCE $APT_SECURITY_SOURCE"
 cp /etc/apt/sources.list  /etc/apt/sources.list.bak


### PR DESCRIPTION
### This PR  is intended to  use mirror when  a guy stunk in apt install stage as he build docker image. 

- And here is another point, I found that guacamole team use ubuntu as a base image  instead of debian . For the  code consistency ,the division of ubuntu apt packages(free softwares) are _main ,restricted, universe and multiverse_
 Another point is packages impish or security version.  For example ,impish release version, it contains _impish(base version) ,impish-updates(update version), impish-security(with security version) ,impish-backports(backup version)._ The last backports version is always not installed as a first choice. 

- So I think it is a better name use impish as a grep keyword . And if we enable mirror config ,we shoud add all repo search location.
- It is suggested that security repo should be declared separately for more safety.