### PR TITLE
GUACAMOLE-1669: Include ext-info-c in preferred KEX algorithms to ensure RSA key upgrades can happen.

### DIFF
--- a/src/common-ssh/ssh.c
+++ b/src/common-ssh/ssh.c
@@ -49,9 +49,12 @@ GCRY_THREAD_OPTION_PTHREAD_IMPL;
 
 /**
  * A list of all key exchange algorithms that are both FIPS-compliant, and
- * OpenSSL-supported.
+ * OpenSSL-supported. Note that "ext-info-c" is also included. While not a key
+ * exchange algorithm per se, it must be in the list to ensure that the server
+ * will send a SSH_MSG_EXT_INFO response, which is required to perform RSA key
+ * upgrades.
  */
-#define FIPS_COMPLIANT_KEX_ALGORITHMS "diffie-hellman-group-exchange-sha256"
+#define FIPS_COMPLIANT_KEX_ALGORITHMS "diffie-hellman-group-exchange-sha256,ext-info-c"
 
 /**
  * A list of ciphers that are both FIPS-compliant, and OpenSSL-supported.


### PR DESCRIPTION
It took a while to work out what was going on here, but excluding "ext-info-c" from the list of preferred KEX algorithms precludes the ssh server from sending the `SSH_MSG_EXT_INFO`  response during negotiation, which will in turn prevent any RSA key upgrades from occurring.

Key upgrade is now working as expected (when using a libssh2 that supports key upgrades).