### PR TITLE
GUACAMOLE-1910: Add locking around TLS socket

### DIFF
--- a/src/libguac/guacamole/socket-ssl.h
+++ b/src/libguac/guacamole/socket-ssl.h
@@ -31,6 +31,7 @@
 #include "socket-types.h"
 
 #include <openssl/ssl.h>
+#include <pthread.h>
 
 /**
  * SSL socket-specific data.
@@ -53,6 +54,12 @@ typedef struct guac_socket_ssl_data {
      * guac_socket_open_secure().
      */
     SSL* ssl;
+
+    /**
+     * Lock that is acquired when an instruction is being written, and released
+     * when the instruction is finished being written.
+     */
+    pthread_mutex_t socket_lock;
 
 } guac_socket_ssl_data;
 


### PR DESCRIPTION
When TLS is turned on the file descriptor for the socket does not use locking when writing to it. It results in corrupted guacamole instructions being written to the stream when there are multiple connected clients.

This adds a mutex in the same manner done in `socket-fd.c`.