### PR TITLE
GUACAMOLE-1332: Add support for certificate fingerprints and auto-accept.

### DIFF
--- a/src/protocols/rdp/settings.h
+++ b/src/protocols/rdp/settings.h
@@ -287,6 +287,18 @@ typedef struct guac_rdp_settings {
     int ignore_certificate;
 
     /**
+     * Whether or not a certificate should be added to the local trust
+     * store on first use.
+     */
+    int certificate_tofu;
+
+    /**
+     * The fingerprints of host certificates that should be trusted for
+     * this connection.
+     */
+    char* certificate_fingerprints;
+
+    /**
      * Whether authentication should be disabled. This is different from the
      * authentication that takes place when a user provides their username
      * and password. Authentication is required by definition for NLA.


### PR DESCRIPTION
This pull requests adds options to support the following additional certificate handling in RDP connections:
* Trust on First Use (tofu): If a host is not "known" to the underlying FreeRDP library, the certificate will be accepted and the fingerprint stored. This is equivalent to the xfreerdp command line option `/cert:tofu`.
* Fingerprint + Hash: You can provide a comma-separated list of certificate hash and fingerprint combinations that FreeRDP will accept for the connection. It's worth noting that I actually don't know the proper way to specify these at the moment, so I've been unable to actually prove this works, but I'm getting identical behavior on the xfreerdp command line as in Guacamole. I've an e-mail out to the FreeRDP mailing list to try to get some guidance on it.