### PR TITLE
GUACAMOLE-1540: Correct automated retrieval of Docker build dependencies.

### DIFF
--- a/src/guacd-docker/bin/list-dependencies.sh
+++ b/src/guacd-docker/bin/list-dependencies.sh
@@ -37,7 +37,7 @@ while [ -n "$1" ]; do
 
         # List the package providing that library, if any
         apk info -W "$LIBRARY" 2> /dev/null \
-            | grep 'is owned by' | grep -o '[^ ]*$'
+            | grep 'is owned by' | grep -o '[^ ]*$' || true
 
     done
 

--- a/src/guacd-docker/bin/list-dependencies.sh
+++ b/src/guacd-docker/bin/list-dependencies.sh
@@ -47,5 +47,5 @@ while [ -n "$1" ]; do
 # Strip the "-VERSION" suffix from each package name, listing each resulting
 # package uniquely ("apk add" cannot handle package names that include the
 # version number)
-done | sed 's/\(.*\)-[0-9]\..*$/\1/' | sort -u
+done | sed 's/\(.*\)-[0-9]\+\..*$/\1/' | sort -u
 


### PR DESCRIPTION
As noted by @myamoto on #388, the new Alpine-based Docker build does not correctly determine the packages needed to satisfy runtime dependencies. This is because the `list-dependencies.sh` script was erroring out early when it ran into a library that our new Docker build manually builds itself, causing the dependencies of other files to be ignored.

This changes corrects the above by:

* Ignoring if `apk` cannot determine the package for a particular library, proceeding with determining all other dependencies.
* Ensuring that the package version is stripped correctly regardless of how many digits are in the major number (an issue that appeared only after dependency retrieval was allowed to finish in its entirety)

Before:

```console
$ docker run --rm guacd cat /opt/guacamole/DEPENDENCIES 
brotli-libs
cairo
expat
fontconfig
freetype
libbz2
libcrypto1.1
libjpeg-turbo
libpng
libssl1.1
libuuid
libwebp
libx11
libxau
libxcb
libxdmcp
libxext
libxrender
musl
pixman
zlib
$
```

After:

```console
$ docker run --rm guacd cat /opt/guacamole/DEPENDENCIES 
brotli-libs
cairo
dbus-libs
expat
flac
fontconfig
freetype
fribidi
glib
graphite2
harfbuzz
libasyncns
libblkid
libbz2
libcrypto1.1
libffi
libintl
libjpeg-turbo
libmount
libogg
libpng
libpulse
libsndfile
libssl1.1
libuuid
libvorbis
libwebp
libx11
libxau
libxcb
libxdmcp
libxext
libxrender
musl
opus
pango
pcre
pixman
zlib
$
```