### PR TITLE
GUACAMOLE-1869: Aligned library names of ./configure output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1243,7 +1243,7 @@ $PACKAGE_NAME version $PACKAGE_VERSION
      freerdp2 ............ ${have_freerdp2}
      pango ............... ${have_pango}
      libavcodec .......... ${have_libavcodec}
-     libavformat.......... ${have_libavformat}
+     libavformat ......... ${have_libavformat}
      libavutil ........... ${have_libavutil}
      libssh2 ............. ${have_libssh2}
      libssl .............. ${have_ssl}


### PR DESCRIPTION
Fixing https://issues.apache.org/jira/projects/GUACAMOLE/issues/GUACAMOLE-1869

Aligning library names to contain a space after the name.