### PR TITLE
GUACAMOLE-1892: Fix the build issues related to librt for Ubuntu 22.04.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,14 @@ AC_CHECK_LIB([pthread], [pthread_create], [PTHREAD_LIBS=-lpthread
               AC_DEFINE([HAVE_LIBPTHREAD],,
                         [Whether libpthread was found])])
 
+# librt
+AC_CHECK_FUNC([timer_create], [AC_MSG_RESULT([timer_create was found without librt.])],
+              [AC_CHECK_LIB([rt], [timer_create],
+                            [AC_MSG_RESULT([timer_create was found in librt.])
+                                           RT_LIBS=-lrt],
+                            [AC_MSG_ERROR([timer_create could not be found.])])
+              ])
+
 # Include libdl for dlopen() if necessary
 AC_CHECK_LIB([dl], [dlopen],
              [DL_LIBS=-ldl],
@@ -128,6 +136,7 @@ AC_SUBST(MATH_LIBS)
 AC_SUBST(PNG_LIBS)
 AC_SUBST(JPEG_LIBS)
 AC_SUBST(CAIRO_LIBS)
+AC_SUBST(RT_LIBS)
 AC_SUBST(PTHREAD_LIBS)
 AC_SUBST(UUID_LIBS)
 AC_SUBST(CUNIT_LIBS)

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -167,6 +167,7 @@ libguac_la_LDFLAGS =     \
     @JPEG_LIBS@          \
     @PNG_LIBS@           \
     @PTHREAD_LIBS@       \
+    @RT_LIBS@            \
     @SSL_LIBS@           \
     @UUID_LIBS@          \
     @VORBIS_LIBS@        \


### PR DESCRIPTION
I've fixed the build issues related to librt for Ubuntu 22.04.