### PR TITLE
GUACAMOLE-1867: Explicitly link unit tests requiring libguac.

### DIFF
--- a/src/common-ssh/tests/Makefile.am
+++ b/src/common-ssh/tests/Makefile.am
@@ -45,7 +45,8 @@ test_common_ssh_CFLAGS =    \
 test_common_ssh_LDADD = \
     @CUNIT_LIBS@        \
     @COMMON_SSH_LTLIB@  \
-    @COMMON_LTLIB@
+    @COMMON_LTLIB@      \
+    @LIBGUAC_LTLIB@
 
 #
 # Autogenerate test runner

--- a/src/common/tests/Makefile.am
+++ b/src/common/tests/Makefile.am
@@ -55,7 +55,8 @@ test_common_CFLAGS =        \
 
 test_common_LDADD =  \
     @COMMON_LTLIB@   \
-    @CUNIT_LIBS@
+    @CUNIT_LIBS@     \
+    @LIBGUAC_LTLIB@
 
 #
 # Autogenerate test runner

--- a/src/protocols/rdp/tests/Makefile.am
+++ b/src/protocols/rdp/tests/Makefile.am
@@ -44,7 +44,8 @@ test_rdp_CFLAGS =                \
 
 test_rdp_LDADD =               \
     @CUNIT_LIBS@               \
-    @LIBGUAC_CLIENT_RDP_LTLIB@
+    @LIBGUAC_CLIENT_RDP_LTLIB@ \
+    @LIBGUAC_LTLIB@
 
 #
 # Autogenerate test runner


### PR DESCRIPTION
The build is currently failing on some build environments with an error like the following:

```
...
#8 157.1 /usr/bin/ld: fs/test_rdp-normalize_path.o: undefined reference to symbol 'PRIV_guac_mem_alloc'
#8 157.1 /usr/bin/ld: /build/guacamole-server/src/libguac/.libs/libguac.so.21: error adding symbols: DSO missing from command line
...
```

This is because unit tests leveraging the new functions need to be explicitly linked against libguac. These changes add such linkage to all tests that were updated for GUACAMOLE-1867.