### PR TITLE
GUACAMOLE-1633: Add support of alternate screen buffer

### DIFF
--- a/src/terminal/terminal-handlers.c
+++ b/src/terminal/terminal-handlers.c
@@ -51,6 +51,11 @@
 #define GUAC_TERMINAL_OK          "\x1B[0n"
 
 /**
+ * Alternative buffer CSI sequence.
+ */
+#define GUAC_TERMINAL_ALT_BUFFER   1049
+
+/**
  * Advances the cursor to the next row, scrolling if the cursor would otherwise
  * leave the scrolling region. If the cursor is already outside the scrolling
  * region, the cursor is prevented from leaving the terminal bounds.
@@ -885,6 +890,10 @@ int guac_terminal_csi(guac_terminal* term, unsigned char c) {
                 if (flag != NULL)
                     *flag = true;
 
+                /* Open alternate screen buffer */
+                if (argv[0] == GUAC_TERMINAL_ALT_BUFFER)
+                    guac_terminal_switch_buffers(term, true);
+
                 break;
 
             /* l: Reset Mode */
@@ -894,6 +903,10 @@ int guac_terminal_csi(guac_terminal* term, unsigned char c) {
                 flag = __guac_terminal_get_flag(term, argv[0], private_mode_character);
                 if (flag != NULL)
                     *flag = false;
+                
+                /* Close alternate screen buffer */
+                if (argv[0] == GUAC_TERMINAL_ALT_BUFFER)
+                    guac_terminal_switch_buffers(term, false);
 
                 break;
 

--- a/src/terminal/terminal/terminal-priv.h
+++ b/src/terminal/terminal/terminal-priv.h
@@ -244,6 +244,11 @@ struct guac_terminal {
     int cursor_row;
 
     /**
+     * Backup of cursor_row when using alternate buffer.
+     */
+    int cursor_row_alt;
+
+    /**
      * The current column location of the cursor. Note that while most
      * terminal operations will clip the cursor location within the bounds
      * of the terminal, this is not guaranteed. There are times when the
@@ -251,6 +256,11 @@ struct guac_terminal {
      * end of a line is reached, but it is not yet necessary to scroll up).
      */
     int cursor_col;
+
+    /**
+     * Backup of cursor_col when using alternate buffer.
+     */
+    int cursor_col_alt;
 
     /**
      * The desired visibility state of the cursor.
@@ -264,10 +274,20 @@ struct guac_terminal {
     int visible_cursor_row;
 
     /**
+     * Backup of visible_cursor_row when using alternate buffer.
+     */
+    int visible_cursor_row_alt;
+
+    /**
      * The column of the rendered cursor.
      * Will be set to -1 if the cursor is not visible.
      */
     int visible_cursor_col;
+
+    /**
+     * Backup of visible_cursor_col when using alternate buffer.
+     */
+    int visible_cursor_col_alt;
 
     /**
      * The row of the saved cursor (ESC 7).
@@ -310,6 +330,18 @@ struct guac_terminal {
      * facilitates transfer of a set of changes to the remote display.
      */
     guac_terminal_buffer* buffer;
+
+    /**
+     * Alternate buffer.
+     */
+    guac_terminal_buffer* buffer_alt;
+
+    /**
+     * Actual state of the buffer:
+     *  - true if switched to alternate buffer.
+     *  - false if normal buffer.
+     */
+    bool buffer_switched;
 
     /**
      * Automatically place a tabstop every N characters. If zero, then no
@@ -665,6 +697,19 @@ void guac_terminal_copy_rows(guac_terminal* terminal,
  * Flushes all pending operations within the given guac_terminal.
  */
 void guac_terminal_flush(guac_terminal* terminal);
+
+/**
+ * Swith betwen normal and alternate buffer.
+ *
+ * @param terminal
+ *      Terminal on which we switch buffers.
+ *
+ * @param to_alt
+ *      Direction of buffer inversion.
+ *      True if normal to alternate buffer.
+ *      False if alternate to normal buffer.
+ */
+void guac_terminal_switch_buffers(guac_terminal* terminal, bool to_alt);
 
 #endif
 


### PR DESCRIPTION
Add support of alternate screen buffer for tools like less/vi/man/...

Before:
![image](https://github.com/corentin-soriano/guacamole-server/assets/107032768/18dc1af1-424e-410e-8782-18f61edb7d97)

After:
![image](https://github.com/corentin-soriano/guacamole-server/assets/107032768/c7453113-2f03-4ec8-bf27-4481fd67d0f9)
![image](https://github.com/corentin-soriano/guacamole-server/assets/107032768/e23d5b26-441d-42fb-8c4d-02795f4e4760)
![image](https://github.com/corentin-soriano/guacamole-server/assets/107032768/87c9a3e1-23a5-46e7-b83f-cb1964608c30)
