### PR TITLE
GUACAMOLE-1674: Warn about NLA mode if FIPS mode is enabled, or disable if possible.

### DIFF
--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -28,6 +28,7 @@
 #include <freerdp/settings.h>
 #include <freerdp/freerdp.h>
 #include <guacamole/client.h>
+#include <guacamole/fips.h>
 #include <guacamole/string.h>
 #include <guacamole/user.h>
 #include <guacamole/wol-constants.h>
@@ -38,6 +39,16 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+
+/**
+ * A warning to log when NLA mode is selected while FIPS mode is active on the
+ * guacd server.
+ */
+const char fips_nla_mode_warning[] = (
+        "NLA security mode was selected, but is known to be currently incompatible "
+        "with FIPS mode (see FreeRDP/FreeRDP#3412). Security negotiation with the "
+        "RDP server may fail unless TLS security mode is selected instead."
+);
 
 /* Client plugin arguments */
 const char* GUAC_RDP_CLIENT_ARGS[] = {
@@ -706,12 +717,27 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     if (strcmp(argv[IDX_SECURITY], "nla") == 0) {
         guac_user_log(user, GUAC_LOG_INFO, "Security mode: NLA");
         settings->security_mode = GUAC_SECURITY_NLA;
+
+        /*
+         * NLA is known not to work with FIPS; allow the mode selection but
+         * warn that it will not work.
+         */
+        if (guac_fips_enabled())
+            guac_user_log(user, GUAC_LOG_WARNING, fips_nla_mode_warning);
+
     }
 
     /* Extended NLA security */
     else if (strcmp(argv[IDX_SECURITY], "nla-ext") == 0) {
         guac_user_log(user, GUAC_LOG_INFO, "Security mode: Extended NLA");
         settings->security_mode = GUAC_SECURITY_EXTENDED_NLA;
+
+        /*
+         * NLA is known not to work with FIPS; allow the mode selection but
+         * warn that it will not work.
+         */
+        if (guac_fips_enabled())
+            guac_user_log(user, GUAC_LOG_WARNING, fips_nla_mode_warning);
     }
 
     /* TLS security */
@@ -1529,7 +1555,21 @@ void guac_rdp_push_settings(guac_client* client,
         case GUAC_SECURITY_ANY:
             rdp_settings->RdpSecurity = TRUE;
             rdp_settings->TlsSecurity = TRUE;
-            rdp_settings->NlaSecurity = guac_settings->username && guac_settings->password;
+
+            /* Explicitly disable NLA if FIPS mode is enabled - it won't work */
+            if (guac_fips_enabled()) {
+
+                guac_client_log(client, GUAC_LOG_INFO,
+                        "FIPS mode is enabled. Excluding NLA security mode from security negotiation "
+                        "(see: https://github.com/FreeRDP/FreeRDP/issues/3412).");
+                rdp_settings->NlaSecurity = FALSE;
+
+            }
+
+            /* NLA mode is allowed if FIPS is not enabled */
+            else
+                rdp_settings->NlaSecurity = TRUE;
+
             rdp_settings->ExtSecurity = FALSE;
             break;
 


### PR DESCRIPTION
As discussed in https://issues.apache.org/jira/browse/GUACAMOLE-1674, this change does the following when FIPS mode is active on the guacd server:

- Disables NLA security mode when "any" mode is selected in Guacamole
- Warns the user that their selected mode is known not to work if they explicitly select NLA security mode

NOTE: Theoretically both TLS and RDP modes _should_ work, though I was not able to get RDP security mode to work with FIPS enabled, either with a Windows or XRDP remote machine.

In practice, this probably won't matter too much, since the security mode negotiation always seems to prefer TLS over RDP anyway. 

I can also disable/warn about RDP mode too, if people think that's a good idea, though I think we should probably just leave it as is for now. Maybe there's some combination of FreeRDP version / remote environment where it will work, though I wasn't able to find it.