### PR TITLE
GUACAMOLE-1944: display margin only affects the default layer and not scrollbar layer

### DIFF
--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -1881,10 +1881,6 @@ static void guac_terminal_double_click(guac_terminal* terminal, int row, int col
 static int __guac_terminal_send_mouse(guac_terminal* term, guac_user* user,
         int x, int y, int mask) {
 
-    /* Remove display margin from mouse position without going below 0 */
-    y = y >= term->display->margin ? y - term->display->margin : 0;
-    x = x >= term->display->margin ? x - term->display->margin : 0;
-
     /* Ignore user input if terminal is not started */
     if (!term->started) {
         guac_client_log(term->client, GUAC_LOG_DEBUG, "Ignoring user input "
@@ -1913,6 +1909,10 @@ static int __guac_terminal_send_mouse(guac_terminal* term, guac_user* user,
         return 0;
 
     }
+
+    /* Remove display margin from mouse position without going below 0 */
+    y = y >= term->display->margin ? y - term->display->margin : 0;
+    x = x >= term->display->margin ? x - term->display->margin : 0;
 
     term->mouse_mask = mask;
 


### PR DESCRIPTION
The display margin is only present on the default layer.

Little mistake in https://github.com/apache/guacamole-server/pull/509: the scrollbar layer has no margin and should therefore not receive the negative offset.

In red the effective margin:
![image](https://github.com/apache/guacamole-server/assets/107032768/447c547d-bb51-457b-8780-7937a6611402)
