### PR TITLE
GUACAMOLE-600: Add support for the FreeRDP TcpAckTimeout setting

### DIFF
--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -54,6 +54,7 @@ const char fips_nla_mode_warning[] = (
 const char* GUAC_RDP_CLIENT_ARGS[] = {
     "hostname",
     "port",
+    "server-timeout",
     GUAC_RDP_ARGV_DOMAIN,
     GUAC_RDP_ARGV_USERNAME,
     GUAC_RDP_ARGV_PASSWORD,
@@ -158,6 +159,11 @@ enum RDP_ARGS_IDX {
      * used.
      */
     IDX_PORT,
+
+    /**
+     * The amount of time to wait for the server to respond, in seconds.
+     */
+    IDX_SERVER_TIMEOUT,
 
     /**
      * The domain of the user logging in.
@@ -779,6 +785,11 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     settings->port =
         guac_user_parse_args_int(user, GUAC_RDP_CLIENT_ARGS, argv, IDX_PORT,
                 settings->security_mode == GUAC_SECURITY_VMCONNECT ? RDP_DEFAULT_VMCONNECT_PORT : RDP_DEFAULT_PORT);
+
+    /* Look for timeout settings and parse or set defaults. */
+    settings->server_timeout =
+        guac_user_parse_args_int(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_SERVER_TIMEOUT, RDP_DEFAULT_SERVER_TIMEOUT);
 
     guac_user_log(user, GUAC_LOG_DEBUG,
             "User resolution is %ix%i at %i DPI",
@@ -1424,6 +1435,7 @@ void guac_rdp_push_settings(guac_client* client,
     /* Connection */
     rdp_settings->ServerHostname = guac_strdup(guac_settings->hostname);
     rdp_settings->ServerPort = guac_settings->port;
+    rdp_settings->TcpAckTimeout = guac_settings->server_timeout * 1000;
 
     /* Session */
     rdp_settings->ColorDepth = guac_settings->color_depth;

--- a/src/protocols/rdp/settings.h
+++ b/src/protocols/rdp/settings.h
@@ -34,6 +34,11 @@
 #define RDP_CLIENT_HOSTNAME_SIZE 32
 
 /**
+ * The default server response timeout, in seconds.
+ */
+#define RDP_DEFAULT_SERVER_TIMEOUT 10
+
+/**
  * The default RDP port.
  */
 #define RDP_DEFAULT_PORT 3389
@@ -155,6 +160,11 @@ typedef struct guac_rdp_settings {
      * The port to connect to.
      */
     int port;
+
+    /**
+     * The timeout, in seconds, to wait for the remote host to respond.
+     */
+    int server_timeout;
 
     /**
      * The domain of the user logging in.


### PR DESCRIPTION
This first PR in an expected set of them to allow for adjusting the connection timeouts for the various protocols. This allows adjusting the TcpAckTimeout within the FreeRDP settings, setting the timeout to something other than the 9 seconds that the FreeRDP library appears to default to.