### PR TITLE
GUACAMOLE-1952: Add compatibility with FFMPEG 7.0

### DIFF
--- a/src/guacenc/video.c
+++ b/src/guacenc/video.c
@@ -500,7 +500,9 @@ int guacenc_video_free(guacenc_video* video) {
 
     /* Clean up encoding context */
     if (video->context != NULL) {
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 3, 100)
         avcodec_close(video->context);
+#endif
         avcodec_free_context(&(video->context));
     }
 


### PR DESCRIPTION
Deprecated avcodec_close was removed in FFMPEG 7.0