### PR TITLE
GUACAMOLE-1196: Implement support for VNC display size updates

### DIFF
--- a/src/common/common/display.h
+++ b/src/common/common/display.h
@@ -29,6 +29,22 @@
 #include <pthread.h>
 
 /**
+ * The minimum display size (height or width) in pixels.
+ */
+#define GUAC_COMMON_DISPLAY_MIN_SIZE 200
+
+/**
+ * The maximum display size (height or width) in pixels.
+ */
+#define GUAC_COMMON_DISPLAY_MAX_SIZE 8192
+
+/**
+ * The minimum amount of time that must elapse between display size updates,
+ * in milliseconds.
+ */
+#define GUAC_COMMON_DISPLAY_UPDATE_INTERVAL 500
+
+/**
  * A list element representing a pairing of a Guacamole layer with a
  * corresponding guac_common_surface which wraps that layer. Adjacent layers
  * within the same list are pointed to with traditional prev/next pointers. The
@@ -134,6 +150,19 @@ typedef struct guac_common_display {
  */
 guac_common_display* guac_common_display_alloc(guac_client* client,
         int width, int height);
+
+/**
+ * Fits a given dimension within the allowed bounds for display sizing,
+ * adjusting the other dimension such that aspect ratio is maintained.
+ *
+ * @param a
+ *     The dimension to fit within allowed bounds.
+ *
+ * @param b
+ *     The other dimension to adjust if and only if necessary to preserve
+ *     aspect ratio.
+ */
+void guac_common_display_fit(int* a, int* b);
 
 /**
  * Frees the given display, and any associated resources, including any
@@ -257,6 +286,8 @@ void guac_common_display_free_buffer(guac_common_display* display,
  */
 void guac_common_display_set_lossless(guac_common_display* display,
         int lossless);
+
+
 
 #endif
 

--- a/src/common/display.c
+++ b/src/common/display.c
@@ -187,6 +187,37 @@ void guac_common_display_dup(
 
 }
 
