### PR TITLE
GUACAMOLE-1586: Don't add \n in clipboard if the line isn't finished.

### DIFF
--- a/src/terminal/buffer.c
+++ b/src/terminal/buffer.c
@@ -48,6 +48,7 @@ guac_terminal_buffer* guac_terminal_buffer_alloc(int rows, guac_terminal_char* d
         /* Allocate row  */
         row->available = 256;
         row->length = 0;
+        row->wrapped_row = false;
         row->characters = guac_mem_alloc(sizeof(guac_terminal_char), row->available);
 
         /* Next row */
@@ -166,6 +167,10 @@ void guac_terminal_buffer_copy_rows(guac_terminal_buffer* buffer,
         /* Copy data */
         memcpy(dst_row->characters, src_row->characters, sizeof(guac_terminal_char) * src_row->length);
         dst_row->length = src_row->length;
+        dst_row->wrapped_row = src_row->wrapped_row;
+
+        /* Reset src wrapped_row */
+        src_row->wrapped_row = false;
 
         /* Next current_row */
         current_row += step;

--- a/src/terminal/select.c
+++ b/src/terminal/select.c
@@ -371,17 +371,31 @@ void guac_terminal_select_end(guac_terminal* terminal) {
     /* Otherwise, copy multiple rows */
     else {
 
-        /* Store first row */
+        /* Get the first selected row */
+        guac_terminal_buffer_row* buffer_row = guac_terminal_buffer_get_row(terminal->buffer, start_row, 0);
+
+        /* Store first row from start_col to last available col */
         guac_terminal_clipboard_append_row(terminal, start_row, start_col, -1);
 
         /* Store all middle rows */
         for (int row = start_row + 1; row < end_row; row++) {
-            guac_common_clipboard_append(terminal->clipboard, "\n", 1);
+
+            /* Add a new line only if the line was not wrapped */
+            if (buffer_row->wrapped_row == false)
+                guac_common_clipboard_append(terminal->clipboard, "\n", 1);
+
+            /* Store middle row */
             guac_terminal_clipboard_append_row(terminal, row, 0, -1);
+
+            /* Get next buffer row */
+            buffer_row = guac_terminal_buffer_get_row(terminal->buffer, row, 0);
         }
 
-        /* Store last row */
-        guac_common_clipboard_append(terminal->clipboard, "\n", 1);
+        /* Add a new line only if the line was not wrapped */
+        if (buffer_row->wrapped_row == false)
+            guac_common_clipboard_append(terminal->clipboard, "\n", 1);
+
+        /* Store last row from col 0 to end_col */
         guac_terminal_clipboard_append_row(terminal, end_row, 0, end_col);
 
     }

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -241,9 +241,10 @@ void guac_terminal_reset(guac_terminal* term) {
     /* Reset display palette */
     guac_terminal_display_reset_palette(term->display);
 
-    /* Clear terminal */
+    /* Clear terminal with a row length of term_width-1 
+     * to avoid exceed the size of the display layer */
     for (row=0; row<term->term_height; row++)
-        guac_terminal_set_columns(term, row, 0, term->term_width, &(term->default_char));
+        guac_terminal_set_columns(term, row, 0, term->term_width-1, &(term->default_char));
 
 }
 

--- a/src/terminal/terminal/buffer.h
+++ b/src/terminal/terminal/buffer.h
@@ -51,6 +51,12 @@ typedef struct guac_terminal_buffer_row {
      */
     int available;
 
+    /**
+     * True if the current row has been wrapped to avoid going off the screen.
+     * False otherwise.
+     */
+    bool wrapped_row;
+
 } guac_terminal_buffer_row;
 
 /**


### PR DESCRIPTION
In the case of selecting multiple lines, do not add \n if the line is not really finished.

**Changes:**
- Correct buffer_row length on terminal init.
- Using the last column of the buffer_row (out of screen) to store a 1 if the word wrap was forced (0 is written when initializing the row).
- In case of selection on several lines, we add a \n only if the value of the last column is 0.
