### PR TITLE
GUACAMOLE-1917: Ensure remote changes to clipboard are immediately received by connected users.

### DIFF
--- a/src/common/clipboard.c
+++ b/src/common/clipboard.c
@@ -114,6 +114,7 @@ static void* __send_user_clipboard(guac_user* user, void* data) {
 
     /* End stream */
     guac_protocol_send_end(user->socket, stream);
+    guac_socket_flush(user->socket);
     guac_user_free_stream(user, stream);
 
     return NULL;


### PR DESCRIPTION
As noted on [GUACAMOLE-1917](https://issues.apache.org/jira/browse/GUACAMOLE-1917), these changes add the `guac_socket_flush()` call missing from the internals of `guac_common_clipboard_send()`, ensuring changes to the clipboard don't get stuck waiting until something else happens to flush the socket.