### PR TITLE
GUACAMOLE-1906: Bump soversion for liguac after API changes.

### DIFF
--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -160,7 +160,7 @@ libguac_la_CFLAGS = \
     -Werror -Wall -pedantic
 
 libguac_la_LDFLAGS =     \
-    -version-info 23:0:0 \
+    -version-info 24:0:0 \
     -no-undefined        \
     @CAIRO_LIBS@         \
     @DL_LIBS@            \


### PR DESCRIPTION
After the changes in #484, the version of libguac needs to be bumped.