### PR TITLE
GUACAMOLE-1669: Prefer FIPS compliant ciphers and algorithms when FIPS mode is enabled.

### DIFF
--- a/src/common-ssh/ssh.c
+++ b/src/common-ssh/ssh.c
@@ -49,9 +49,12 @@ GCRY_THREAD_OPTION_PTHREAD_IMPL;
 
 /**
  * A list of all key exchange algorithms that are both FIPS-compliant, and
- * OpenSSL-supported.
+ * OpenSSL-supported. Note that "ext-info-c" is also included. While not a key
+ * exchange algorithm per se, it must be in the list to ensure that the server
+ * will send a SSH_MSG_EXT_INFO response, which is required to perform RSA key
+ * upgrades.
  */
-#define FIPS_COMPLIANT_KEX_ALGORITHMS "diffie-hellman-group-exchange-sha256"
+#define FIPS_COMPLIANT_KEX_ALGORITHMS "diffie-hellman-group-exchange-sha256,ext-info-c"
 
 /**
  * A list of ciphers that are both FIPS-compliant, and OpenSSL-supported.

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -44,6 +44,7 @@ libguacinc_HEADERS =                  \
     guacamole/client-types.h          \
     guacamole/error.h                 \
     guacamole/error-types.h           \
+    guacamole/fips.h                  \
     guacamole/hash.h                  \
     guacamole/layer.h                 \
     guacamole/layer-types.h           \
@@ -93,6 +94,7 @@ libguac_la_SOURCES =   \
     encode-jpeg.c      \
     encode-png.c       \
     error.c            \
+    fips.c             \
     hash.c             \
     id.c               \
     palette.c          \
@@ -100,7 +102,7 @@ libguac_la_SOURCES =   \
     pool.c             \
     protocol.c         \
     raw_encoder.c      \
-    recording.c             \
+    recording.c        \
     socket.c           \
     socket-broadcast.c \
     socket-fd.c        \

--- a/src/libguac/fips.c
+++ b/src/libguac/fips.c
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "config.h"
+#include "guacamole/fips.h"
+
+/* If OpenSSL is available, include header for version numbers */
+#ifdef ENABLE_SSL
+    #include <openssl/opensslv.h>
+
+    /* OpenSSL versions prior to 0.9.7e did not have FIPS support */
+    #if !defined(OPENSSL_VERSION_NUMBER) || (OPENSSL_VERSION_NUMBER < 0x00090705f)
+    #define GUAC_FIPS_ENABLED 0
+
+    /* OpenSSL 3+ uses EVP_default_properties_is_fips_enabled() */
+    #elif defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+    #include <openssl/evp.h>
+    #define GUAC_FIPS_ENABLED EVP_default_properties_is_fips_enabled(NULL)
+
+    /* For OpenSSL versions between 0.9.7e and 3.0, use FIPS_mode() */
+    #else
+    #include <openssl/crypto.h>
+    #define GUAC_FIPS_ENABLED FIPS_mode()
+    #endif
+
+/* FIPS support does not exist if OpenSSL is not available. */
+#else
+#define GUAC_FIPS_ENABLED 0
+#endif
+
+int guac_fips_enabled() {
+
+    return GUAC_FIPS_ENABLED;
+
+}

--- a/src/libguac/guacamole/fips.h
+++ b/src/libguac/guacamole/fips.h
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_FIPS_H
+#define GUAC_FIPS_H
+
+/**
+ * Returns a non-zero value if FIPS mode is enabled, or zero if FIPS mode
+ * is not enabled.
+ *
+ * @return
+ *      A non-zero value if FIPS mode is enabled, or zero if FIPS mode is
+ *      not enabled.
+ */
+int guac_fips_enabled();
+
+#endif


### PR DESCRIPTION
This change reapplies the same commits from #391 (and corrections to this from #393) against `staging/1.5.2`.