### PR TITLE
ru_ru_qwerty.keymap for Russian keyboard for RDP

### DIFF
--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -252,7 +252,8 @@ rdp_keymaps =                                \
     $(srcdir)/keymaps/ro_ro_qwerty.keymap    \
     $(srcdir)/keymaps/sv_se_qwerty.keymap    \
     $(srcdir)/keymaps/da_dk_qwerty.keymap    \
-    $(srcdir)/keymaps/tr_tr_qwerty.keymap
+    $(srcdir)/keymaps/tr_tr_qwerty.keymap    \
+    $(srcdir)/keymaps/ru_ru_qwerty.keymap
 
 _generated_keymaps.c: $(rdp_keymaps) $(srcdir)/keymaps/generate.pl
 	$(AM_V_GEN) $(srcdir)/keymaps/generate.pl $(rdp_keymaps)

--- a/src/protocols/rdp/keymaps/ru_ru_qwerty.keymap
+++ b/src/protocols/rdp/keymaps/ru_ru_qwerty.keymap
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+parent  "base"
+name    "ru-ru-qwerty"
+# We use the "KBD_US" layout because we switch the language, not the layout
+freerdp "KBD_US"
+
+# Let's define the scan codes of the main Latin keys
+# 
+map -caps -shift 0x10..0x19 ~ "qwertyuiop"
+map -caps -shift 0x1E..0x26 ~ "asdfghjkl"
+map -caps -shift 0x2C..0x32 ~ "zxcvbnm"
+
+map -caps +shift 0x10..0x19 ~ "QWERTYUIOP"
+map -caps +shift 0x1E..0x26 ~ "ASDFGHJKL"
+map -caps +shift 0x2C..0x32 ~ "ZXCVBNM"
+
+map -caps +shift 0x10..0x19 ~ "QWERTYUIOP"
+map -caps +shift 0x1E..0x26 ~ "ASDFGHJKL"
+map -caps +shift 0x2C..0x32 ~ "ZXCVBNM"
+
+map +caps +shift 0x10..0x19 ~ "qwertyuiop"
+map +caps +shift 0x1E..0x26 ~ "asdfghjkl"
+map +caps +shift 0x2C..0x32 ~ "zxcvbnm"
+
+# Let's define the scan codes of the main Russian keys
+#
+map -caps -shift 0x10..0x19 ~ "йцукенгшщз"
+map -caps -shift 0x1E..0x26 ~ "фывапролд"
+map -caps -shift 0x2C..0x32 ~ "ячсмить"
+
+map -caps +shift 0x10..0x19 ~ "ЙЦУКЕНГШЩЗ"
+map -caps +shift 0x1E..0x26 ~ "ФЫВАПРОЛД"
+map -caps +shift 0x2C..0x32 ~ "ЯЧСМИТЬ"
+
+map +caps -shift 0x10..0x19 ~ "ЙЦУКЕНГШЩЗ"
+map +caps -shift 0x1E..0x26 ~ "ФЫВАПРОЛД"
+map +caps -shift 0x2C..0x32 ~ "ЯЧСМИТЬ"
+
+map +caps +shift 0x10..0x19 ~ "йцукенгшщз"
+map +caps +shift 0x1E..0x26 ~ "фывапролд"
+map +caps +shift 0x2C..0x32 ~ "ячсмить"


### PR DESCRIPTION
Add Russian keyboard support for RDP.
Solve problem Ctrl+ and "ю"  instead of "." [GUACAMOLE-925](https://issues.apache.org/jira/browse/GUACAMOLE-925l)