### PR TITLE
GUACAMOLE-1802: Switch memory allocation back to _aligned_malloc due to segfault caused by using _aligned_recalloc.

### DIFF
--- a/src/protocols/rdp/pointer.c
+++ b/src/protocols/rdp/pointer.c
@@ -41,7 +41,7 @@ BOOL guac_rdp_pointer_new(rdpContext* context, rdpPointer* pointer) {
             rdp_client->display, pointer->width, pointer->height);
 
     /* Allocate data for image */
-    unsigned char* data = _aligned_recalloc(NULL, 1, pointer->width * pointer->height * 4, 16);
+    unsigned char* data = _aligned_malloc(pointer->width * pointer->height * 4, 16);
 
     cairo_surface_t* surface;
 


### PR DESCRIPTION
This change reverts part of the change made in #418 and #432, moving the memory allocation from `_aligned_recalloc()` back to `_aligned_malloc()`. In at least a couple of different versions of FreeRDP the call to `_aligned_recalloc()` is failing, causing segfaults when attempting to establish RDP connections.