### PR TITLE
GUACAMOLE-1732: Free dangling locks and correct and remove unnecessary locks.

### DIFF
--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -115,7 +115,6 @@ BOOL rdp_freerdp_pre_connect(freerdp* instance) {
 
         /* Downgrade the lock to allow for concurrent read access */
         guac_rwlock_release_lock(&(rdp_client->lock));
-        guac_rwlock_acquire_read_lock(&(rdp_client->lock));
     }
 
     /* Load "cliprdr" service if not disabled */
@@ -537,6 +536,7 @@ static int guac_rdp_handle_connection(guac_client* client) {
     }
 
     /* Upgrade to write lock again for further exclusive operations */
+    guac_rwlock_release_lock(&(rdp_client->lock));
     guac_rwlock_acquire_write_lock(&(rdp_client->lock));
 
     /* Connection complete */
@@ -843,4 +843,3 @@ void* guac_rdp_client_thread(void* data) {
     return NULL;
 
 }
-


### PR DESCRIPTION
This pull request corrects issues identified by Coverity Scan related to a misunderstanding of lock upgrading in `rwlock.h`. I refined the locking logic to ensure consistent lock acquisition and release, following the intended use of the `rwlock.h`