### PR TITLE
GUACAMOLE-192: Select word in terminal on double click

### DIFF
--- a/src/terminal/select.c
+++ b/src/terminal/select.c
@@ -194,7 +194,7 @@ void guac_terminal_select_update(guac_terminal* terminal, int row, int column) {
 
     /* Only update if selection has changed */
     if (row != terminal->selection_end_row
-        || column <  terminal->selection_end_column
+        || column <=  terminal->selection_end_column
         || column >= terminal->selection_end_column + terminal->selection_end_width) {
 
         int width = guac_terminal_find_char(terminal, row, &column);

--- a/src/terminal/terminal/terminal-priv.h
+++ b/src/terminal/terminal/terminal-priv.h
@@ -465,6 +465,16 @@ struct guac_terminal {
      */
     bool disable_copy;
 
+    /**
+     * The time betwen two left clicks.
+     */
+    guac_timestamp click_timer;
+
+    /**
+     * Counter for left clicks.
+     */
+    int click_counter;
+
 };
 
 /**


### PR DESCRIPTION
Allows selecting a word on double-click and a complete line on triple-click.

Based on the unmaintained PR by @Saiyeux (https://github.com/apache/guacamole-server/pull/406) :

- All "rewritten" functions have been removed in favor of existing functions.
	-> Code simplification.
	-> Fixes several unexpected behaviors when scrolling upwards.
- The following characters are now considered part of a "word": [0-9\\/A-Za-z_\\~\\&\\-\\.\\?\\\\%=:\$]
	-> Allows selecting an IP address, a path or URL (ex: https://www.test.tld/file.php?param1=value1&param2=value%202)
- Improved condition in the guac_terminal_select_update (select.c) function to allow selecting a "word" of a single character on double-click (no impact on single-click).
