### PR TITLE
GUACAMOLE-1903: set rcMask to NULL

### DIFF
--- a/src/protocols/vnc/cursor.c
+++ b/src/protocols/vnc/cursor.c
@@ -124,6 +124,9 @@ void guac_vnc_cursor(rfbClient* client, int x, int y, int w, int h, int bpp) {
     guac_mem_free(buffer);
 
     /* libvncclient does not free rcMask as it does rcSource */
-    free(client->rcMask);
+    if (client->rcMask) {
+        free(client->rcMask);
+        client->rcMask = NULL;
+    }
 }
 

--- a/src/protocols/vnc/cursor.c
+++ b/src/protocols/vnc/cursor.c
@@ -124,7 +124,7 @@ void guac_vnc_cursor(rfbClient* client, int x, int y, int w, int h, int bpp) {
     guac_mem_free(buffer);
 
     /* libvncclient does not free rcMask as it does rcSource */
-    if (client->rcMask) {
+    if (client->rcMask != NULL) {
         free(client->rcMask);
         client->rcMask = NULL;
     }


### PR DESCRIPTION
set rcMask to NULL to prevent double-free errors occuring in libvncclient 0.9.13 and up