### PR TITLE
GUACAMOLE-1886: Bump version numbers / soversions for 1.5.4.

### DIFF
--- a/bin/guacctl
+++ b/bin/guacctl
@@ -117,7 +117,7 @@ error() {
 ##
 usage() {
     cat >&2 <<END
-guacctl 1.5.3, Apache Guacamole terminal session control utility.
+guacctl 1.5.4, Apache Guacamole terminal session control utility.
 Usage: guacctl [OPTION] [FILE or NAME]...
 
     -d, --download         download each of the files listed.

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@
 #
 
 AC_PREREQ([2.61])
-AC_INIT([guacamole-server], [1.5.3])
+AC_INIT([guacamole-server], [1.5.4])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AM_SILENT_RULES([yes])

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -160,7 +160,7 @@ libguac_la_CFLAGS = \
     -Werror -Wall -pedantic
 
 libguac_la_LDFLAGS =     \
-    -version-info 22:0:1 \
+    -version-info 23:0:0 \
     -no-undefined        \
     @CAIRO_LIBS@         \
     @DL_LIBS@            \

--- a/src/terminal/Makefile.am
+++ b/src/terminal/Makefile.am
@@ -77,7 +77,7 @@ libguac_terminal_la_LIBADD = \
     @LIBGUAC_LTLIB@
 
 libguac_terminal_la_LDFLAGS = \
-    -version-info 0:0:0       \
+    -version-info 1:0:1       \
     -no-undefined             \
     @CAIRO_LIBS@              \
     @MATH_LIBS@               \


### PR DESCRIPTION
This change updates the version numbers within guacamole-server to 1.5.4. [Library soversion numbers](https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html) have also been updated to reflect the nature of changes made:

* libguac contains changes to the `guac_client` structure that affect structure member offsets. Established code linking against libguac would need to be rebuilt.
* libguac-terminal adds a new function (`guac_terminal_sync_users()`) but otherwise presents the exact same API and ABI.