### PR TITLE
GUACAMOLE-1652: Only call SSL init functions when the library version requires it.

### DIFF
--- a/src/common-ssh/ssh.c
+++ b/src/common-ssh/ssh.c
@@ -165,9 +165,11 @@ int guac_common_ssh_init(guac_client* client) {
     CRYPTO_set_locking_callback(guac_common_ssh_openssl_locking_callback);
 #endif
 
-    /* Init OpenSSL */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    /* Init OpenSSL - only required for OpenSSL Versions < 1.1.0 */
     SSL_library_init();
     ERR_load_crypto_strings();
+#endif
 
     /* Init libssh2 */
     libssh2_init(0);

--- a/src/guacd/daemon.c
+++ b/src/guacd/daemon.c
@@ -381,10 +381,15 @@ int main(int argc, char* argv[]) {
         CRYPTO_set_locking_callback(guacd_openssl_locking_callback);
 #endif
 
-        /* Init SSL */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+        /* Init OpenSSL for OpenSSL Versions < 1.1.0 */
         SSL_library_init();
         SSL_load_error_strings();
         ssl_context = SSL_CTX_new(SSLv23_server_method());
+#else
+        /* Set up OpenSSL for OpenSSL Versions >= 1.1.0 */
+        ssl_context = SSL_CTX_new(TLS_server_method());
+#endif
 
         /* Load key */
         if (config->key_file != NULL) {


### PR DESCRIPTION
This change fixes the issues with SFTP + VNC as described here: https://issues.apache.org/jira/browse/GUACAMOLE-1652.