### PR TITLE
GUACAMOLE-1140: Fix RDP pipe svc race condition with lock and NULL check.

### DIFF
--- a/src/protocols/rdp/channels/pipe-svc.c
+++ b/src/protocols/rdp/channels/pipe-svc.c
@@ -48,16 +48,18 @@ void guac_rdp_pipe_svc_send_pipes(
 
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
 
-    guac_common_list_lock(rdp_client->available_svc);
+    if (rdp_client->available_svc != NULL) {
+        guac_common_list_lock(rdp_client->available_svc);
 
-    /* Send pipe for each allocated SVC's output stream */
-    guac_common_list_element* current = rdp_client->available_svc->head;
-    while (current != NULL) {
-        guac_rdp_pipe_svc_send_pipe(socket, (guac_rdp_pipe_svc*) current->data);
-        current = current->next;
+        /* Send pipe for each allocated SVC's output stream */
+        guac_common_list_element* current = rdp_client->available_svc->head;
+        while (current != NULL) {
+            guac_rdp_pipe_svc_send_pipe(socket, (guac_rdp_pipe_svc*) current->data);
+            current = current->next;
+        }
+
+        guac_common_list_unlock(rdp_client->available_svc);
     }
-
-    guac_common_list_unlock(rdp_client->available_svc);
 }
 
 void guac_rdp_pipe_svc_add(guac_client* client, guac_rdp_pipe_svc* pipe_svc) {

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -117,6 +117,8 @@ static int guac_rdp_join_pending_handler(guac_client* client) {
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
     guac_socket* broadcast_socket = client->pending_socket;
 
+    pthread_rwlock_rdlock(&(rdp_client->lock));
+
     /* Synchronize any audio stream for each pending user */
     if (rdp_client->audio)
         guac_client_foreach_pending_user(
@@ -130,6 +132,8 @@ static int guac_rdp_join_pending_handler(guac_client* client) {
         guac_common_display_dup(rdp_client->display, client, broadcast_socket);
         guac_socket_flush(broadcast_socket);
     }
+
+    pthread_rwlock_unlock(&(rdp_client->lock));
 
     return 0;
 


### PR DESCRIPTION
This PR attempts to address the race condition associated with the RDP client join handler and the pipe svc attempt to access the available_svc member of the rdp_client data structure. I've taken both suggestions in one of the Jira tickets for 1) acquiring the overall lock and 2) doing a NULL check around available_svc before attempting to access it.

It's worth noting that simply acquiring the lock on its own within the guac_rdp_join_pending_handler() function does not actually resolve the problem - the NULL check is required. So, I'm not sure in the lock is actually worth anything, or if there's somewhere else (around the SFTP connection, maybe?) that the lock should also be acquired?