### PR TITLE
GUACAMOLE-1850: Add locking around cursor to ensure cairo display is not used while being recreated.

### DIFF
--- a/src/common/common/cursor.h
+++ b/src/common/common/cursor.h
@@ -123,6 +123,14 @@ typedef struct guac_common_cursor {
      */
     guac_timestamp timestamp;
 
+    /**
+     * Lock which restricts simultaneous access to the cursor, guaranteeing
+     * ordered modifications to the cursor and that incompatible operations
+     * do not occur simultaneously. This lock is for internal use within the
+     * cursor only.
+     */
+    pthread_mutex_t _lock;
+
 } guac_common_cursor;
 
 /**

--- a/src/common/cursor.c
+++ b/src/common/cursor.c
@@ -31,6 +31,7 @@
 #include <guacamole/timestamp.h>
 #include <guacamole/user.h>
 
+#include <pthread.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
@@ -74,11 +75,15 @@ guac_common_cursor* guac_common_cursor_alloc(guac_client* client) {
     cursor->x = 0;
     cursor->y = 0;
 
+    pthread_mutex_init(&(cursor->_lock), NULL);
+
     return cursor;
 
 }
 
 void guac_common_cursor_free(guac_common_cursor* cursor) {
+
+    pthread_mutex_destroy(&(cursor->_lock));
 
     guac_client* client = cursor->client;
     guac_layer* buffer = cursor->buffer;
@@ -102,6 +107,8 @@ void guac_common_cursor_free(guac_common_cursor* cursor) {
 void guac_common_cursor_dup(guac_common_cursor* cursor, guac_user* user,
         guac_socket* socket) {
 
+    pthread_mutex_lock(&(cursor->_lock));
+
     /* Synchronize location */
     guac_protocol_send_mouse(socket, cursor->x, cursor->y, cursor->button_mask,
             cursor->timestamp);
@@ -118,6 +125,8 @@ void guac_common_cursor_dup(guac_common_cursor* cursor, guac_user* user,
                 cursor->hotspot_x, cursor->hotspot_y,
                 cursor->buffer, 0, 0, cursor->width, cursor->height);
     }
+
+    pthread_mutex_unlock(&(cursor->_lock));
 
     guac_socket_flush(socket);
 
@@ -154,6 +163,8 @@ static void* guac_common_cursor_broadcast_state(guac_user* user,
 void guac_common_cursor_update(guac_common_cursor* cursor, guac_user* user,
         int x, int y, int button_mask) {
 
+    pthread_mutex_lock(&(cursor->_lock));
+
     /* Update current user of cursor */
     cursor->user = user;
 
@@ -168,6 +179,8 @@ void guac_common_cursor_update(guac_common_cursor* cursor, guac_user* user,
     /* Notify all other users of change in cursor state */
     guac_client_foreach_user(cursor->client,
             guac_common_cursor_broadcast_state, cursor);
+
+    pthread_mutex_unlock(&(cursor->_lock));
 
 }
 
@@ -212,6 +225,8 @@ static void guac_common_cursor_resize(guac_common_cursor* cursor,
 void guac_common_cursor_set_argb(guac_common_cursor* cursor, int hx, int hy,
     unsigned const char* data, int width, int height, int stride) {
 
+    pthread_mutex_lock(&(cursor->_lock));
+
     /* Copy image data */
     guac_common_cursor_resize(cursor, width, height, stride);
     memcpy(cursor->image_buffer, data, height * stride);
@@ -241,6 +256,8 @@ void guac_common_cursor_set_argb(guac_common_cursor* cursor, int hx, int hy,
             cursor->buffer, 0, 0, cursor->width, cursor->height);
 
     guac_socket_flush(cursor->client->socket);
+
+    pthread_mutex_unlock(&(cursor->_lock));
 
 }
 
@@ -298,9 +315,13 @@ void guac_common_cursor_set_blank(guac_common_cursor* cursor) {
 void guac_common_cursor_remove_user(guac_common_cursor* cursor,
         guac_user* user) {
 
+    pthread_mutex_lock(&(cursor->_lock));
+
     /* Disassociate from given user */
     if (cursor->user == user)
         cursor->user = NULL;
+
+    pthread_mutex_unlock(&(cursor->_lock));
 
 }
 


### PR DESCRIPTION
I am seeing the issue described in [GUACAMOLE-1850](https://issues.apache.org/jira/browse/GUACAMOLE-1850) more often when testing [this change](https://github.com/apache/guacamole-server/pull/455).

Adding a mutex to control concurrent access to the surface underlying the socket appears to resolve this issue.