### PR TITLE
GUACAMOLE-1717: Fix RDP cursor use of uninitialized memory

### DIFF
--- a/src/protocols/rdp/pointer.c
+++ b/src/protocols/rdp/pointer.c
@@ -42,18 +42,17 @@ BOOL guac_rdp_pointer_new(rdpContext* context, rdpPointer* pointer) {
             rdp_client->display, pointer->width, pointer->height);
 
     /* Allocate data for image */
-    unsigned char* data = _aligned_malloc(pointer->width * pointer->height * 4, 16);
+    unsigned char* data = _aligned_recalloc(NULL, 1, pointer->width * pointer->height * 4, 16);
 
     cairo_surface_t* surface;
 
-    /* Convert to alpha cursor if mask data present */
-    if (pointer->andMaskData && pointer->xorMaskData)
-        freerdp_image_copy_from_pointer_data(data,
-                guac_rdp_get_native_pixel_format(TRUE), 0, 0, 0,
-                pointer->width, pointer->height, pointer->xorMaskData,
-                pointer->lengthXorMask, pointer->andMaskData,
-                pointer->lengthAndMask, pointer->xorBpp,
-                &context->gdi->palette);
+    /* Convert to alpha cursor using mask data */
+    freerdp_image_copy_from_pointer_data(data,
+        guac_rdp_get_native_pixel_format(TRUE), 0, 0, 0,
+        pointer->width, pointer->height, pointer->xorMaskData,
+        pointer->lengthXorMask, pointer->andMaskData,
+        pointer->lengthAndMask, pointer->xorBpp,
+        &context->gdi->palette);
 
     /* Create surface from image data */
     surface = cairo_image_surface_create_for_data(


### PR DESCRIPTION
As kindly described by Mike Powers in [GUACAMOLE-1717](https://issues.apache.org/jira/browse/GUACAMOLE-1717), using GNOME Remote Desktop (GRD) with gaucd causes a clearly junk/corrupt cursor to be rendered. Mike tracked this down to use of uninitialized memory (`data`) in [`src/protocols/rdp/pointer.c#guac_rdp_pointer_new()`](https://github.com/apache/guacamole-server/blob/ce27936ed539872d55039b6a1b9aa54d8388659e/src/protocols/rdp/pointer.c#L35) when the call to `freerdp_image_copy_from_pointer_data()` is skipped because connecting to GRD causes `pointer->andMaskData` to be `NULL`.

As described in the ticket, the `if` guard (on line 49) causing this to happen is not necessary because FreeRDP protects against this case internally (at least in 2.0 versions), and at any rate there is a bug because if FreeRDP can't handle this situation we should at least zero `data` instead of returning garbage.

Tested on Ubuntu 22.10 with the fix applied on top of master.