### PR TITLE
add-optional-permissions: add ability to change permissions of screen recording file and path

### DIFF
--- a/src/libguac/guacamole/recording.h
+++ b/src/libguac/guacamole/recording.h
@@ -22,6 +22,8 @@
 
 #include <guacamole/client.h>
 
+#include <sys/types.h>
+
 /**
  * Provides functions and structures to be use for session recording.
  *
@@ -122,6 +124,14 @@ typedef struct guac_recording {
  *     written, or non-zero if the path should be created if it does not yet
  *     exist.
  *
+ * @param file_permissions
+ *     The permissions to apply for the recording file created within the specified
+ *     path.
+ *
+ * @param path_permissions
+ *     The permissions to apply for the recording path created within the specified
+ *     path.
+ *
  * @param include_output
  *     Non-zero if output which is broadcast to each connected client
  *     (graphics, streams, etc.) should be included in the session recording,
@@ -154,8 +164,8 @@ typedef struct guac_recording {
  *     recording will be written, NULL otherwise.
  */
 guac_recording* guac_recording_create(guac_client* client,
-        const char* path, const char* name, int create_path,
-        int include_output, int include_mouse, int include_touch,
+        const char* path, const char* name, int create_path, mode_t file_permissions,
+        mode_t path_permissions, int include_output, int include_mouse, int include_touch,
         int include_keys);
 
 /**

--- a/src/libguac/guacamole/user.h
+++ b/src/libguac/guacamole/user.h
@@ -42,6 +42,7 @@
 
 #include <pthread.h>
 #include <stdarg.h>
+#include <sys/types.h>
 
 struct guac_user_info {
 
@@ -1000,6 +1001,37 @@ int guac_user_parse_args_int(guac_user* user, const char** arg_names,
  */
 int guac_user_parse_args_boolean(guac_user* user, const char** arg_names,
         const char** argv, int index, int default_value);
+
+/**
+ * Parses a string representation of file permissions (e.g., "rwxrwxrwx")
+ * and converts it to a mode_t value.
+ *
+ * @param user
+ *     The user joining the connection and providing the given arguments.
+ *
+ * @param arg_names
+ *     A NULL-terminated array of argument names, corresponding to the provided
+ *     array of argument values. This array must be exactly the same size as
+ *     the argument value array, with one additional entry for the NULL
+ *     terminator.
+ *
+ * @param argv
+ *     An array of all argument values, corresponding to the provided array of
+ *     argument names. This array must be exactly the same size as the argument
+ *     name array, with the exception of the NULL terminator.
+ *
+ * @param index
+ *     The index of the entry in both the arg_names and argv arrays which
+ *     corresponds to the argument being parsed.
+ *
+ * @param default_value
+ *     The value to return if the provided argument is blank or invalid.
+ *
+ * @return
+ *     The parsed mode_t value.
+ */
+mode_t guac_user_parse_args_mode(guac_user* user, const char** arg_names,
+        const char** argv, int index, mode_t default_value);
 
 #endif
 

