### PR TITLE
GUACAMOLE-1374: Guacamole in Docker on ARM

### DIFF
--- a/src/guacd-docker/bin/build-all.sh
+++ b/src/guacd-docker/bin/build-all.sh
@@ -96,10 +96,26 @@ install_from_git() {
 }
 
 #
+# Determine any option overrides to guarantee successful build
+#
+
+export BUILD_ARCHITECTURE="$(arch)" # Determine architecture building on
+echo "Build architecture: $BUILD_ARCHITECTURE"
+
+case $BUILD_ARCHITECTURE in
+    armv6l|armv7l|aarch64)
+        export FREERDP_OPTS_OVERRIDES="-DWITH_SSE2=OFF" # Disable SSE2 on ARM
+        ;;
+    *)
+        export FREERDP_OPTS_OVERRIDES=""
+        ;;
+esac
+
+#
 # Build and install core protocol library dependencies
 #
 
-install_from_git "https://github.com/FreeRDP/FreeRDP" "$WITH_FREERDP" $FREERDP_OPTS
+install_from_git "https://github.com/FreeRDP/FreeRDP" "$WITH_FREERDP" $FREERDP_OPTS $FREERDP_OPTS_OVERRIDES
 install_from_git "https://github.com/libssh2/libssh2" "$WITH_LIBSSH2" $LIBSSH2_OPTS
 install_from_git "https://github.com/seanmiddleditch/libtelnet" "$WITH_LIBTELNET" $LIBTELNET_OPTS
 install_from_git "https://github.com/LibVNC/libvncserver" "$WITH_LIBVNCCLIENT" $LIBVNCCLIENT_OPTS


### PR DESCRIPTION
Pull request based on discussion [here](https://lists.apache.org/thread/yoqfy9s6bfvcsgccc33kylgyk9h7pwko). 

It is difficult to dynamically determine build options based on a given architecture from within a Dockerfile without requiring manually passing in the architecture type as an argument during the build process. Instead, this proposed approach uses the fact that a build script is used to actually build the dependencies and checks the architecture there. With this information it generates a list of overrides which are appended to the end of the `install_from_git` functions. Options are processed in order so by appending them to the end, they will override any options provided in the main Dockerfile. This guarantees the build process succeeds (even if the user provides bad options in the Dockerfile). 

I have tested that it works on macOS (arch: amd64) and a Raspberry Pi 4 (arch: aarch64), open to hearing how it works on other architectures!