### PR TITLE
GUACAMOLE-1505: Avoid null pointer dereference in RDP protocol when display is already freed.

### DIFF
--- a/src/protocols/rdp/user.c
+++ b/src/protocols/rdp/user.c
@@ -165,8 +165,9 @@ int guac_rdp_user_leave_handler(guac_user* user) {
 
     guac_rdp_client* rdp_client = (guac_rdp_client*) user->client->data;
 
-    /* Update shared cursor state */
-    guac_common_cursor_remove_user(rdp_client->display->cursor, user);
+    /* Update shared cursor state if the display still exists */
+    if (rdp_client->display != NULL)
+        guac_common_cursor_remove_user(rdp_client->display->cursor, user);
 
     /* Free settings if not owner (owner settings will be freed with client) */
     if (!user->owner) {


### PR DESCRIPTION
This fixes a bug/race condition where the display pointer may already be freed and set to null when the user leave handler is called in the RDP code.