### PR TITLE
GUACAMOLE-1604: Bump version number and libtool version info for 1.5.0.

### DIFF
--- a/bin/guacctl
+++ b/bin/guacctl
@@ -117,7 +117,7 @@ error() {
 ##
 usage() {
     cat >&2 <<END
-guacctl 1.4.0, Apache Guacamole terminal session control utility.
+guacctl 1.5.0, Apache Guacamole terminal session control utility.
 Usage: guacctl [OPTION] [FILE or NAME]...
 
     -d, --download         download each of the files listed.

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@
 #
 
 AC_PREREQ([2.61])
-AC_INIT([guacamole-server], [1.4.0])
+AC_INIT([guacamole-server], [1.5.0])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AM_SILENT_RULES([yes])

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -137,7 +137,7 @@ libguac_la_CFLAGS = \
     -Werror -Wall -pedantic
 
 libguac_la_LDFLAGS =     \
-    -version-info 20:0:0 \
+    -version-info 21:0:0 \
     -no-undefined        \
     @CAIRO_LIBS@         \
     @DL_LIBS@            \

--- a/src/terminal/Makefile.am
+++ b/src/terminal/Makefile.am
@@ -77,6 +77,8 @@ libguac_terminal_la_LIBADD = \
     @LIBGUAC_LTLIB@
 
 libguac_terminal_la_LDFLAGS = \
+    -version-info 0:0:0       \
+    -no-undefined             \
     @CAIRO_LIBS@              \
     @MATH_LIBS@               \
     @PANGO_LIBS@              \


### PR DESCRIPTION
This change:

* Bumps the version number to 1.5.0.
* Bumps the libtool version number for libguac to reflect that an interface was changed (`guac_user_info` now has a `name` member).
* Adds explicit libtool version info for libguac-terminal.