### PR TITLE
GUACAMOLE-1256: Correct terminal scroll with text editors.

### DIFF
--- a/src/terminal/terminal-handlers.c
+++ b/src/terminal/terminal-handlers.c
@@ -835,6 +835,32 @@ int guac_terminal_csi(guac_terminal* term, unsigned char c) {
 
                 break;
 
+            /* S: Scroll Up by amount */
+            case 'S':
+
+                /* Get move amount */
+                amount = argv[0];
+                if (amount == 0) amount = 1;
+
+                /* Scroll up */
+                guac_terminal_scroll_up(term, term->scroll_start,
+                        term->scroll_end, amount);
+
+                break;
+
+            /* T: Scroll Down by amount */
+            case 'T':
+
+                /* Get move amount */
+                amount = argv[0];
+                if (amount == 0) amount = 1;
+
+                /* Scroll Down */
+                guac_terminal_scroll_down(term, term->scroll_start,
+                        term->scroll_end, amount);
+
+                break;
+
             /* X: Erase characters (no scroll) */
             case 'X':
 

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -924,6 +924,10 @@ int guac_terminal_scroll_up(guac_terminal* term,
             end_row - amount + 1, 0,
             end_row, term->term_width - 1);
 
+    /* Flush display copy before the cursor commit override operation
+     * type for visible cursor row and breaks display. */
+    guac_terminal_display_flush(term->display);
+
     return 0;
 }
 
@@ -936,6 +940,10 @@ int guac_terminal_scroll_down(guac_terminal* term,
     guac_terminal_clear_range(term,
             start_row, 0,
             start_row + amount - 1, term->term_width - 1);
+
+    /* Flush display copy before the cursor commit override operation
+     * type for visible cursor row and breaks display. */
+    guac_terminal_display_flush(term->display);
 
     return 0;
 }


### PR DESCRIPTION
- Add support of 'S' and 'T' CSI sequences (scroll up/down by amount).
- Force display flush when scrolling to avoid conflict when cursor_commit use the set_collumns function which change the operation_type.