### PR TITLE
GUACAMOLE-1717: Fix RDP cursor use of uninitialized memory

### DIFF
--- a/src/protocols/rdp/pointer.c
+++ b/src/protocols/rdp/pointer.c
@@ -41,18 +41,17 @@ BOOL guac_rdp_pointer_new(rdpContext* context, rdpPointer* pointer) {
             rdp_client->display, pointer->width, pointer->height);
 
     /* Allocate data for image */
-    unsigned char* data = _aligned_malloc(pointer->width * pointer->height * 4, 16);
+    unsigned char* data = _aligned_recalloc(NULL, 1, pointer->width * pointer->height * 4, 16);
 
     cairo_surface_t* surface;
 
-    /* Convert to alpha cursor if mask data present */
-    if (pointer->andMaskData && pointer->xorMaskData)
-        freerdp_image_copy_from_pointer_data(data,
-                guac_rdp_get_native_pixel_format(TRUE), 0, 0, 0,
-                pointer->width, pointer->height, pointer->xorMaskData,
-                pointer->lengthXorMask, pointer->andMaskData,
-                pointer->lengthAndMask, pointer->xorBpp,
-                &context->gdi->palette);
+    /* Convert to alpha cursor using mask data */
+    freerdp_image_copy_from_pointer_data(data,
+        guac_rdp_get_native_pixel_format(TRUE), 0, 0, 0,
+        pointer->width, pointer->height, pointer->xorMaskData,
+        pointer->lengthXorMask, pointer->andMaskData,
+        pointer->lengthAndMask, pointer->xorBpp,
+        &context->gdi->palette);
 
     /* Create surface from image data */
     surface = cairo_image_surface_create_for_data(


### PR DESCRIPTION
This change reapplies the same commits from #418 against `staging/1.5.2`.