### PR TITLE
GUACAMOLE-1290: Migrate SSH certificate auth support to new memory management functions.

### DIFF
--- a/src/common-ssh/user.c
+++ b/src/common-ssh/user.c
@@ -89,8 +89,8 @@ int guac_common_ssh_user_import_public_key(guac_common_ssh_user* user,
         char* public_key) {
 
     /* Free existing public key, if present */
-    free(user->public_key);
-    user->public_key = strdup(public_key);
+    guac_mem_free(user->public_key);
+    user->public_key = guac_strdup(public_key);
 
     /* Fail if key could not be read */
     return user->public_key == NULL;


### PR DESCRIPTION
This change updates the only code specific to `master` that still pointed at good ol' `free()` and `strdup()` following the merge of #462, thankfully all relevant to the same JIRA issue ([GUACAMOLE-1290](https://issues.apache.org/jira/browse/GUACAMOLE-1290)).

Outside of this, the only other old code that remains using `free()`, `malloc()`, etc. is code that deals with memory allocated or freed by a third-party library.