### PR TITLE
GUACAMOLE-1595: Ensure all mouse buttons are initially released when terminal starts.

### DIFF
--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -485,6 +485,10 @@ guac_terminal* guac_terminal_create(guac_client* client,
     /* Init terminal */
     guac_terminal_reset(term);
 
+    /* All mouse buttons are released */
+    term->mouse_mask = 0;
+
+    /* All keyboard modifiers are released */
     term->mod_alt   =
     term->mod_ctrl  =
     term->mod_shift = 0;


### PR DESCRIPTION
This change reapplies the same commits from #381 against `staging/1.5.2`.