### PR TITLE
GUACAMOLE-1846: Check for NULLs before attempting to sync state in join pending handlers.

### DIFF
--- a/src/protocols/kubernetes/client.c
+++ b/src/protocols/kubernetes/client.c
@@ -95,10 +95,12 @@ static int guac_kubernetes_join_pending_handler(guac_client* client) {
         (guac_kubernetes_client*) client->data;
 
     /* Synchronize the terminal state to all pending users */
-    guac_socket* broadcast_socket = client->pending_socket;
-    guac_terminal_sync_users(kubernetes_client->term, client, broadcast_socket);
-    guac_kubernetes_send_current_argv_batch(client, broadcast_socket);
-    guac_socket_flush(broadcast_socket);
+    if (kubernetes_client->term != NULL) {
+        guac_socket* broadcast_socket = client->pending_socket;
+        guac_terminal_sync_users(kubernetes_client->term, client, broadcast_socket);
+        guac_kubernetes_send_current_argv_batch(client, broadcast_socket);
+        guac_socket_flush(broadcast_socket);
+    }
 
     return 0;
 

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -125,9 +125,10 @@ static int guac_rdp_join_pending_handler(guac_client* client) {
     guac_rdp_pipe_svc_send_pipes(client, broadcast_socket);
 
     /* Synchronize with current display */
-    guac_common_display_dup(rdp_client->display, client, broadcast_socket);
-
-    guac_socket_flush(broadcast_socket);
+    if (rdp_client->display != NULL) {
+        guac_common_display_dup(rdp_client->display, client, broadcast_socket);
+        guac_socket_flush(broadcast_socket);
+    }
 
     return 0;
 

--- a/src/protocols/ssh/client.c
+++ b/src/protocols/ssh/client.c
@@ -52,10 +52,12 @@ static int guac_ssh_join_pending_handler(guac_client* client) {
     guac_ssh_client* ssh_client = (guac_ssh_client*) client->data;
 
     /* Synchronize the terminal state to all pending users */
-    guac_socket* broadcast_socket = client->pending_socket;
-    guac_terminal_sync_users(ssh_client->term, client, broadcast_socket);
-    guac_ssh_send_current_argv_batch(client, broadcast_socket);
-    guac_socket_flush(broadcast_socket);
+    if (ssh_client->term != NULL) {
+        guac_socket* broadcast_socket = client->pending_socket;
+        guac_terminal_sync_users(ssh_client->term, client, broadcast_socket);
+        guac_ssh_send_current_argv_batch(client, broadcast_socket);
+        guac_socket_flush(broadcast_socket);
+    }
 
     return 0;
 

--- a/src/protocols/telnet/client.c
+++ b/src/protocols/telnet/client.c
@@ -51,10 +51,12 @@ static int guac_telnet_join_pending_handler(guac_client* client) {
     guac_telnet_client* telnet_client = (guac_telnet_client*) client->data;
 
     /* Synchronize the terminal state to all pending users */
-    guac_socket* broadcast_socket = client->pending_socket;
-    guac_terminal_sync_users(telnet_client->term, client, broadcast_socket);
-    guac_telnet_send_current_argv_batch(client, broadcast_socket);
-    guac_socket_flush(broadcast_socket);
+    if (telnet_client->term != NULL) {
+        guac_socket* broadcast_socket = client->pending_socket;
+        guac_terminal_sync_users(telnet_client->term, client, broadcast_socket);
+        guac_telnet_send_current_argv_batch(client, broadcast_socket);
+        guac_socket_flush(broadcast_socket);
+    }
 
     return 0;
 

--- a/src/protocols/vnc/client.c
+++ b/src/protocols/vnc/client.c
@@ -87,8 +87,10 @@ static int guac_vnc_join_pending_handler(guac_client* client) {
 #endif
 
     /* Synchronize with current display */
-    guac_common_display_dup(vnc_client->display, client, broadcast_socket);
-    guac_socket_flush(broadcast_socket);
+    if (vnc_client->display != NULL) {
+        guac_common_display_dup(vnc_client->display, client, broadcast_socket);
+        guac_socket_flush(broadcast_socket);
+    }
 
     return 0;
 


### PR DESCRIPTION
The user promotion thread is started before the client initialization is fully complete, so we should not expect that all client resources will be available when the pending handlers run. 

If the resources _are_ uninitialized, the pending handlers can still run successfully because there isn't any state to sync anyway.