### PR TITLE
GUACAMOLE-1755: Remove usage of .setpdfwrite for print filtering (deprecated in newer GhostScript).

### DIFF
--- a/src/protocols/rdp/print-job.c
+++ b/src/protocols/rdp/print-job.c
@@ -47,8 +47,6 @@ char* const guac_rdp_pdf_filter_command[] = {
     "-dPARANOIDSAFER",
     "-sDEVICE=pdfwrite",
     "-sOutputFile=-",
-    "-c",
-    ".setpdfwrite",
     "-sstdout=/dev/null",
     "-f",
     "-",


### PR DESCRIPTION
The `-c .setpdfwrite` option causes print filtering to fail if a sufficiently new version of GhostScript is installed, such as that provided by the current Alpine Linux image.