### PR TITLE
GUACAMOLE-1632: Have spaces written in the appended clipboard.

### DIFF
--- a/src/terminal/select.c
+++ b/src/terminal/select.c
@@ -296,9 +296,10 @@ static void guac_terminal_clipboard_append_row(guac_terminal* terminal,
     /* Clip given range to actual bounds of row */
     if (end < 0 || end > buffer_row->length - 1)
         end = buffer_row->length - 1;
-
+    
+    /* Skip blank chars at the end of a line */
     int j = end;
-    while((!buffer_row->characters[j].value)&& (j > start)){
+    while ((!buffer_row->characters[j].value) && (j > start)) {
         j--;
     }
     if(j != start)

--- a/src/terminal/select.c
+++ b/src/terminal/select.c
@@ -309,8 +309,12 @@ static void guac_terminal_clipboard_append_row(guac_terminal* terminal,
 
             int codepoint = buffer_row->characters[i].value;
 
+            /* Keep consistency with vim display */
+            if (codepoint == 0)
+                codepoint = 32;
+            
             /* Ignore null (blank) characters */
-            if (codepoint == 0 || codepoint == GUAC_CHAR_CONTINUATION)
+            if (codepoint == GUAC_CHAR_CONTINUATION)
                 continue;
 
             /* Encode current codepoint as UTF-8 */

--- a/src/terminal/select.c
+++ b/src/terminal/select.c
@@ -298,10 +298,11 @@ static void guac_terminal_clipboard_append_row(guac_terminal* terminal,
         end = buffer_row->length - 1;
 
     int j = end;
-    while(!buffer_row->characters[j].value){
+    while((!buffer_row->characters[j].value)&& (j > start)){
         j--;
     }
-    end = j;
+    if(j != start)
+        end = j;
 
     /* Repeatedly convert chunks of terminal buffer rows until entire specified
      * region has been appended to clipboard */

--- a/src/terminal/select.c
+++ b/src/terminal/select.c
@@ -297,6 +297,12 @@ static void guac_terminal_clipboard_append_row(guac_terminal* terminal,
     if (end < 0 || end > buffer_row->length - 1)
         end = buffer_row->length - 1;
 
+    int j = end;
+    while(!buffer_row->characters[j].value){
+        j--;
+    }
+    end = j;
+
     /* Repeatedly convert chunks of terminal buffer rows until entire specified
      * region has been appended to clipboard */
     while (i <= end) {


### PR DESCRIPTION
Add end of line identification when writing to the clipboard, avoiding converted spaces.