### PR TITLE
GUACAMOLE-377: Update unit tests for new prototype of guac_protocol_send_sync().

### DIFF
--- a/src/libguac/tests/socket/fd_send_instruction.c
+++ b/src/libguac/tests/socket/fd_send_instruction.c
@@ -54,7 +54,7 @@ static void write_instructions(int fd) {
 
     /* Write instructions */
     guac_protocol_send_name(socket, "a" UTF8_4 "b" UTF8_4 "c");
-    guac_protocol_send_sync(socket, 12345);
+    guac_protocol_send_sync(socket, 12345, 1);
     guac_socket_flush(socket);
 
     /* Close and free socket */
@@ -76,7 +76,7 @@ static void read_expected_instructions(int fd) {
 
     char expected[] =
         "4.name,11.a" UTF8_4 "b" UTF8_4 "c;"
-        "4.sync,5.12345;";
+        "4.sync,5.12345,1.1;";
 
     int numread;
     char buffer[1024];

--- a/src/libguac/tests/socket/nested_send_instruction.c
+++ b/src/libguac/tests/socket/nested_send_instruction.c
@@ -65,7 +65,7 @@ static void write_instructions(int fd) {
 
     /* Write instructions */
     guac_protocol_send_name(nested_socket, "a" UTF8_4 "b" UTF8_4 "c");
-    guac_protocol_send_sync(nested_socket, 12345);
+    guac_protocol_send_sync(nested_socket, 12345, 1);
 
     /* Close and free sockets */
     guac_socket_free(nested_socket);
@@ -86,9 +86,9 @@ static void write_instructions(int fd) {
 static void read_expected_instructions(int fd) {
 
     char expected[] =
-        "4.nest,3.123,37."
+        "4.nest,3.123,41."
             "4.name,11.a" UTF8_4 "b" UTF8_4 "c;"
-            "4.sync,5.12345;"
+            "4.sync,5.12345,1.1;"
         ";";
 
     int numread;


### PR DESCRIPTION
The new `guac_protocol_send_sync()` requires an additional parameter - the number of logical frames associated with the sync:

https://github.com/apache/guacamole-server/blob/ffb6c809bebff431bb195685d35bb304f86a9910/src/libguac/guacamole/protocol.h#L372-L375

#363 added this parameter but did make corresponding updates to the unit tests, thus breaking the build on Jenkins. These changes update the unit tests to include the new parameter.