--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -234,6 +234,8 @@ void* guac_kubernetes_client_thread(void* data) {
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path,
+                settings->recording_file_permissions,
+                settings->recording_path_permissions,
                 !settings->recording_exclude_output,
                 !settings->recording_exclude_mouse,
                 0, /* Touch events not supported */

--- a/src/protocols/kubernetes/settings.c
+++ b/src/protocols/kubernetes/settings.c
@@ -51,6 +51,8 @@ const char* GUAC_KUBERNETES_CLIENT_ARGS[] = {
     "recording-exclude-mouse",
     "recording-include-keys",
     "create-recording-path",
+    "recording-file-permissions",
+    "recording-path-permissions",
     "read-only",
     "backspace",
     "scrollback",
@@ -209,6 +211,18 @@ enum KUBERNETES_ARGS_IDX {
      * created if it does not yet exist.
      */
     IDX_CREATE_RECORDING_PATH,
+
+    /**
+     * The permissions that should be given to screen recording file which is written in
+     * the given path.
+     */
+    IDX_RECORDING_FILE_PERMISSIONS,
+
+    /**
+     * The permissions that should be given to screen recording path which is written in
+     * the given path.
+     */
+    IDX_RECORDING_PATH_PERMISSIONS,
 
     /**
      * "true" if this connection should be read-only (user input should be
@@ -388,6 +402,16 @@ guac_kubernetes_settings* guac_kubernetes_parse_args(guac_user* user,
     settings->create_recording_path =
         guac_user_parse_args_boolean(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
                 IDX_CREATE_RECORDING_PATH, false);
+
+    /* Parse file permissions flag */
+    settings->recording_file_permissions =
+        guac_user_parse_args_mode(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
+                IDX_RECORDING_FILE_PERMISSIONS, GUAC_KUBERNETES_DEFAULT_RECORDING_FILE_PERMISSIONS);
+
+    /* Parse path permissions flag */
+    settings->recording_path_permissions =
+        guac_user_parse_args_mode(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
+                IDX_RECORDING_PATH_PERMISSIONS, GUAC_KUBERNETES_DEFAULT_RECORDING_PATH_PERMISSIONS);
 
     /* Parse backspace key code */
     settings->backspace =

--- a/src/protocols/kubernetes/settings.h
+++ b/src/protocols/kubernetes/settings.h
@@ -23,6 +23,8 @@
 #include <guacamole/user.h>
 
 #include <stdbool.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 /**
  * The port to connect to when initiating any Kubernetes connection, if no
@@ -45,6 +47,16 @@
  * The filename to use for the screen recording, if not specified.
  */
 #define GUAC_KUBERNETES_DEFAULT_RECORDING_NAME "recording"
+
+/**
+ * The permissions to use for the screen recording file, if not specified.
+ */
+#define GUAC_KUBERNETES_DEFAULT_RECORDING_FILE_PERMISSIONS (S_IRUSR | S_IWUSR | S_IRGRP)
+
+/**
+ * The permissions to use for the screen recording path, if not specified.
+ */
+#define GUAC_KUBERNETES_DEFAULT_RECORDING_PATH_PERMISSIONS (S_IRWXU | S_IRGRP | S_IXGRP)
 
 /**
  * Settings for the Kubernetes connection. The values for this structure are
@@ -207,6 +219,16 @@ typedef struct guac_kubernetes_settings {
      * does not already exist.
      */
     bool create_recording_path;
+
+    /**
+     * The permissions to apply for the screen recording file.
+     */
+    mode_t recording_file_permissions;
+
+    /**
+     * The permissions to apply for the screen recording file.
+     */
+    mode_t recording_path_permissions;
 
     /**
      * Whether output which is broadcast to each connected client (graphics,

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -821,6 +821,8 @@ void* guac_rdp_client_thread(void* data) {
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path,
+                settings->recording_file_permissions,
+                settings->recording_path_permissions,
                 !settings->recording_exclude_output,
                 !settings->recording_exclude_mouse,
                 !settings->recording_exclude_touch,

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -122,6 +122,8 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
     "recording-exclude-touch",
     "recording-include-keys",
     "create-recording-path",
+    "recording-file-permissions",
+    "recording-path-permissions",
     "resize-method",
     "enable-audio-input",
     "enable-touch",
@@ -563,6 +565,18 @@ enum RDP_ARGS_IDX {
      * created if it does not yet exist.
      */
     IDX_CREATE_RECORDING_PATH,
+
+    /**
+     * The permissions that should be given to screen recording file which is written in
+     * the given path.
+     */
+    IDX_RECORDING_FILE_PERMISSIONS,
+
+    /**
+     * The permissions that should be given to screen recording path which is written in
+     * the given path.
+     */
+    IDX_RECORDING_PATH_PERMISSIONS,
 
     /**
      * The method to use to apply screen size changes requested by the user.
@@ -1160,6 +1174,16 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     settings->create_recording_path =
         guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
                 IDX_CREATE_RECORDING_PATH, 0);
+
+    /* Parse file permissions flag */
+    settings->recording_file_permissions =
+        guac_user_parse_args_mode(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_RECORDING_FILE_PERMISSIONS, GUAC_RDP_DEFAULT_RECORDING_FILE_PERMISSIONS);
+
+    /* Parse path permissions flag */
+    settings->recording_path_permissions =
+        guac_user_parse_args_mode(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_RECORDING_PATH_PERMISSIONS, GUAC_RDP_DEFAULT_RECORDING_PATH_PERMISSIONS);
 
     /* No resize method */
     if (strcmp(argv[IDX_RESIZE_METHOD], "") == 0) {

--- a/src/protocols/rdp/settings.h
+++ b/src/protocols/rdp/settings.h
@@ -27,6 +27,9 @@
 #include <guacamole/client.h>
 #include <guacamole/user.h>
 
+#include <sys/stat.h>
+#include <sys/types.h>
+
 /**
  * The maximum number of bytes in the client hostname claimed during
  * connection.
@@ -67,6 +70,16 @@
  * The filename to use for the screen recording, if not specified.
  */
 #define GUAC_RDP_DEFAULT_RECORDING_NAME "recording"
+
+/**
+ * The permissions to use for the screen recording file, if not specified.
+ */
+#define GUAC_RDP_DEFAULT_RECORDING_FILE_PERMISSIONS (S_IRUSR | S_IWUSR | S_IRGRP)
+
+/**
+ * The permissions to use for the screen recording path, if not specified.
+ */
+#define GUAC_RDP_DEFAULT_RECORDING_PATH_PERMISSIONS (S_IRWXU | S_IRGRP | S_IXGRP)
 
 /**
  * The number of entries contained within the OrderSupport BYTE array
@@ -524,6 +537,16 @@ typedef struct guac_rdp_settings {
      * does not already exist.
      */
     int create_recording_path;
+
+    /**
+     * The permissions to apply for the screen recording file.
+     */
+    mode_t recording_file_permissions;
+
+    /**
+     * The permissions to apply for the screen recording path.
+     */
+    mode_t recording_path_permissions;
 
     /**
      * Non-zero if output which is broadcast to each connected client

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -63,6 +63,8 @@ const char* GUAC_SSH_CLIENT_ARGS[] = {
     "recording-exclude-mouse",
     "recording-include-keys",
     "create-recording-path",
+    "recording-file-permissions",
+    "recording-path-permissions",
     "read-only",
     "server-alive-interval",
     "backspace",
@@ -240,6 +242,18 @@ enum SSH_ARGS_IDX {
      * created if it does not yet exist.
      */
     IDX_CREATE_RECORDING_PATH,
+
+    /**
+     * The permissions that should be given to screen recording file which is written in
+     * the given path.
+     */
+    IDX_RECORDING_FILE_PERMISSIONS,
+
+    /**
+     * The permissions that should be given to screen recording path which is written in
+     * the given path.
+     */
+    IDX_RECORDING_PATH_PERMISSIONS,
 
     /**
      * "true" if this connection should be read-only (user input should be
@@ -494,6 +508,16 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
     settings->create_recording_path =
         guac_user_parse_args_boolean(user, GUAC_SSH_CLIENT_ARGS, argv,
                 IDX_CREATE_RECORDING_PATH, false);
+
+    /* Parse file permissions flag */
+    settings->recording_file_permissions =
+        guac_user_parse_args_mode(user, GUAC_SSH_CLIENT_ARGS, argv,
+                IDX_RECORDING_FILE_PERMISSIONS, GUAC_SSH_DEFAULT_RECORDING_FILE_PERMISSIONS);
+
+    /* Parse path permissions flag */
+    settings->recording_path_permissions =
+        guac_user_parse_args_mode(user, GUAC_SSH_CLIENT_ARGS, argv,
+                IDX_RECORDING_PATH_PERMISSIONS, GUAC_SSH_DEFAULT_RECORDING_PATH_PERMISSIONS);
 
     /* Parse server alive interval */
     settings->server_alive_interval =

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -25,6 +25,8 @@
 #include <guacamole/user.h>
 
 #include <stdbool.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 /**
  * The port to connect to when initiating any SSH connection, if no other port
@@ -41,6 +43,16 @@
  * The filename to use for the screen recording, if not specified.
  */
 #define GUAC_SSH_DEFAULT_RECORDING_NAME "recording"
+
+/**
+ * The permissions to use for the screen recording file, if not specified.
+ */
+#define GUAC_SSH_DEFAULT_RECORDING_FILE_PERMISSIONS (S_IRUSR | S_IWUSR | S_IRGRP)
+
+/**
+ * The permissions to use for the screen recording path, if not specified.
+ */
+#define GUAC_SSH_DEFAULT_RECORDING_PATH_PERMISSIONS (S_IRWXU | S_IRGRP | S_IXGRP)
 
 /**
  * The default polling timeout for SSH activity in milliseconds.
@@ -224,6 +236,16 @@ typedef struct guac_ssh_settings {
      * does not already exist.
      */
     bool create_recording_path;
+
+    /**
+     * The permissions to apply for the screen recording file.
+     */
+    mode_t recording_file_permissions;
+
+    /**
+     * The permissions to apply for the screen recording path.
+     */
+    mode_t recording_path_permissions;
 
     /**
      * Whether output which is broadcast to each connected client (graphics,

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -261,6 +261,8 @@ void* ssh_client_thread(void* data) {
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path,
+                settings->recording_file_permissions,
+                settings->recording_path_permissions,
                 !settings->recording_exclude_output,
                 !settings->recording_exclude_mouse,
                 0, /* Touch events not supported */

--- a/src/protocols/telnet/settings.c
+++ b/src/protocols/telnet/settings.c
@@ -55,6 +55,8 @@ const char* GUAC_TELNET_CLIENT_ARGS[] = {
     "recording-exclude-mouse",
     "recording-include-keys",
     "create-recording-path",
+    "recording-file-permissions",
+    "recording-path-permissions",
     "read-only",
     "backspace",
     "terminal-type",
@@ -192,6 +194,18 @@ enum TELNET_ARGS_IDX {
      * created if it does not yet exist.
      */
     IDX_CREATE_RECORDING_PATH,
+
+    /**
+     * The permissions that should be given to screen recording file which is written in
+     * the given path.
+     */
+    IDX_RECORDING_FILE_PERMISSIONS,
+
+    /**
+     * The permissions that should be given to screen recording path which is written in
+     * the given path.
+     */
+    IDX_RECORDING_PATH_PERMISSIONS,
 
     /**
      * "true" if this connection should be read-only (user input should be
@@ -485,6 +499,16 @@ guac_telnet_settings* guac_telnet_parse_args(guac_user* user,
     settings->create_recording_path =
         guac_user_parse_args_boolean(user, GUAC_TELNET_CLIENT_ARGS, argv,
                 IDX_CREATE_RECORDING_PATH, false);
+
+    /* Parse file permissions flag */
+    settings->recording_file_permissions =
+        guac_user_parse_args_mode(user, GUAC_TELNET_CLIENT_ARGS, argv,
+                IDX_RECORDING_FILE_PERMISSIONS, GUAC_TELNET_DEFAULT_RECORDING_FILE_PERMISSIONS);
+
+    /* Parse path permissions flag */
+    settings->recording_path_permissions =
+        guac_user_parse_args_mode(user, GUAC_TELNET_CLIENT_ARGS, argv,
+                IDX_RECORDING_PATH_PERMISSIONS, GUAC_TELNET_DEFAULT_RECORDING_PATH_PERMISSIONS);
 
     /* Parse backspace key code */
     settings->backspace =

--- a/src/protocols/telnet/settings.h
+++ b/src/protocols/telnet/settings.h
@@ -25,6 +25,7 @@
 #include <guacamole/user.h>
 
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <regex.h>
 #include <stdbool.h>
 /**
@@ -48,6 +49,16 @@
  * The filename to use for the screen recording, if not specified.
  */
 #define GUAC_TELNET_DEFAULT_RECORDING_NAME "recording"
+
+/**
+ * The permissions to use for the screen recording file, if not specified.
+ */
+#define GUAC_TELNET_DEFAULT_RECORDING_FILE_PERMISSIONS (S_IRUSR | S_IWUSR | S_IRGRP)
+
+/**
+ * The permissions to use for the screen recording path, if not specified.
+ */
+#define GUAC_TELNET_DEFAULT_RECORDING_PATH_PERMISSIONS (S_IRWXU | S_IRGRP | S_IXGRP)
 
 /**
  * The regular expression to use when searching for the username/login prompt
@@ -212,6 +223,16 @@ typedef struct guac_telnet_settings {
      * does not already exist.
      */
     bool create_recording_path;
+
+    /**
+     * The permissions to apply for the screen recording file.
+     */
+    mode_t recording_file_permissions;
+
+    /**
+     * The permissions to apply for the screen recording file.
+     */
+    mode_t recording_path_permissions;
 
     /**
      * Whether output which is broadcast to each connected client (graphics,

--- a/src/protocols/telnet/telnet.c
+++ b/src/protocols/telnet/telnet.c
@@ -603,6 +603,8 @@ void* guac_telnet_client_thread(void* data) {
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path,
+                settings->recording_file_permissions,
+                settings->recording_path_permissions,
                 !settings->recording_exclude_output,
                 !settings->recording_exclude_mouse,
                 0, /* Touch events not supported */

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -84,6 +84,8 @@ const char* GUAC_VNC_CLIENT_ARGS[] = {
     "recording-exclude-mouse",
     "recording-include-keys",
     "create-recording-path",
+    "recording-file-permissions",
+    "recording-path-permissions",
     "disable-copy",
     "disable-paste",
     
@@ -330,6 +332,18 @@ enum VNC_ARGS_IDX {
      * created if it does not yet exist.
      */
     IDX_CREATE_RECORDING_PATH,
+
+    /**
+     * The permissions that should be given to screen recording file which is written in
+     * the given path.
+     */
+    IDX_RECORDING_FILE_PERMISSIONS,
+
+    /**
+     * The permissions that should be given to screen recording path which is written in
+     * the given path.
+     */
+    IDX_RECORDING_PATH_PERMISSIONS,
 
     /**
      * Whether outbound clipboard access should be blocked. If set to "true",
@@ -593,6 +607,16 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
     settings->create_recording_path =
         guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_CREATE_RECORDING_PATH, false);
+
+    /* Parse path creation flag */
+    settings->recording_file_permissions =
+        guac_user_parse_args_mode(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_RECORDING_FILE_PERMISSIONS, GUAC_VNC_DEFAULT_RECORDING_FILE_PERMISSIONS);
+
+    /* Parse path creation flag */
+    settings->recording_path_permissions =
+        guac_user_parse_args_mode(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_RECORDING_PATH_PERMISSIONS, GUAC_VNC_DEFAULT_RECORDING_PATH_PERMISSIONS);
 
     /* Parse clipboard copy disable flag */
     settings->disable_copy =

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -24,11 +24,23 @@
 #include "config.h"
 
 #include <stdbool.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 /**
  * The filename to use for the screen recording, if not specified.
  */
 #define GUAC_VNC_DEFAULT_RECORDING_NAME "recording"
+
+/**
+ * The permissions to use for the screen recording file, if not specified.
+ */
+#define GUAC_VNC_DEFAULT_RECORDING_FILE_PERMISSIONS (S_IRUSR | S_IWUSR | S_IRGRP)
+
+/**
+ * The permissions to use for the screen recording path, if not specified.
+ */
+#define GUAC_VNC_DEFAULT_RECORDING_PATH_PERMISSIONS (S_IRWXU | S_IRGRP | S_IXGRP)
 
 /**
  * VNC-specific client data.
@@ -249,6 +261,16 @@ typedef struct guac_vnc_settings {
      * does not already exist.
      */
     bool create_recording_path;
+
+    /**
+     * The permissions to apply for the screen recording file.
+     */
+    mode_t recording_file_permissions;
+
+    /**
+     * The permissions to apply for the screen recording path.
+     */
+    mode_t recording_path_permissions;
 
     /**
      * Whether output which is broadcast to each connected client (graphics,

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -425,6 +425,8 @@ void* guac_vnc_client_thread(void* data) {
                 settings->recording_path,
                 settings->recording_name,
                 settings->create_recording_path,
+                settings->recording_file_permissions,
+                settings->recording_path_permissions,
                 !settings->recording_exclude_output,
                 !settings->recording_exclude_mouse,
                 0, /* Touch events not supported */


### PR DESCRIPTION
### Description

Add record-path-permissions and record-file-permissions optional fields when starting record of session.