### PR TITLE
GUACAMOLE-1267: Add VNC setting 'disable-remote-input'

### DIFF
--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -87,6 +87,7 @@ const char* GUAC_VNC_CLIENT_ARGS[] = {
     "recording-write-existing",
     "disable-copy",
     "disable-paste",
+    "disable-server-input",
     
     "wol-send-packet",
     "wol-mac-addr",
@@ -353,6 +354,12 @@ enum VNC_ARGS_IDX {
      * using the clipboard. By default, clipboard access is not blocked.
      */
     IDX_DISABLE_PASTE,
+
+    /**
+     * Whether or not to disable the input on the server side when the VNC client
+     * is connected. The default is not to disable the input.
+     */
+    IDX_DISABLE_SERVER_INPUT,
     
     /**
      * Whether to send the magic Wake-on-LAN (WoL) packet to wake the remote
@@ -456,6 +463,11 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
     settings->read_only =
         guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_READ_ONLY, false);
+
+    /* Disable server input */
+    settings->disable_server_input =
+            guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
+                                         IDX_DISABLE_SERVER_INPUT, false);
 
     /* Parse color depth */
     settings->color_depth =

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -321,6 +321,11 @@ typedef struct guac_vnc_settings {
      */
     int wol_wait_time;
 
+    /**
+     * Whether or not to disable the input on the server side.
+     */
+    bool disable_server_input;
+
 } guac_vnc_settings;
 
 /**

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -416,6 +416,20 @@ void* guac_vnc_client_thread(void* data) {
     }
 #endif
 
+    /* Disable remote console (Server input) */
+    if (settings->disable_server_input) {
+        rfbSetServerInputMsg msg;
+        msg.type = rfbSetServerInput;
+        msg.status = 1;
+        msg.pad = 0;
+
+        if (WriteToRFBServer(rfb_client, (char*)&msg, sz_rfbSetServerInputMsg))
+            guac_client_log(client, GUAC_LOG_DEBUG, "Successfully sent request to disable server input.");
+
+        else
+            guac_client_log(client, GUAC_LOG_WARNING, "Failed to send request to disable server input.");
+    }
+
     /* Set remaining client data */
     vnc_client->rfb_client = rfb_client;
 


### PR DESCRIPTION
Finishing up the work that @stefan-esq started on #327 - this should tie up the final changes for adding the server-side setting for `disable-remote-input` on the VNC protocol.

This closes #327.