### PR TITLE
Bimjaku patch 1

### DIFF
--- a/src/protocols/vnc/cursor.c
+++ b/src/protocols/vnc/cursor.c
@@ -99,9 +99,9 @@ void guac_vnc_cursor(rfbClient* client, int x, int y, int w, int h, int bpp) {
             else              alpha = 0x00;
 
             /* Translate value to RGB */
-            red   = (v >> client->format.redShift)   * 0x100 / (client->format.redMax  + 1);
-            green = (v >> client->format.greenShift) * 0x100 / (client->format.greenMax+ 1);
-            blue  = (v >> client->format.blueShift)  * 0x100 / (client->format.blueMax + 1);
+            red   = ((v >> client->format.redShift)   & client->format.redMax)  * 0xFF / client->format.redMax;
+            green = ((v >> client->format.greenShift) & client->format.greenMax)* 0xFF / client->format.greenMax;
+            blue  = ((v >> client->format.blueShift)  & client->format.blueMax) * 0xFF / client->format.blueMax;
 
             /* Output ARGB */
             if (vnc_client->settings->swap_red_blue)

--- a/src/protocols/vnc/display.c
+++ b/src/protocols/vnc/display.c
@@ -109,9 +109,9 @@ void guac_vnc_update(rfbClient* client, int x, int y, int w, int h) {
             }
 
             /* Translate value to RGB */
-            red   = (v >> client->format.redShift)   * 0x100 / (client->format.redMax  + 1);
-            green = (v >> client->format.greenShift) * 0x100 / (client->format.greenMax+ 1);
-            blue  = (v >> client->format.blueShift)  * 0x100 / (client->format.blueMax + 1);
+            red   = ((v >> client->format.redShift)   & client->format.redMax)  * 0xFF / client->format.redMax;
+            green = ((v >> client->format.greenShift) & client->format.greenMax)* 0xFF / client->format.greenMax;
+            blue  = ((v >> client->format.blueShift)  & client->format.blueMax) * 0xFF / client->format.blueMax;
 
             /* Output RGB */
             if (vnc_client->settings->swap_red_blue)


### PR DESCRIPTION
Corrected translation values to RGB

Old code produces encoded 8 bpp white color 0xFF

R: 7*256 / 8 = 224
G: 7*256 / 8 = 224
B: 3*256 / 8 = 192

New code produces

R: 7*255 / 7 = 255
G: 7*255 / 7 = 255
B: 3*255 / 3 = 255

Also for 15 bpp, 16 bpp ...
