### PR TITLE
GUACAMOLE-1918: Sync multitouch attribute for default surface.

### DIFF
--- a/src/common/surface.c
+++ b/src/common/surface.c
@@ -2009,12 +2009,13 @@ void guac_common_surface_dup(guac_common_surface* surface,
         guac_protocol_send_move(socket, surface->layer,
                 surface->parent, surface->x, surface->y, surface->z);
 
-        /* Synchronize multi-touch support level */
-        guac_protocol_send_set_int(surface->socket, surface->layer,
-                GUAC_PROTOCOL_LAYER_PARAMETER_MULTI_TOUCH,
-                surface->touches);
-
     }
+
+    /* Synchronize multi-touch support level */
+    else if (surface->layer->index == 0)
+        guac_protocol_send_set_int(socket, surface->layer,
+                GUAC_PROTOCOL_LAYER_PARAMETER_MULTI_TOUCH,
+                    surface->touches);
 
     /* Sync size to new socket */
     guac_protocol_send_size(socket, surface->layer,


### PR DESCRIPTION
These changes correct the incorrect socket and the logic error in `guac_common_surface_dup()` that are currently preventing the multitouch attribute from being correctly synced at all ([GUACAMOLE-1918](https://issues.apache.org/jira/browse/GUACAMOLE-1918)). The multitouch attribute should be synced for the default layer (not for all layers _except_ the default) and must be sent along the provided socket (not the surface's socket).