### PR TITLE
GUACAMOLE-377: Correct guac_common_display_dup() for compatibility with batch join API.

### DIFF
--- a/src/common/display.c
+++ b/src/common/display.c
@@ -167,8 +167,6 @@ void guac_common_display_dup(
         guac_common_display* display, guac_client* client,
         guac_socket* socket) {
 
-    guac_client* client = user->client;
-
     pthread_mutex_lock(&display->_lock);
 
     /* Sunchronize shared cursor */


### PR DESCRIPTION
This change removes the errant retrieval of `guac_client` from a `guac_user` that no longer exists following merge of the batch join API via #455.

The line in question persists on `master` despite its absence from `staging/1.5.4` because the line was added as part of [GUACAMOLE-377](https://issues.apache.org/jira/browse/GUACAMOLE-377) - an in-progress change specific to `master` and not part of any 1.5.x release.