### PR TITLE
GUACAMOLE-1761: Fix hungarian keymap

### DIFF
--- a/src/protocols/rdp/keymaps/hu_hu_qwertz.keymap
+++ b/src/protocols/rdp/keymaps/hu_hu_qwertz.keymap
@@ -26,7 +26,7 @@ freerdp "KBD_HUNGARIAN"
 #
 
 map -caps -altgr -shift 0x29 0x02..0x0D      ~ "0123456789öüó"
-map -caps -altgr -shift      0x10..0x1B      ~ "qwertzuıopőú"
+map -caps -altgr -shift      0x10..0x1B      ~ "qwertzuiopőú"
 map -caps -altgr -shift      0x1E..0x28 0x2B ~ "asdfghjkléáű"
 map -caps -altgr -shift 0x56 0x2C..0x35      ~ "íyxcvbnm,.-"
 


### PR DESCRIPTION
This change reapplies the same commits from #422 against `staging/1.5.2`.