+void guac_common_display_fit(int* a, int* b) {
+
+    int a_value = *a;
+    int b_value = *b;
+
+    /* Ensure first dimension is within allowed range */
+    if (a_value < GUAC_COMMON_DISPLAY_MIN_SIZE) {
+
+        /* Adjust other dimension to maintain aspect ratio */
+        int adjusted_b = b_value * GUAC_COMMON_DISPLAY_MIN_SIZE / a_value;
+        if (adjusted_b > GUAC_COMMON_DISPLAY_MAX_SIZE)
+            adjusted_b = GUAC_COMMON_DISPLAY_MAX_SIZE;
+
+        *a = GUAC_COMMON_DISPLAY_MIN_SIZE;
+        *b = adjusted_b;
+
+    }
+    else if (a_value > GUAC_COMMON_DISPLAY_MAX_SIZE) {
+
+        /* Adjust other dimension to maintain aspect ratio */
+        int adjusted_b = b_value * GUAC_COMMON_DISPLAY_MAX_SIZE / a_value;
+        if (adjusted_b < GUAC_COMMON_DISPLAY_MIN_SIZE)
+            adjusted_b = GUAC_COMMON_DISPLAY_MIN_SIZE;
+
+        *a = GUAC_COMMON_DISPLAY_MAX_SIZE;
+        *b = adjusted_b;
+
+    }
+
+}
+
 void guac_common_display_set_lossless(guac_common_display* display,
         int lossless) {
 

--- a/src/protocols/rdp/channels/disp.c
+++ b/src/protocols/rdp/channels/disp.c
@@ -18,6 +18,7 @@
  */
 
 #include "channels/disp.h"
+#include "common/display.h"
 #include "plugins/channels.h"
 #include "fs.h"
 #include "rdp.h"
@@ -149,56 +150,14 @@ void guac_rdp_disp_load_plugin(rdpContext* context) {
 
 }
 
-/**
- * Fits a given dimension within the allowed bounds for Display Update
- * messages, adjusting the other dimension such that aspect ratio is
- * maintained.
- *
- * @param a The dimension to fit within allowed bounds.
- *
- * @param b
- *     The other dimension to adjust if and only if necessary to preserve
- *     aspect ratio.
- */
-static void guac_rdp_disp_fit(int* a, int* b) {
-
-    int a_value = *a;
-    int b_value = *b;
-
-    /* Ensure first dimension is within allowed range */
-    if (a_value < GUAC_RDP_DISP_MIN_SIZE) {
-
-        /* Adjust other dimension to maintain aspect ratio */
-        int adjusted_b = b_value * GUAC_RDP_DISP_MIN_SIZE / a_value;
-        if (adjusted_b > GUAC_RDP_DISP_MAX_SIZE)
-            adjusted_b = GUAC_RDP_DISP_MAX_SIZE;
-
-        *a = GUAC_RDP_DISP_MIN_SIZE;
-        *b = adjusted_b;
-
-    }
-    else if (a_value > GUAC_RDP_DISP_MAX_SIZE) {
-
-        /* Adjust other dimension to maintain aspect ratio */
-        int adjusted_b = b_value * GUAC_RDP_DISP_MAX_SIZE / a_value;
-        if (adjusted_b < GUAC_RDP_DISP_MIN_SIZE)
-            adjusted_b = GUAC_RDP_DISP_MIN_SIZE;
-
-        *a = GUAC_RDP_DISP_MAX_SIZE;
-        *b = adjusted_b;
-
-    }
-
-}
-
 void guac_rdp_disp_set_size(guac_rdp_disp* disp, guac_rdp_settings* settings,
         freerdp* rdp_inst, int width, int height) {
 
     /* Fit width within bounds, adjusting height to maintain aspect ratio */
-    guac_rdp_disp_fit(&width, &height);
+    guac_common_display_fit(&width, &height);
 
     /* Fit height within bounds, adjusting width to maintain aspect ratio */
-    guac_rdp_disp_fit(&height, &width);
+    guac_common_display_fit(&height, &width);
 
     /* Width must be even */
     if (width % 2 == 1)
@@ -226,7 +185,7 @@ void guac_rdp_disp_update_size(guac_rdp_disp* disp,
     guac_timestamp now = guac_timestamp_current();
 
     /* Limit display update frequency */
-    if (now - disp->last_request <= GUAC_RDP_DISP_UPDATE_INTERVAL)
+    if (now - disp->last_request <= GUAC_COMMON_DISPLAY_UPDATE_INTERVAL)
         return;
 
     /* Do NOT send requests unless the size will change */

--- a/src/protocols/rdp/channels/disp.h
+++ b/src/protocols/rdp/channels/disp.h
@@ -28,22 +28,6 @@
 #include <guacamole/timestamp.h>
 
 /**
- * The minimum value for width or height, in pixels.
- */
-#define GUAC_RDP_DISP_MIN_SIZE 200
-
-/**
- * The maximum value for width or height, in pixels.
- */
-#define GUAC_RDP_DISP_MAX_SIZE 8192
-
-/**
- * The minimum amount of time that must elapse between display size updates,
- * in milliseconds.
- */
-#define GUAC_RDP_DISP_UPDATE_INTERVAL 500
-
-/**
  * Display size update module.
  */
 typedef struct guac_rdp_disp {

--- a/src/protocols/vnc/client.c
+++ b/src/protocols/vnc/client.c
@@ -106,10 +106,15 @@ int guac_client_init(guac_client* client) {
     guac_vnc_client* vnc_client = guac_mem_zalloc(sizeof(guac_vnc_client));
     client->data = vnc_client;
 
+    vnc_client->vnc_display = guac_vnc_display_update_alloc(client);
+
 #ifdef ENABLE_VNC_TLS_LOCKING
     /* Initialize the TLS write lock */
     pthread_mutex_init(&vnc_client->tls_lock, NULL);
 #endif
+
+    /* Initialize the message lock. */
+    pthread_mutex_init(&(vnc_client->message_lock), NULL);
 
     /* Init clipboard */
     vnc_client->clipboard = guac_common_clipboard_alloc();
@@ -208,6 +213,11 @@ int guac_vnc_client_free_handler(guac_client* client) {
     /* Clean up TLS lock mutex. */
     pthread_mutex_destroy(&(vnc_client->tls_lock));
 #endif
+
+    /* Clean up the message lock. */
+    pthread_mutex_destroy(&(vnc_client->message_lock));
+
+    guac_vnc_display_update_free(vnc_client->vnc_display);
 
     /* Free generic data struct */
     guac_mem_free(client->data);

--- a/src/protocols/vnc/client.c
+++ b/src/protocols/vnc/client.c
@@ -106,8 +106,6 @@ int guac_client_init(guac_client* client) {
     guac_vnc_client* vnc_client = guac_mem_zalloc(sizeof(guac_vnc_client));
     client->data = vnc_client;
 
-    vnc_client->vnc_display = guac_vnc_display_update_alloc(client);
-
 #ifdef ENABLE_VNC_TLS_LOCKING
     /* Initialize the TLS write lock */
     pthread_mutex_init(&vnc_client->tls_lock, NULL);
@@ -216,8 +214,6 @@ int guac_vnc_client_free_handler(guac_client* client) {
 
     /* Clean up the message lock. */
     pthread_mutex_destroy(&(vnc_client->message_lock));
-
-    guac_vnc_display_update_free(vnc_client->vnc_display);
 
     /* Free generic data struct */
     guac_mem_free(client->data);

--- a/src/protocols/vnc/display.c
+++ b/src/protocols/vnc/display.c
@@ -259,13 +259,17 @@ void guac_vnc_display_set_size(rfbClient* client, int width, int height) {
     /* Fit height within bounds, adjusting width to maintain aspect ratio */
     guac_common_display_fit(&height, &width);
 
-    /* Send the display size update. */
+    /* Acquire the lock for sending messages to server. */
     pthread_mutex_lock(&(vnc_client->message_lock));
+
+    /* Send the display size update. */
     guac_client_log(gc, GUAC_LOG_TRACE, "Setting VNC display size.");
     if (guac_vnc_send_desktop_size(client, width, height))
         guac_client_log(gc, GUAC_LOG_TRACE, "Successfully sent desktop size message.");
     else
         guac_client_log(gc, GUAC_LOG_TRACE, "Failed to send desktop size message.");
+    
+    /* Release the lock. */
     pthread_mutex_unlock(&(vnc_client->message_lock));
 
 }

--- a/src/protocols/vnc/display.c
+++ b/src/protocols/vnc/display.c
@@ -247,6 +247,21 @@ static rfbBool guac_vnc_send_desktop_size(rfbClient* client, int width, int heig
     return TRUE;
 }
 
+void* guac_vnc_display_set_owner_size(guac_user* owner, void* data) {
+
+    /* Pull RFB clients from provided data. */
+    rfbClient* rfb_client = (rfbClient*) data;
+
+    guac_user_log(owner, GUAC_LOG_DEBUG, "Sending VNC display size for owner's display.");
+    
+    /* Set the display size. */
+    guac_vnc_display_set_size(rfb_client, owner->info.optimal_width, owner->info.optimal_height);
+
+    /* Always return NULL. */
+    return NULL;
+
+}
+
 void guac_vnc_display_set_size(rfbClient* client, int width, int height) {
 
     /* Get the VNC client */

--- a/src/protocols/vnc/display.c
+++ b/src/protocols/vnc/display.c
@@ -155,6 +155,98 @@ void guac_vnc_copyrect(rfbClient* client, int src_x, int src_y, int w, int h, in
 
 }
 
+/**
+ * This function does the actual work of sending the message to the RFB/VNC
+ * server to request the resize, and then makes sure that the client frame
+ * buffer is updated, as well.
+ *
+ * @param client
+ *     The remote frame buffer client that is triggering the resize
+ *     request.
+ *
+ * @param width
+ *     The updated width of the screen.
+ *
+ * @param height
+ *     The updated height of the screen.
+ *
+ * @return
+ *     TRUE if the screen update was sent to the server, otherwise false. Note
+ *     that a successful send of the resize message to the server does NOT mean
+ *     that the server has any obligation to resize the display - it only
+ *     indicates that the VNC library has successfully sent the request.
+ */
+static rfbBool guac_vnc_send_desktop_size(rfbClient* client, int width, int height) {
+
+    /* Get the Guacamole client data */
+    guac_client* gc = rfbClientGetClientData(client, GUAC_VNC_CLIENT_KEY);
+
+    /* Don't send an update if the sreen appears to be uninitialized. */
+    if (client->screen.width == 0 || client->screen.height == 0) {
+        guac_client_log(gc, GUAC_LOG_ERROR, "Screen has not been initialized, cannot send resize.");
+        return FALSE;
+    }
+    
+    /* Don't send an update if the requested dimensions are identical to current dimensions. */
+    if (client->screen.width == rfbClientSwap16IfLE(width) && client->screen.height == rfbClientSwap16IfLE(height)) {
+        guac_client_log(gc, GUAC_LOG_WARNING, "Screen size has not changed, not sending update.");
+        return FALSE;
+    }
+
+    /**
+     * Note: The RFB protocol requires two message types to be sent during a
+     * resize request - the first for the desktop size (total size of all
+     * monitors), and then a message for each screen that is attached to the 
+     * remote server. Both libvncclient and Guacamole only support a single
+     * screen, so we send the desktop resize and screen resize with (nearly)
+     * identical data, but if one or both of these components is updated in the
+     * future to support multiple screens, this will need to be re-worked.
+     */
+
+    /* Set up the messages. */
+    rfbSetDesktopSizeMsg size_msg;
+    rfbExtDesktopScreen new_screen;
+
+    /* Configure the desktop size update message. */
+    size_msg.type = rfbSetDesktopSize;
+    size_msg.width = rfbClientSwap16IfLE(width);
+    size_msg.height = rfbClientSwap16IfLE(height);
+    size_msg.numberOfScreens = 1;
+
+    /* Configure the screen update message. */
+    new_screen.id = client->screen.id;
+    new_screen.x = client->screen.x;
+    new_screen.y = client->screen.y;
+    new_screen.flags = client->screen.flags;
+    new_screen.width = rfbClientSwap16IfLE(width);
+    new_screen.height = rfbClientSwap16IfLE(height);
+
+    /* Stop updates while the resize is in progress. */
+    client->requestedResize = TRUE;
+
+    /* Send the resize messages to the remote server. */
+    if (!WriteToRFBServer(client, (char *)&size_msg, sz_rfbSetDesktopSizeMsg)
+        || !WriteToRFBServer(client, (char *)&new_screen, sz_rfbExtDesktopScreen)) {
+
+        guac_client_log(gc, GUAC_LOG_ERROR, "Failed to send new desktop and screen size to the VNC server.");
+        return FALSE;
+
+    }
+
+    /* Update the client frame buffer with the requested size. */
+    client->screen.width = rfbClientSwap16IfLE(width);
+    client->screen.height = rfbClientSwap16IfLE(height);
+
+    /* Request a full screen update. */
+    client->requestedResize = FALSE;
+    if (!SendFramebufferUpdateRequest(client, 0, 0, width, height, FALSE)) {
+        guac_client_log(gc, GUAC_LOG_WARNING, "Failed to request a full screen update.");
+    }
+
+    /* Update should be successful. */
+    return TRUE;
+}
+
 void guac_vnc_display_set_size(rfbClient* client, int width, int height) {
 
     /* Get the VNC client */
@@ -169,7 +261,11 @@ void guac_vnc_display_set_size(rfbClient* client, int width, int height) {
 
     /* Send the display size update. */
     pthread_mutex_lock(&(vnc_client->message_lock));
-    SendExtDesktopSize(client, width, height);
+    guac_client_log(gc, GUAC_LOG_TRACE, "Setting VNC display size.");
+    if (guac_vnc_send_desktop_size(client, width, height))
+        guac_client_log(gc, GUAC_LOG_TRACE, "Successfully sent desktop size message.");
+    else
+        guac_client_log(gc, GUAC_LOG_TRACE, "Failed to send desktop size message.");
     pthread_mutex_unlock(&(vnc_client->message_lock));
 
 }

--- a/src/protocols/vnc/display.c
+++ b/src/protocols/vnc/display.c
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include "client.h"
+#include "display.h"
 #include "common/iconv.h"
 #include "common/surface.h"
 #include "vnc.h"
@@ -30,6 +31,7 @@
 #include <guacamole/mem.h>
 #include <guacamole/protocol.h>
 #include <guacamole/socket.h>
+#include <guacamole/timestamp.h>
 #include <rfb/rfbclient.h>
 #include <rfb/rfbproto.h>
 
@@ -153,6 +155,88 @@ void guac_vnc_copyrect(rfbClient* client, int src_x, int src_y, int w, int h, in
 
 }
 
+guac_vnc_display* guac_vnc_display_update_alloc(guac_client* client) {
+
+    guac_vnc_display* display = guac_mem_alloc(sizeof(guac_vnc_display));
+    display->client = client;
+
+    /* No requests have been made */
+    display->last_request = guac_timestamp_current();
+    display->requested_width  = 0;
+    display->requested_height = 0;
+
+    return display;
+
+}
+
+void guac_vnc_display_update_free(guac_vnc_display* display) {
+    guac_mem_free(display);
+}
+
+/**
+ * This function does the actual work of updating the display size if adequate
+ * time has passed since the last update and the size is actually different.
+*
+ * @param display
+ *     The data structure that contains information used for determing if and
+ *     when display updates should be allowed.
+ *
+ * @param rfb_client
+ *     A pointer to the VNC (RFB) client.
+ */
+static void guac_vnc_display_update_size(guac_vnc_display* display,
+        rfbClient* rfb_client) {
+
+    int width = display->requested_width;
+    int height = display->requested_height;
+
+    /* Do not update size if no requests have been received */
+    if (width == 0 || height == 0)
+        return;
+
+    guac_timestamp now = guac_timestamp_current();
+
+    /* Limit display update frequency */
+    if (now - display->last_request <= GUAC_COMMON_DISPLAY_UPDATE_INTERVAL)
+        return;
+
+    /* Do NOT send requests unless the size will change */
+    if (rfb_client != NULL
+            && width == rfb_client->screen.width
+            && height == rfb_client->screen.height)
+        return;
+
+    /* Send the display size update. */
+    guac_vnc_client* vnc_client = (guac_vnc_client*) display->client->data;
+    pthread_mutex_lock(&(vnc_client->message_lock));
+    SendExtDesktopSize(rfb_client, width, height);
+    display->last_request = now;
+    pthread_mutex_unlock(&(vnc_client->message_lock));
+
+}
+
+void guac_vnc_display_set_size(guac_vnc_display* display,
+        rfbClient* rfb_client, int width, int height) {
+
+    /* Fit width within bounds, adjusting height to maintain aspect ratio */
+    guac_common_display_fit(&width, &height);
+
+    /* Fit height within bounds, adjusting width to maintain aspect ratio */
+    guac_common_display_fit(&height, &width);
+
+    /* Width must be even */
+    if (width % 2 == 1)
+        width -= 1;
+
+    /* Store deferred size */
+    display->requested_width = width;
+    display->requested_height = height;
+
+    /* Send display update notification if possible */
+    guac_vnc_display_update_size(display, rfb_client);
+
+}
+
 void guac_vnc_set_pixel_format(rfbClient* client, int color_depth) {
     client->format.trueColour = 1;
     switch(color_depth) {
@@ -205,4 +289,3 @@ rfbBool guac_vnc_malloc_framebuffer(rfbClient* rfb_client) {
     /* Use original, wrapped proc */
     return vnc_client->rfb_MallocFrameBuffer(rfb_client);
 }
-

--- a/src/protocols/vnc/display.h
+++ b/src/protocols/vnc/display.h
@@ -85,6 +85,23 @@ void guac_vnc_copyrect(rfbClient* client, int src_x, int src_y, int w, int h,
         int dest_x, int dest_y);
 
 /**
+ * A callback for guac_client_for_owner that sets the VNC display size to the
+ * width and height of the owner's display.
+ *
+ * @param owner
+ *     A pointer to the  guac_user data structure that contains the owner of
+ *     the current connection.
+ *
+ * @param data
+ *     A pointer to the rfbClient data structure that represents the current
+ *     VNC client for the current connection.
+ *
+ * @return
+ *     This callback always returns NULL.
+ */
+void* guac_vnc_display_set_owner_size(guac_user* owner, void* data);
+
+/**
  * Attempts to set the display size of the remote server to the size requested
  * by the client, usually as part of a client (browser) resize, if supported by
  * both the VNC client and the remote server.

--- a/src/protocols/vnc/display.h
+++ b/src/protocols/vnc/display.h
@@ -26,34 +26,6 @@
 #include <rfb/rfbproto.h>
 
 /**
- * Display size update module for VNC.
- */
-typedef struct guac_vnc_display {
-
-    /**
-     * The guac_client instance handling the relevant VNC connection.
-     */
-    guac_client* client;
-
-    /**
-     * The timestamp of the last display update request, or 0 if no request
-     * has been sent yet.
-     */
-    guac_timestamp last_request;
-
-    /**
-     * The last requested screen width, in pixels.
-     */
-    int requested_width;
-
-    /**
-     * The last requested screen height, in pixels.
-     */
-    int requested_height;
-
-} guac_vnc_display;
-
-/**
  * Callback invoked by libVNCServer when it receives a new binary image data
  * from the VNC server. The image itself will be stored in the designated sub-
  * rectangle of client->framebuffer.
@@ -113,41 +85,12 @@ void guac_vnc_copyrect(rfbClient* client, int src_x, int src_y, int w, int h,
         int dest_x, int dest_y);
 
 /**
- * Allocates a new VNC display update module, which will keep track of the data
- * needed to handle display updates.
- *
- * @param client
- *     The guac_client instance handling the relevant VNC connection.
- *
- * @return
- *     A newly-allocated VNC display update module.
- */
-guac_vnc_display* guac_vnc_display_update_alloc(guac_client* client);
-
-/**
- * Frees the resources associated with the data structure that keeps track of
- * items related to VNC display updates. Only resources specific to Guacamole
- * are freed. Resources that are part of the rfbClient will be freed separately.
- * If no resources are currently allocated for Display Update support, this
- * function has no effect.
- *
- * @param display
- *     The display update module to free.
- */
-void guac_vnc_display_update_free(guac_vnc_display* display);
-
-/**
  * Attempts to set the display size of the remote server to the size requested
  * by the client, usually as part of a client (browser) resize, if supported by
  * both the VNC client and the remote server.
  *
  * @param display
- *     The VNC display update object that tracks information related to display
- *     update requests.
- *
- * @param rfb_client
- *     The data structure containing the VNC client that is used by this
- *     connection.
+ *     The VNC client to which the display size update should be sent.
  *
  * @param width
  *     The width that is being requested, in pixels.
@@ -155,8 +98,7 @@ void guac_vnc_display_update_free(guac_vnc_display* display);
  * @param height
  *     The height that is being requested, in pixels.
  */
-void guac_vnc_display_set_size(guac_vnc_display* display, rfbClient* rfb_client,
-        int width, int height);
+void guac_vnc_display_set_size(rfbClient* client, int width, int height);
 
 /**
  * Sets the pixel format to request of the VNC server. The request will be made

--- a/src/protocols/vnc/display.h
+++ b/src/protocols/vnc/display.h
@@ -26,8 +26,36 @@
 #include <rfb/rfbproto.h>
 
 /**
- * Callback invoked by libVNCServer when it receives a new binary image data.
- * the VNC server. The image itself will be stored in the designated sub-
+ * Display size update module for VNC.
+ */
+typedef struct guac_vnc_display {
+
+    /**
+     * The guac_client instance handling the relevant VNC connection.
+     */
+    guac_client* client;
+
+    /**
+     * The timestamp of the last display update request, or 0 if no request
+     * has been sent yet.
+     */
+    guac_timestamp last_request;
+
+    /**
+     * The last requested screen width, in pixels.
+     */
+    int requested_width;
+
+    /**
+     * The last requested screen height, in pixels.
+     */
+    int requested_height;
+
+} guac_vnc_display;
+
+/**
+ * Callback invoked by libVNCServer when it receives a new binary image data
+ * from the VNC server. The image itself will be stored in the designated sub-
  * rectangle of client->framebuffer.
  *
  * @param client
@@ -83,6 +111,52 @@ void guac_vnc_update(rfbClient* client, int x, int y, int w, int h);
  */
 void guac_vnc_copyrect(rfbClient* client, int src_x, int src_y, int w, int h,
         int dest_x, int dest_y);
+
+/**
+ * Allocates a new VNC display update module, which will keep track of the data
+ * needed to handle display updates.
+ *
+ * @param client
+ *     The guac_client instance handling the relevant VNC connection.
+ *
+ * @return
+ *     A newly-allocated VNC display update module.
+ */
+guac_vnc_display* guac_vnc_display_update_alloc(guac_client* client);
+
+/**
+ * Frees the resources associated with the data structure that keeps track of
+ * items related to VNC display updates. Only resources specific to Guacamole
+ * are freed. Resources that are part of the rfbClient will be freed separately.
+ * If no resources are currently allocated for Display Update support, this
+ * function has no effect.
+ *
+ * @param display
+ *     The display update module to free.
+ */
+void guac_vnc_display_update_free(guac_vnc_display* display);
+
+/**
+ * Attempts to set the display size of the remote server to the size requested
+ * by the client, usually as part of a client (browser) resize, if supported by
+ * both the VNC client and the remote server.
+ *
+ * @param display
+ *     The VNC display update object that tracks information related to display
+ *     update requests.
+ *
+ * @param rfb_client
+ *     The data structure containing the VNC client that is used by this
+ *     connection.
+ *
+ * @param width
+ *     The width that is being requested, in pixels.
+ *
+ * @param height
+ *     The height that is being requested, in pixels.
+ */
+void guac_vnc_display_set_size(guac_vnc_display* display, rfbClient* rfb_client,
+        int width, int height);
 
 /**
  * Sets the pixel format to request of the VNC server. The request will be made

--- a/src/protocols/vnc/input.c
+++ b/src/protocols/vnc/input.c
@@ -67,11 +67,11 @@ int guac_vnc_user_key_handler(guac_user* user, int keysym, int pressed) {
 
 int guac_vnc_user_size_handler(guac_user* user, int width, int height) {
 
+    /* Get the Guacamole VNC client */
     guac_vnc_client* vnc_client = (guac_vnc_client*) user->client->data;
-    rfbClient* rfb_client = vnc_client->rfb_client;
 
     /* Send display update */
-    guac_vnc_display_set_size(vnc_client->vnc_display, rfb_client, width, height);
+    guac_vnc_display_set_size(vnc_client->rfb_client, width, height);
 
     return 0;
 

--- a/src/protocols/vnc/input.c
+++ b/src/protocols/vnc/input.c
@@ -67,6 +67,8 @@ int guac_vnc_user_key_handler(guac_user* user, int keysym, int pressed) {
 
 int guac_vnc_user_size_handler(guac_user* user, int width, int height) {
 
+    guac_user_log(user, GUAC_LOG_TRACE, "Running user size handler.");
+
     /* Get the Guacamole VNC client */
     guac_vnc_client* vnc_client = (guac_vnc_client*) user->client->data;
 

--- a/src/protocols/vnc/input.c
+++ b/src/protocols/vnc/input.c
@@ -21,6 +21,7 @@
 
 #include "common/cursor.h"
 #include "common/display.h"
+#include "display.h"
 #include "vnc.h"
 
 #include <guacamole/recording.h>
@@ -64,3 +65,14 @@ int guac_vnc_user_key_handler(guac_user* user, int keysym, int pressed) {
     return 0;
 }
 
+int guac_vnc_user_size_handler(guac_user* user, int width, int height) {
+
+    guac_vnc_client* vnc_client = (guac_vnc_client*) user->client->data;
+    rfbClient* rfb_client = vnc_client->rfb_client;
+
+    /* Send display update */
+    guac_vnc_display_set_size(vnc_client->vnc_display, rfb_client, width, height);
+
+    return 0;
+
+}

--- a/src/protocols/vnc/input.h
+++ b/src/protocols/vnc/input.h
@@ -34,5 +34,9 @@ guac_user_mouse_handler guac_vnc_user_mouse_handler;
  */
 guac_user_key_handler guac_vnc_user_key_handler;
 
-#endif
+/**
+ * Handler for Guacamole user resize events.
+ */
+guac_user_size_handler guac_vnc_user_size_handler;
 
+#endif // GUAC_VNC_INPUT_H

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -38,6 +38,7 @@ const char* GUAC_VNC_CLIENT_ARGS[] = {
     "hostname",
     "port",
     "read-only",
+    "disable-display-resize",
     "encodings",
     GUAC_VNC_ARGV_USERNAME,
     GUAC_VNC_ARGV_PASSWORD,
@@ -118,6 +119,13 @@ enum VNC_ARGS_IDX {
      * dropped), "false" or blank otherwise.
      */
     IDX_READ_ONLY,
+
+    /**
+     * "true" if the VNC client should disable attempts to resize the remote
+     * display to the client's size, "false" or blank if those resize messages
+     * should be sent.
+     */
+    IDX_DISABLE_DISPLAY_RESIZE,
 
     /**
      * Space-separated list of encodings to use within the VNC session. If not
@@ -468,6 +476,11 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
     settings->disable_server_input =
             guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
                                          IDX_DISABLE_SERVER_INPUT, false);
+
+    /* Disable display resize */
+    settings->disable_display_resize =
+            guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
+                                         IDX_DISABLE_DISPLAY_RESIZE, false);
 
     /* Parse color depth */
     settings->color_depth =

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -55,6 +55,12 @@ typedef struct guac_vnc_settings {
     char* password;
 
     /**
+     * Disable the VNC client messages to request that the remote (server)
+     * display resize to match the client resolution.
+     */
+    bool disable_display_resize;
+
+    /**
      * Space-separated list of encodings to use within the VNC session.
      */
     char* encodings;

--- a/src/protocols/vnc/user.c
+++ b/src/protocols/vnc/user.c
@@ -91,6 +91,9 @@ int guac_vnc_user_join_handler(guac_user* user, int argc, char** argv) {
             user->file_handler = guac_vnc_sftp_file_handler;
 #endif
 
+        /* Handle display size changes. */
+        user->size_handler = guac_vnc_user_size_handler;
+
     }
 
     /**

--- a/src/protocols/vnc/user.c
+++ b/src/protocols/vnc/user.c
@@ -91,8 +91,9 @@ int guac_vnc_user_join_handler(guac_user* user, int argc, char** argv) {
             user->file_handler = guac_vnc_sftp_file_handler;
 #endif
 
-        /* Handle display size changes. */
-        user->size_handler = guac_vnc_user_size_handler;
+        /* If user is owner, set size handler. */
+        if (user->owner)
+            user->size_handler = guac_vnc_user_size_handler;
 
     }
 

--- a/src/protocols/vnc/user.c
+++ b/src/protocols/vnc/user.c
@@ -92,7 +92,7 @@ int guac_vnc_user_join_handler(guac_user* user, int argc, char** argv) {
 #endif
 
         /* If user is owner, set size handler. */
-        if (user->owner)
+        if (user->owner && !settings->disable_display_resize)
             user->size_handler = guac_vnc_user_size_handler;
 
     }

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -509,6 +509,9 @@ void* guac_vnc_client_thread(void* data) {
 
     }
 
+    /* Update the display with the owner's screen size. */
+    guac_client_for_owner(client, guac_vnc_display_set_owner_size, rfb_client);
+
     guac_socket_flush(client->socket);
 
     guac_timestamp last_frame_end = guac_timestamp_current();

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -456,11 +456,17 @@ void* guac_vnc_client_thread(void* data) {
         msg.status = 1;
         msg.pad = 0;
 
+        /* Acquire lock for writing to server. */
+        pthread_mutex_lock(&(vnc_client->message_lock));
+
         if (WriteToRFBServer(rfb_client, (char*)&msg, sz_rfbSetServerInputMsg))
             guac_client_log(client, GUAC_LOG_DEBUG, "Successfully sent request to disable server input.");
 
         else
             guac_client_log(client, GUAC_LOG_WARNING, "Failed to send request to disable server input.");
+
+        /* Release lock. */
+        pthread_mutex_unlock(&(vnc_client->message_lock));
     }
 
     /* Set remaining client data */

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -510,7 +510,8 @@ void* guac_vnc_client_thread(void* data) {
     }
 
     /* Update the display with the owner's screen size. */
-    guac_client_for_owner(client, guac_vnc_display_set_owner_size, rfb_client);
+    if (!settings->disable_display_resize)
+        guac_client_for_owner(client, guac_vnc_display_set_owner_size, rfb_client);
 
     guac_socket_flush(client->socket);
 

--- a/src/protocols/vnc/vnc.h
+++ b/src/protocols/vnc/vnc.h
@@ -141,11 +141,6 @@ typedef struct guac_vnc_client {
      */
     guac_iconv_write* clipboard_writer;
 
-    /**
-     * VNC display update module.
-     */
-    guac_vnc_display* vnc_display;
-
 } guac_vnc_client;
 
 /**

--- a/src/protocols/vnc/vnc.h
+++ b/src/protocols/vnc/vnc.h
@@ -26,6 +26,7 @@
 #include "common/display.h"
 #include "common/iconv.h"
 #include "common/surface.h"
+#include "display.h"
 #include "settings.h"
 
 #include <guacamole/client.h>
@@ -62,6 +63,11 @@ typedef struct guac_vnc_client {
      */
     pthread_mutex_t tls_lock;
 #endif
+
+    /**
+     * Lock which synchronizes messages sent to VNC server.
+     */
+    pthread_mutex_t message_lock;
 
     /**
      * The underlying VNC client.
@@ -134,6 +140,11 @@ typedef struct guac_vnc_client {
      * Clipboard encoding-specific writer.
      */
     guac_iconv_write* clipboard_writer;
+
+    /**
+     * VNC display update module.
+     */
+    guac_vnc_display* vnc_display;
 
 } guac_vnc_client;
 


### PR DESCRIPTION
This PR takes a crack at implementing the recently-added libvncclient support for `SendExtDesktopSize()`, which should allow Guacamole as a VNC client to send its size to VNC servers that support such functionality and have the display dynamically resized.

I'm creating as a draft for the moment since I have not actually tested the functionality. Among the things I'm not sure of:
* The RDP protocol contains a `resolution` setting which specifies the DPI resolution of the screen. I don't see any reason to try to mirror this into the VNC protocol, as I don't think VNC actually does anything with it (I think the DPI is fixed), but if I'm wrong let me know and I can add that support and try to update the code accordingly.
* In the Jira issue (https://issues.apache.org/jira/browse/GUACAMOLE-1196), @mike-jumper mentioned a way of possibly sending the resize command/message using `WriteToRFBServer()` - I'm wondering if it's worth trying to implement the display update functionality with that in cases where libvncclient doesn't contain the `SendExtDesktopSize()` function?
* I added the `message_lock` mutex for sending this message, as in the RDP protocol, but I don't know if there are other places where this lock should be used (authentication, for example), or if it's even required in this scenario?
* I moved a few bits from the RDP protocol to the common/display.h file - among them are the minimum and maximum display size. It wasn't clear to me from the comments in the code whether those minimum and maximum sizes are arbitrary or if there's some particular reason those values are used? Not sure if there's something specific to RDP that has those bounds?