### PR TITLE
GUACAMOLE-1636: Fixed some typo mistakes.

### DIFF
--- a/src/protocols/rdp/bitmap.c
+++ b/src/protocols/rdp/bitmap.c
@@ -149,7 +149,7 @@ BOOL guac_rdp_bitmap_setsurface(rdpContext* context, rdpBitmap* bitmap, BOOL pri
 
     else {
 
-        /* Make sure that the recieved bitmap is not NULL before processing */
+        /* Make sure that the received bitmap is not NULL before processing */
         if (bitmap == NULL) {
             guac_client_log(client, GUAC_LOG_INFO, "NULL bitmap found in bitmap_setsurface instruction.");
             return TRUE;

--- a/src/protocols/rdp/channels/common-svc.h
+++ b/src/protocols/rdp/channels/common-svc.h
@@ -115,7 +115,7 @@ struct guac_rdp_common_svc {
     guac_rdp_common_svc_receive_handler* _receive_handler;
 
     /**
-     * Handler which is invokved when the SVC has been disconnected and is
+     * Handler which is involved when the SVC has been disconnected and is
      * about to be freed.
      */
     guac_rdp_common_svc_terminate_handler* _terminate_handler;

--- a/src/protocols/rdp/channels/disp.h
+++ b/src/protocols/rdp/channels/disp.h
@@ -109,7 +109,7 @@ void guac_rdp_disp_free(guac_rdp_disp* disp);
 /**
  * Adds FreeRDP's "disp" plugin to the list of dynamic virtual channel plugins
  * to be loaded by FreeRDP's "drdynvc" plugin. The context of the plugin will
- * automatically be assicated with the guac_rdp_disp instance pointed to by the
+ * automatically be associated with the guac_rdp_disp instance pointed to by the
  * current guac_rdp_client. The plugin will only be loaded once the "drdynvc"
  * plugin is loaded. The "disp" plugin ultimately adds support for the Display
  * Update channel.

--- a/src/protocols/rdp/channels/rdpei.h
+++ b/src/protocols/rdp/channels/rdpei.h
@@ -110,7 +110,7 @@ void guac_rdp_rdpei_free(guac_rdp_rdpei* rdpei);
 /**
  * Adds FreeRDP's "rdpei" plugin to the list of dynamic virtual channel plugins
  * to be loaded by FreeRDP's "drdynvc" plugin. The context of the plugin will
- * automatically be assicated with the guac_rdp_rdpei instance pointed to by the
+ * automatically be associated with the guac_rdp_rdpei instance pointed to by the
  * current guac_rdp_client. The plugin will only be loaded once the "drdynvc"
  * plugin is loaded. The "rdpei" plugin ultimately adds support for multi-touch
  * input via the RDPEI channel.

--- a/src/protocols/rdp/gdi.c
+++ b/src/protocols/rdp/gdi.c
@@ -247,7 +247,7 @@ BOOL guac_rdp_gdi_memblt(rdpContext* context, MEMBLT_ORDER* memblt) {
     int x_src = memblt->nXSrc;
     int y_src = memblt->nYSrc;
 
-    /* Make sure that the recieved bitmap is not NULL before processing */
+    /* Make sure that the received bitmap is not NULL before processing */
     if (bitmap == NULL) {
         guac_client_log(client, GUAC_LOG_INFO, "NULL bitmap found in memblt instruction.");
         return TRUE;

--- a/src/protocols/rdp/glyph.h
+++ b/src/protocols/rdp/glyph.h
@@ -96,11 +96,11 @@ BOOL guac_rdp_glyph_new(rdpContext* context, const rdpGlyph* glyph);
  *     The height of the glyph being drawn.
  *
  * @param sx
- *     The X coordinare of the upper-left corner of the glyph within the source
+ *     The X coordinate of the upper-left corner of the glyph within the source
  *     cache surface containing the glyph.
  *
  * @param sy
- *     The Y coordinare of the upper-left corner of the glyph within the source
+ *     The Y coordinate of the upper-left corner of the glyph within the source
  *     cache surface containing the glyph.
  *
  * @param redundant

--- a/src/protocols/rdp/keyboard.c
+++ b/src/protocols/rdp/keyboard.c
@@ -140,7 +140,7 @@ static void guac_rdp_send_unicode_event(guac_rdp_client* rdp_client,
 }
 
 /**
- * Immediately sends an RDP synchonize event having the given flags. An RDP
+ * Immediately sends an RDP synchronize event having the given flags. An RDP
  * synchronize event sets the state of remote lock keys absolutely, where a
  * lock key will be active only if its corresponding flag is set in the event.
  *

--- a/src/protocols/rdp/plugins/guacai/guacai-messages.c
+++ b/src/protocols/rdp/plugins/guacai/guacai-messages.c
@@ -251,7 +251,7 @@ void guac_rdp_ai_process_version(guac_client* client,
 
     /* Verify we have at least 4 bytes available (UINT32) */
     if (Stream_GetRemainingLength(stream) < 4) {
-        guac_client_log(client, GUAC_LOG_WARNING, "Audio input Versoin PDU "
+        guac_client_log(client, GUAC_LOG_WARNING, "Audio input Version PDU "
                 "does not contain the expected number of bytes. Audio input "
                 "redirection may not work as expected.");
         return;

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -360,7 +360,7 @@ enum RDP_ARGS_IDX {
     IDX_DISABLE_BITMAP_CACHING,
 
     /**
-     * "true" if the offscreen caching should be disabled, false if offscren
+     * "true" if the offscreen caching should be disabled, false if offscreen
      * caching should remain enabled.
      */
     IDX_DISABLE_OFFSCREEN_CACHING,


### PR DESCRIPTION
This change reapplies the same commits from #386 against `staging/1.5.2`, except that `src/protocols/rdp/channels/rdpgfx.h` does not exist in 1.5.2.