### PR TITLE
GUACAMOLE-1816: Bump server versions to 1.5.3.

### DIFF
--- a/bin/guacctl
+++ b/bin/guacctl
@@ -117,7 +117,7 @@ error() {
 ##
 usage() {
     cat >&2 <<END
-guacctl 1.5.2, Apache Guacamole terminal session control utility.
+guacctl 1.5.3, Apache Guacamole terminal session control utility.
 Usage: guacctl [OPTION] [FILE or NAME]...
 
     -d, --download         download each of the files listed.

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@
 #
 
 AC_PREREQ([2.61])
-AC_INIT([guacamole-server], [1.5.2])
+AC_INIT([guacamole-server], [1.5.3])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
Bumps the versions relevant for guacd to 1.5.3.