### PR TITLE
GUACAMOLE-1686: Fix fd resource leak in WoL code.

### DIFF
--- a/src/libguac/wol.c
+++ b/src/libguac/wol.c
@@ -212,6 +212,9 @@ int guac_wol_wake_and_wait(const char* mac_addr, const char* broadcast_addr,
         return 0;
     }
 
+    /* Close the fd to avoid resource leak. */
+    close(sockfd);
+
     /* Send the magic WOL packet and store return value. */
     int retval = guac_wol_wake(mac_addr, broadcast_addr, udp_port);
 


### PR DESCRIPTION
This fixes an issue that Coverity identified that I missed the first time around with a resource leak when failing to close file descriptors before they go out of scope.