### PR TITLE
GUACAMOLE-377: Restructure rdp logic to improve graphical data rendering.

### DIFF
--- a/src/protocols/rdp/gdi.c
+++ b/src/protocols/rdp/gdi.c
@@ -34,7 +34,6 @@
 #include <winpr/wtypes.h>
 
 #include <stddef.h>
-#include <stddef.h>
 
 guac_transfer_function guac_rdp_rop3_transfer_function(guac_client* client,
         int rop3) {
@@ -411,7 +410,7 @@ BOOL guac_rdp_gdi_frame_marker(rdpContext* context, const FRAME_MARKER_ORDER* fr
 
 BOOL guac_rdp_gdi_surface_frame_marker(rdpContext* context, const SURFACE_FRAME_MARKER* surface_frame_marker) {
 
-    guac_rdp_gdi_mark_frame(context, surface_frame_marker->frameAction == SURFACECMD_FRAMEACTION_END);
+    guac_rdp_gdi_mark_frame(context, surface_frame_marker->frameAction != SURFACECMD_FRAMEACTION_END);
 
     if (context->settings->FrameAcknowledge > 0)
         IFCALL(context->update->SurfaceFrameAcknowledge, context,
@@ -497,5 +496,3 @@ BOOL guac_rdp_gdi_desktop_resize(rdpContext* context) {
             guac_rdp_get_height(context->instance));
 
 }
-
-

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -533,8 +533,6 @@ static int guac_rdp_handle_connection(guac_client* client) {
     /* Connection complete */
     rdp_client->rdp_inst = rdp_inst;
 
-    guac_timestamp last_frame_end = guac_timestamp_current();
-
     /* Signal that reconnect has been completed */
     guac_rdp_disp_reconnect_complete(rdp_client->disp);
 
@@ -586,7 +584,7 @@ static int guac_rdp_handle_connection(guac_client* client) {
                                 - frame_end;
 
                 /* Calculate time that client needs to catch up */
-                int time_elapsed = frame_end - last_frame_end;
+                int time_elapsed = frame_end - frame_start;
                 int required_wait = processing_lag - time_elapsed;
 
                 /* Increase the duration of this frame if client is lagging */
@@ -837,4 +835,3 @@ void* guac_rdp_client_thread(void* data) {
     return NULL;
 
 }
-


### PR DESCRIPTION
XRPD Connection is noticeably slow. Screen updates take time to occur and appear "laggy".

In this Pull Request we:
- Remove duplicated `include` statement.
- Consolidate frame start and last frame end timestamps when reading from rdp. 
- Change mark frames as 1 (`in_frame`) when we receive anything but an end frame from RDP (`SURFACECMD_FRAMEACTION_END`). Otherwise mark frames as 0.
