### PR TITLE
GUACAMOLE-1632: Don't fill empty lines with spaces.

### DIFF
--- a/src/terminal/select.c
+++ b/src/terminal/select.c
@@ -298,7 +298,7 @@ static void guac_terminal_clipboard_append_row(guac_terminal* terminal,
         end = buffer_row->length - 1;
 
     /* Get position of last not null char */
-    for (eol = buffer_row->length; eol > start; eol--) {
+    for (eol = buffer_row->length - 1; eol > start; eol--) {
 
         if (buffer_row->characters[eol].value != 0)
             break;


### PR DESCRIPTION
Little issue in #523: the last buffer column is buffer_row->length - 1 and not buffer_row->length.
We can sometimes find other values than 0 in this column which is not part of the buffer content and this implies that the row is entirely filled with spaces in the clipboard.
Example:
![image](https://github.com/apache/guacamole-server/assets/107032768/4b81b7e9-ea27-4da6-b981-a82153640ed0)
