### PR TITLE
GUACAMOLE-1633: Adding alternate screen buffer for non-linux terminal type

### DIFF
--- a/src/terminal/terminal-handlers.c
+++ b/src/terminal/terminal-handlers.c
@@ -885,6 +885,20 @@ int guac_terminal_csi(guac_terminal* term, unsigned char c) {
                 if (flag != NULL)
                     *flag = true;
 
+                /* Proceed for entering alternate screen buffer with non-linux term type */
+                if (argv[0] == 1049){
+                    guac_terminal_scroll_backup(term);
+                    guac_terminal_buffer_backup(term);
+                    guac_terminal_display_backup(term);
+                    int save = term->cursor_row;
+                    int amount = term->term_height - save;
+                    term->buffer->length += amount;
+                    guac_terminal_move_cursor(term, term->term_height - 1, 0);
+                    for (int i = 0; i < save; i++){
+                        guac_terminal_linefeed(term);
+                    }
+                }
+
                 break;
 
             /* l: Reset Mode */
@@ -894,6 +908,13 @@ int guac_terminal_csi(guac_terminal* term, unsigned char c) {
                 flag = __guac_terminal_get_flag(term, argv[0], private_mode_character);
                 if (flag != NULL)
                     *flag = false;
+
+                /* Proceed for leaving alternate screen buffer with non-linux term type */
+                if (argv[0] == 1049){
+                    guac_terminal_buffer_restore(term);
+                    guac_terminal_display_restore(term);
+                    guac_terminal_scroll_restore(term);
+                }
 
                 break;
 

--- a/src/terminal/terminal/terminal-priv.h
+++ b/src/terminal/terminal/terminal-priv.h
@@ -461,6 +461,57 @@ struct guac_terminal {
      */
     bool disable_copy;
 
+    /**
+     * The backup of scroll handle height. The value will be restored after leaving 
+     * alternate buffer.
+     */
+    int handle_height_backup;
+
+    /**
+     * The backup of scroll minimum value. The value will be restored after leaving 
+     * alternate buffer.
+     */
+    int min_scroll_backup;
+
+    /**
+     * The backup of x point of scroll handle. The value will be restored after leaving 
+     * alternate buffer.
+     */
+    int handle_x_backup;
+
+    /**
+     * The backup of y point of scroll handle. The value will be restored after leaving 
+     * alternate buffer.
+     */
+    int handle_y_backup;
+
+
+    /**
+     * The backup of cursol row. The value will be used for recording the row of cursor
+     * and restored after leaving alternate buffer.
+     */
+    int cursor_row_backup;
+
+    /**
+     * The backup of cursol col. The value will be used for recording the col of cursor
+     * and restored after leaving alternate buffer.
+     */
+    int cursor_col_backup;
+
+    /**
+     * A backup of display area. This is used for recording the screen content before
+     * entering alternate screen buffer and restored for display after leaving alternate
+     * buffer.
+     */
+    guac_terminal_display* disbak;
+    
+    /**
+     * A backup of buffer content. This is used for recording the buffer content before
+     * entering alternate screen buffer and restored for buffer after leaving alternate
+     * buffer.
+     */
+    guac_terminal_buffer* altbuf;   
+
 };
 
 /**
@@ -651,6 +702,49 @@ void guac_terminal_copy_rows(guac_terminal* terminal,
  * Flushes all pending operations within the given guac_terminal.
  */
 void guac_terminal_flush(guac_terminal* terminal);
+
+/**
+ * Making backup of buffer for restoring.
+ * 
+ * @param term 
+ */
+
+void guac_terminal_buffer_backup(guac_terminal* term);
+
+/**
+ * Making backup of display for restoring.
+ * 
+ * @param term 
+ */
+void guac_terminal_display_backup(guac_terminal* term);
+
+/**
+ * Restoring buffer content from altbuf.
+ * 
+ * @param term 
+ */
+void guac_terminal_buffer_restore(guac_terminal* term);
+
+/**
+ * Restoring display content from disbak.
+ * 
+ * @param term 
+ */
+void guac_terminal_display_restore(guac_terminal* term);
+
+/**
+ * Making backup of scroll related value for restoring.
+ * 
+ * @param term 
+ */
+void guac_terminal_scroll_backup(guac_terminal* term);
+
+/**
+ * Restoring scroll state from backup value.
+ * 
+ * @param term 
+ */
+void guac_terminal_scroll_restore(guac_terminal* term);
 
 #endif
 


### PR DESCRIPTION
The default terminal type of guacamole-server is linux. This change optimized screen content when using xterm-like terminal which supports alternate screen buffer.