### PR TITLE
GUACAMOLE-1771: add Portuguese keymap to RDP

### DIFF
--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -247,6 +247,7 @@ rdp_keymaps =                                \
     $(srcdir)/keymaps/no_no_qwerty.keymap    \
     $(srcdir)/keymaps/pl_pl_qwerty.keymap    \
     $(srcdir)/keymaps/pt_br_qwerty.keymap    \
+    $(srcdir)/keymaps/pt_pt_qwerty.keymap    \
     $(srcdir)/keymaps/sv_se_qwerty.keymap    \
     $(srcdir)/keymaps/da_dk_qwerty.keymap    \
     $(srcdir)/keymaps/tr_tr_qwerty.keymap

--- a/src/protocols/rdp/keymaps/pt_pt_qwerty.keymap
+++ b/src/protocols/rdp/keymaps/pt_pt_qwerty.keymap
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+parent  "base"
+name    "pt-pt-qwerty"
+freerdp "KBD_PORTUGUESE"
+
+#
+# Basic keys
+#
+
+map -caps -shift 0x29 0x02..0x0D ~ "\1234567890'«"
+map -caps -shift      0x10..0x1A ~ "qwertyuiop+"
+map -caps -shift      0x1E..0x28 ~ "asdfghjklçº"
+map -caps -shift 0x56 0x2C..0x35 ~ "<zxcvbnm,.-"
+
+map -caps +shift 0x29 0x02..0x0D ~ "|!"#$%&/()=?»"
+map -caps +shift      0x10..0x1A ~ "QWERTYUIOP*"
+map -caps +shift      0x1E..0x28 ~ "ASDFGHJKLÇª"
+map -caps +shift 0x56 0x2C..0x35 ~ ">ZXCVBNM;:_"
+
+map +caps -shift 0x29 0x02..0x0D ~ "\1234567890'«"
+map +caps -shift      0x10..0x1A ~ "QWERTYUIOP+"
+map +caps -shift      0x1E..0x28 ~ "ASDFGHJKLÇº"
+map +caps -shift 0x56 0x2C..0x35 ~ "\ZXCVBNM,./"
+
+map +caps +shift 0x29 0x02..0x0D ~ "|!"#$%&/()=?»"
+map +caps +shift      0x10..0x1A ~ "qwertyuiop*"
+map +caps +shift      0x1E..0x28 ~ "asdfghjklçª"
+map +caps +shift 0x56 0x2C..0x35 ~ ">zxcvbnm;:_"
+
+
+#
+# Keys requiring AltGr (unaffected by Caps Lock, but Shift must not be pressed)
+#
+
+map +altgr -shift 0x03..0x0B ~ "@£§½¬{[]}"
+map +altgr -shift 0x12       ~ "€"
+
+#
+# Dead keys requiring AltGr (unaffected by Caps Lock, but Shift must not be pressed)
+#
+
+map +altgr -shift 0x1A ~ 0xFE57 # Dead diaeresis
+
+#
+# Dead keys (unaffected by Caps Lock, but AltGr must not be pressed)
+#
+
+map -altgr -shift 0x1B ~ 0xFE51 # Dead acute
+map -altgr +shift 0x1B ~ 0xFE50 # Dead grave
+map -altgr -shift 0x2B ~ 0xFE53 # Dead tilde
+map -altgr +shift 0x2B ~ 0xFE52 # Dead circumflex


### PR DESCRIPTION
This PR adds the "pt-pt" keyboard layout. Currently only "pt-br" is included.