### PR TITLE
GUACAMOLE-1293: Do not re-acquire __users_lock while already held for writing.

### DIFF
--- a/src/libguac/client.c
+++ b/src/libguac/client.c
@@ -302,14 +302,14 @@ int guac_client_add_user(guac_client* client, guac_user* user, int argc, char** 
         /* Update owner pointer if user is owner */
         if (user->owner)
             client->__owner = user;
-        
-        /* Notify owner of user joining connection. */
-        else
-            guac_client_owner_notify_join(client, user);
 
     }
 
     pthread_rwlock_unlock(&(client->__users_lock));
+
+    /* Notify owner of user joining connection. */
+    if (retval == 0 && !user->owner)
+        guac_client_owner_notify_join(client, user);
 
     return retval;
 
@@ -335,11 +335,11 @@ void guac_client_remove_user(guac_client* client, guac_user* user) {
     if (user->owner)
         client->__owner = NULL;
 
-    /* Update owner of user having left the connection. */
-    else
-        guac_client_owner_notify_leave(client, user);
-
     pthread_rwlock_unlock(&(client->__users_lock));
+
+    /* Update owner of user having left the connection. */
+    if (!user->owner)
+        guac_client_owner_notify_leave(client, user);
 
     /* Call handler, if defined */
     if (user->leave_handler)


### PR DESCRIPTION
These changes make a minor correction to the usage of `__users_lock`. We were incorrectly re-acquiring the lock while it was already held for writing, and then double-releasing the lock. Overall flow is similar for both join/leave notification:

1. User joins/leaves connection and guacd enters `guac_client_add_user()` or `guac_client_remove_user()`.
2. The function in question acquires `__users_lock` for writing.
3. While the lock is held for writing, a function which calls `guac_client_for_owner()` is invoked.
4. `guac_client_for_owner()` acquires `__users_lock` for reading. The behavior of a thread doing this while it already holds the lock for writing is undefined according to POSIX (see below).
5. `guac_client_for_owner()` releases `__users_lock` (first unlock).
6. The function in question also releases `__users_lock` (second unlock).

Per POSIX spec, the behavior of acquiring a read lock on a rwlock that's already acquired for writing is undefined. From the documentation for `pthread_rwlock_rdlock()`:

> ... Results are undefined if the calling thread holds a write lock on rwlock at the time the call is made.

See: https://pubs.opengroup.org/onlinepubs/7908799/xsh/pthread_rwlock_rdlock.html

Coverity caught this in part by noticing the effectively-double call to `pthread_rwlock_unlock()`, however it's also technically incorrect to re-acquire the lock while it's held in the first place. We can avoid both issues by simply invoking the relevant functions outside the scope of the lock.