### PR TITLE
GUACAMOLE-1632: Fill null chars before last printable char with spaces

### DIFF
--- a/src/terminal/select.c
+++ b/src/terminal/select.c
@@ -283,6 +283,7 @@ static void guac_terminal_clipboard_append_row(guac_terminal* terminal,
 
     char buffer[1024];
     int i = start;
+    int eol;
 
     guac_terminal_buffer_row* buffer_row =
         guac_terminal_buffer_get_row(terminal->buffer, row, 0);
@@ -296,6 +297,14 @@ static void guac_terminal_clipboard_append_row(guac_terminal* terminal,
     if (end < 0 || end > buffer_row->length - 1)
         end = buffer_row->length - 1;
 
+    /* Get position of last not null char */
+    for (eol = buffer_row->length; eol > start; eol--) {
+
+        if (buffer_row->characters[eol].value != 0)
+            break;
+
+    }
+
     /* Repeatedly convert chunks of terminal buffer rows until entire specified
      * region has been appended to clipboard */
     while (i <= end) {
@@ -307,6 +316,10 @@ static void guac_terminal_clipboard_append_row(guac_terminal* terminal,
         for (i = start; i <= end; i++) {
 
             int codepoint = buffer_row->characters[i].value;
+
+            /* Fill empty with spaces if not at end of line */
+            if (codepoint == 0 && i < eol)
+                codepoint = GUAC_CHAR_SPACE;
 
             /* Ignore null (blank) characters */
             if (codepoint == 0 || codepoint == GUAC_CHAR_CONTINUATION)

--- a/src/terminal/terminal/types.h
+++ b/src/terminal/terminal/types.h
@@ -42,6 +42,11 @@
 #define GUAC_CHAR_CONTINUATION -1
 
 /**
+ * The ASCII code of space.
+ */
+#define GUAC_CHAR_SPACE 32
+
+/**
  * Terminal attributes, as can be applied to a single character.
  */
 typedef struct guac_terminal_attributes {


### PR DESCRIPTION
This selection :
![image](https://github.com/apache/guacamole-server/assets/107032768/2ec9c70f-5219-4794-be19-2842a18bbb84)

Clipboard content before this code:
```c
/* Pass through start/end coordinates if they are already in the expected
     * order, adjusting only for final character width */
    if (terminal->selection_start_row < terminal->selection_end_row
|| (terminal->selection_start_row == terminal->selection_end_row
&& terminal->selection_start_column < terminal->selection_end_column)) {

*start_row = terminal->selection_start_row;
*start_col = terminal->selection_start_column;
*end_row   = terminal->selection_end_row;
*end_col   = terminal->selection_end_column + terminal->selection_end_width - 1;

}
```

And now:
```c
    /* Pass through start/end coordinates if they are already in the expected
     * order, adjusting only for final character width */
    if (terminal->selection_start_row < terminal->selection_end_row
        || (terminal->selection_start_row == terminal->selection_end_row
            && terminal->selection_start_column < terminal->selection_end_column)) {

        *start_row = terminal->selection_start_row;
        *start_col = terminal->selection_start_column;
        *end_row   = terminal->selection_end_row;
        *end_col   = terminal->selection_end_column + terminal->selection_end_width - 1;

    }
```