### PR TITLE
GUACAMOLE-1776: Batch up base64 encoding to reduce syscalls.

### DIFF
--- a/src/libguac/guacamole/socket-constants.h
+++ b/src/libguac/guacamole/socket-constants.h
@@ -37,5 +37,16 @@
  */
 #define GUAC_SOCKET_KEEP_ALIVE_INTERVAL 5000
 
+/**
+ * The number of bytes of data to buffer prior to bulk conversion to base64.
+ */
+#define GUAC_SOCKET_BASE64_READY_BUFFER_SIZE 768
+
+/**
+ * The size of the buffer required to hold GUAC_SOCKET_BASE64_READY_BUFFER_SIZE
+ * bytes encoded as base64.
+ */
+#define GUAC_SOCKET_BASE64_ENCODED_BUFFER_SIZE 1024
+
 #endif
 

--- a/src/libguac/guacamole/socket.h
+++ b/src/libguac/guacamole/socket.h
@@ -98,10 +98,15 @@ struct guac_socket {
     int __ready;
 
     /**
-     * The base64 "ready" buffer. Once this buffer is filled, base64 data is
-     * flushed to the main write buffer.
+     * The base64 "ready" buffer. Once this buffer is filled, the data is encoded
+     * as base64 and flushed to the main write buffer.
      */
-    int __ready_buf[3];
+    unsigned char __ready_buf[GUAC_SOCKET_BASE64_READY_BUFFER_SIZE];
+
+    /**
+     * The buffer to hold the result of encoding the ready buffer as base64.
+     */
+    char __encoded_buf[GUAC_SOCKET_BASE64_ENCODED_BUFFER_SIZE];
 
     /**
      * Whether automatic keep-alive is enabled.


### PR DESCRIPTION
This introduces a buffer for binary data to be encoded as base64 as well as a buffer for the base64 encoded data, prior to any attempt to writing it to the socket. Doing this significantly reduces the number of system calls made by the socket-fd implementation. Instead of `clock_gettime`, `pthread_mutex_rdlock`, and `pthread_mutex_unlock` being called for every 3 bytes it's now called for every ~768 bytes.