### PR TITLE
GUACAMOLE-1969: Implement recording-include-clipboard connection parameter

### DIFF
--- a/src/libguac/guacamole/recording.h
+++ b/src/libguac/guacamole/recording.h
@@ -95,6 +95,15 @@ typedef struct guac_recording {
      */
     int include_keys;
 
+    /**
+     * Non-zero if clipboard paste data should be included in the session
+     * recording, zero otherwise. Including clipboard data within the recording may
+     * be necessary in certain auditing contexts, but should only be done with
+     * caution. Clipboard can easily contain sensitive information, such as
+     * passwords, credit card numbers, etc.
+     */
+    int include_clipboard;
+
 } guac_recording;
 
 /**
@@ -152,6 +161,13 @@ typedef struct guac_recording {
  *     Non-zero if writing to an existing file should be allowed, or zero
  *     otherwise.
  *
+ * @param include_clipboard
+ *     Non-zero if clipboard paste data should be included in the session
+ *     recording, zero otherwise. Including clipboard data within the recording may
+ *     be necessary in certain auditing contexts, but should only be done with
+ *     caution. Clipboard can easily contain sensitive information, such as
+ *     passwords, credit card numbers, etc.
+ *
  * @return
  *     A new guac_recording structure representing the in-progress
  *     recording if the recording file has been successfully created and a
@@ -160,7 +176,7 @@ typedef struct guac_recording {
 guac_recording* guac_recording_create(guac_client* client,
         const char* path, const char* name, int create_path,
         int include_output, int include_mouse, int include_touch,
-        int include_keys, int allow_write_existing);
+        int include_keys, int allow_write_existing, int include_clipboard);
 
 /**
  * Frees the resources associated with the given in-progress recording. Note
@@ -255,6 +271,53 @@ void guac_recording_report_touch(guac_recording* recording,
  */
 void guac_recording_report_key(guac_recording* recording,
         int keysym, int pressed);
+
+/**
+ * Reports a clipboard paste instruction within the recording.
+ * The full structure consists of clipboard instruction, one or more
+ * blob instructions and end instruction.
+ *
+ * @param recording
+ *     The guac_recording associated with the clipboard instruction.
+ *
+ * @param stream
+ *     The guac_stream allocated for the clipboard paste instruction.
+ *
+ * @param mimetype
+ *     The clipboard data mimetype
+ */
+void guac_recording_report_clipboard(guac_recording* recording,
+        guac_stream* stream, char* mimetype);
+
+/**
+ * Report a clipboard paste blob within the recording.
+ *
+ * @param recording
+ *     The guac_recording associated with the clipboard instruction.
+ *
+ * @param stream
+ *     The guac_stream associated with the clipboard instruction.
+ *
+ * @param data
+ *     The clipboard blob data.
+ *
+ * @param length
+ *     Length of the blob data.
+ */
+void guac_recording_report_clipboard_blob(guac_recording* recording,
+        guac_stream* stream, void* data, int length);
+
+/**
+ * Report a clipboard paste end instruction within the recording.
+ *
+ * @param recording
+ *     The guac_recording associated with the clipboard instruction.
+ *
+ * @param stream
+ *     The guac_stream associated with the clipboard instruction.
+ */
+void guac_recording_report_clipboard_end(guac_recording* recording,
+        guac_stream* stream);
 
 #endif
 

--- a/src/libguac/recording.c
+++ b/src/libguac/recording.c
@@ -42,7 +42,7 @@
 guac_recording* guac_recording_create(guac_client* client,
         const char* path, const char* name, int create_path,
         int include_output, int include_mouse, int include_touch,
-        int include_keys, int allow_write_existing) {
+        int include_keys, int allow_write_existing, int include_clipboard) {
 
     char filename[GUAC_COMMON_RECORDING_MAX_NAME_LENGTH];
 
@@ -76,6 +76,7 @@ guac_recording* guac_recording_create(guac_client* client,
     recording->include_mouse = include_mouse;
     recording->include_touch = include_touch;
     recording->include_keys = include_keys;
+    recording->include_clipboard = include_clipboard;
 
     /* Replace client socket with wrapped recording socket only if including
      * output within the recording */
@@ -133,3 +134,20 @@ void guac_recording_report_key(guac_recording* recording,
 
 }
 
+void guac_recording_report_clipboard(guac_recording* recording, guac_stream* stream, char* mimetype) {
+    /* Report clipboard only if recording should contain it */
+    if (recording->include_clipboard)
+        guac_protocol_send_clipboard(recording->socket, stream, mimetype);
+}
+
+void guac_recording_report_clipboard_blob(guac_recording* recording, guac_stream* stream, void* data, int length) {
+    /* Report clipboard only if recording should contain it */
+    if (recording->include_clipboard)
+        guac_protocol_send_blob(recording->socket, stream, data, length);
+}
+
+void guac_recording_report_clipboard_end(guac_recording* recording, guac_stream* stream) {
+    /* Report clipboard only if recording should contain it */
+    if (recording->include_clipboard)
+        guac_protocol_send_end(recording->socket, stream);
+}

--- a/src/protocols/kubernetes/clipboard.c
+++ b/src/protocols/kubernetes/clipboard.c
@@ -39,6 +39,10 @@ int guac_kubernetes_clipboard_handler(guac_user* user, guac_stream* stream,
     stream->blob_handler = guac_kubernetes_clipboard_blob_handler;
     stream->end_handler = guac_kubernetes_clipboard_end_handler;
 
+    /* Report clipboard within recording */
+    if (kubernetes_client->recording != NULL)
+        guac_recording_report_clipboard(kubernetes_client->recording, stream, mimetype);
+
     return 0;
 }
 
@@ -49,6 +53,10 @@ int guac_kubernetes_clipboard_blob_handler(guac_user* user,
     guac_kubernetes_client* kubernetes_client =
         (guac_kubernetes_client*) client->data;
 
+    /* Report clipboard blob within recording */
+    if (kubernetes_client->recording != NULL)
+        guac_recording_report_clipboard_blob(kubernetes_client->recording, stream, data, length);
+
     /* Append new data */
     guac_terminal_clipboard_append(kubernetes_client->term, data, length);
 
@@ -57,6 +65,14 @@ int guac_kubernetes_clipboard_blob_handler(guac_user* user,
 
 int guac_kubernetes_clipboard_end_handler(guac_user* user,
         guac_stream* stream) {
+
+    guac_client* client = user->client;
+    guac_kubernetes_client* kubernetes_client =
+        (guac_kubernetes_client*) client->data;
+
+    /* Report clipboard blob within recording */
+    if (kubernetes_client->recording != NULL)
+        guac_recording_report_clipboard_end(kubernetes_client->recording, stream);
 
     /* Nothing to do - clipboard is implemented within client */
 

--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -238,7 +238,8 @@ void* guac_kubernetes_client_thread(void* data) {
                 !settings->recording_exclude_mouse,
                 0, /* Touch events not supported */
                 settings->recording_include_keys,
-                settings->recording_write_existing);
+                settings->recording_write_existing,
+                settings->recording_include_clipboard);
     }
 
     /* Create terminal options with required parameters */

--- a/src/protocols/kubernetes/settings.c
+++ b/src/protocols/kubernetes/settings.c
@@ -51,6 +51,7 @@ const char* GUAC_KUBERNETES_CLIENT_ARGS[] = {
     "recording-exclude-output",
     "recording-exclude-mouse",
     "recording-include-keys",
+    "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
     "read-only",
@@ -212,6 +213,16 @@ enum KUBERNETES_ARGS_IDX {
      * as passwords, credit card numbers, etc.
      */
     IDX_RECORDING_INCLUDE_KEYS,
+
+    /**
+     * Whether clipboard paste data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_CLIPBOARD,
 
     /**
      * Whether the specified screen recording path should automatically be
@@ -408,6 +419,11 @@ guac_kubernetes_settings* guac_kubernetes_parse_args(guac_user* user,
     settings->recording_include_keys =
         guac_user_parse_args_boolean(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
                 IDX_RECORDING_INCLUDE_KEYS, false);
+
+    /* Parse clipboard inclusion flag */
+    settings->recording_include_clipboard =
+        guac_user_parse_args_boolean(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_CLIPBOARD, false);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/kubernetes/settings.h
+++ b/src/protocols/kubernetes/settings.h
@@ -246,6 +246,16 @@ typedef struct guac_kubernetes_settings {
     bool recording_include_keys;
 
     /**
+     * Whether clipboard paste data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    bool recording_include_clipboard;
+
+    /**
      * Whether existing files should be appended to when creating a new recording.
      * Disabled by default.
      */

--- a/src/protocols/rdp/channels/cliprdr.c
+++ b/src/protocols/rdp/channels/cliprdr.c
@@ -695,6 +695,11 @@ int guac_rdp_clipboard_handler(guac_user* user, guac_stream* stream,
     /* Clear any current contents, assigning the mimetype the data which will
      * be received */
     guac_common_clipboard_reset(clipboard->clipboard, mimetype);
+
+    /* Report clipboard within recording */
+    if (rdp_client->recording != NULL)
+        guac_recording_report_clipboard(rdp_client->recording, stream, mimetype);
+
     return 0;
 
 }
@@ -710,6 +715,10 @@ int guac_rdp_clipboard_blob_handler(guac_user* user, guac_stream* stream,
     guac_rdp_clipboard* clipboard = rdp_client->clipboard;
     if (clipboard == NULL)
         return 0;
+
+    /* Report clipboard blob within recording */
+    if (rdp_client->recording != NULL)
+        guac_recording_report_clipboard_blob(rdp_client->recording, stream, data, length);
 
     /* Append received data to current clipboard contents */
     guac_common_clipboard_append(clipboard->clipboard, (char*) data, length);
@@ -727,6 +736,10 @@ int guac_rdp_clipboard_end_handler(guac_user* user, guac_stream* stream) {
     guac_rdp_clipboard* clipboard = rdp_client->clipboard;
     if (clipboard == NULL)
         return 0;
+
+    /* Report clipboard stream end within recording */
+    if (rdp_client->recording != NULL)
+        guac_recording_report_clipboard_end(rdp_client->recording, stream);
 
     /* Terminate clipboard data with NULL */
     guac_common_clipboard_append(clipboard->clipboard, "", 1);

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -930,7 +930,8 @@ void* guac_rdp_client_thread(void* data) {
                 !settings->recording_exclude_mouse,
                 !settings->recording_exclude_touch,
                 settings->recording_include_keys,
-                settings->recording_write_existing);
+                settings->recording_write_existing,
+                settings->recording_include_clipboard);
     }
 
     /* Continue handling connections until error or client disconnect */

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -125,6 +125,7 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
     "recording-exclude-mouse",
     "recording-exclude-touch",
     "recording-include-keys",
+    "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
     "resize-method",
@@ -580,6 +581,16 @@ enum RDP_ARGS_IDX {
      * as passwords, credit card numbers, etc.
      */
     IDX_RECORDING_INCLUDE_KEYS,
+
+    /**
+     * Whether clipboard paste data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_CLIPBOARD,
 
     /**
      * Whether the specified screen recording path should automatically be
@@ -1204,6 +1215,11 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     settings->recording_include_keys =
         guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
                 IDX_RECORDING_INCLUDE_KEYS, 0);
+
+    /* Parse clipboard inclusion flag */
+    settings->recording_include_clipboard =
+        guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_CLIPBOARD, false);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/rdp/settings.h
+++ b/src/protocols/rdp/settings.h
@@ -591,6 +591,16 @@ typedef struct guac_rdp_settings {
     int recording_include_keys;
 
     /**
+     * Whether clipboard paste data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    bool recording_include_clipboard;
+
+    /**
      * Non-zero if existing files should be appended to when creating a new 
      * recording. Disabled by default.
      */

--- a/src/protocols/ssh/clipboard.c
+++ b/src/protocols/ssh/clipboard.c
@@ -38,21 +38,36 @@ int guac_ssh_clipboard_handler(guac_user* user, guac_stream* stream,
     stream->blob_handler = guac_ssh_clipboard_blob_handler;
     stream->end_handler = guac_ssh_clipboard_end_handler;
 
+    /* Report clipboard within recording */
+    if (ssh_client->recording != NULL)
+        guac_recording_report_clipboard(ssh_client->recording, stream, mimetype);
+
     return 0;
 }
 
 int guac_ssh_clipboard_blob_handler(guac_user* user, guac_stream* stream,
         void* data, int length) {
-
-    /* Append new data */
     guac_client* client = user->client;
     guac_ssh_client* ssh_client = (guac_ssh_client*) client->data;
+
+    /* Report clipboard blob within recording */
+    if (ssh_client->recording != NULL)
+        guac_recording_report_clipboard_blob(ssh_client->recording, stream, data, length);
+
+    /* Append new data */
     guac_terminal_clipboard_append(ssh_client->term, data, length);
 
     return 0;
 }
 
 int guac_ssh_clipboard_end_handler(guac_user* user, guac_stream* stream) {
+
+    guac_client* client = user->client;
+    guac_ssh_client* ssh_client = (guac_ssh_client*) client->data;
+
+    /* Report clipboard stream end within recording */
+    if (ssh_client->recording != NULL)
+        guac_recording_report_clipboard_end(ssh_client->recording, stream);
 
     /* Nothing to do - clipboard is implemented within client */
 

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -65,6 +65,7 @@ const char* GUAC_SSH_CLIENT_ARGS[] = {
     "recording-exclude-output",
     "recording-exclude-mouse",
     "recording-include-keys",
+    "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
     "read-only",
@@ -250,6 +251,16 @@ enum SSH_ARGS_IDX {
      * as passwords, credit card numbers, etc.
      */
     IDX_RECORDING_INCLUDE_KEYS,
+
+    /**
+     * Whether clipboard paste data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_CLIPBOARD,
 
     /**
      * Whether the specified screen recording path should automatically be
@@ -526,6 +537,11 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
     settings->recording_include_keys =
         guac_user_parse_args_boolean(user, GUAC_SSH_CLIENT_ARGS, argv,
                 IDX_RECORDING_INCLUDE_KEYS, false);
+
+    /* Parse clipboard inclusion flag */
+    settings->recording_include_clipboard =
+        guac_user_parse_args_boolean(user, GUAC_SSH_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_CLIPBOARD, false);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -275,6 +275,16 @@ typedef struct guac_ssh_settings {
     bool recording_include_keys;
 
     /**
+     * Whether clipboard paste data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    bool recording_include_clipboard;
+
+    /**
      * Whether existing files should be appended to when creating a new recording.
      * Disabled by default.
      */

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -286,7 +286,8 @@ void* ssh_client_thread(void* data) {
                 !settings->recording_exclude_mouse,
                 0, /* Touch events not supported */
                 settings->recording_include_keys,
-                settings->recording_write_existing);
+                settings->recording_write_existing,
+                settings->recording_include_clipboard);
     }
 
     /* Create terminal options with required parameters */

--- a/src/protocols/telnet/clipboard.c
+++ b/src/protocols/telnet/clipboard.c
@@ -38,21 +38,37 @@ int guac_telnet_clipboard_handler(guac_user* user, guac_stream* stream,
     stream->blob_handler = guac_telnet_clipboard_blob_handler;
     stream->end_handler = guac_telnet_clipboard_end_handler;
 
+    /* Report clipboard within recording */
+    if (telnet_client->recording != NULL)
+        guac_recording_report_clipboard(telnet_client->recording, stream, mimetype);
+
     return 0;
 }
 
 int guac_telnet_clipboard_blob_handler(guac_user* user, guac_stream* stream,
         void* data, int length) {
 
-    /* Append new data */
     guac_client* client = user->client;
     guac_telnet_client* telnet_client = (guac_telnet_client*) client->data;
+
+    /* Report clipboard blob within recording */
+    if (telnet_client->recording != NULL)
+        guac_recording_report_clipboard_blob(telnet_client->recording, stream, data, length);
+
+    /* Append new data */
     guac_terminal_clipboard_append(telnet_client->term, data, length);
 
     return 0;
 }
 
 int guac_telnet_clipboard_end_handler(guac_user* user, guac_stream* stream) {
+
+    guac_client* client = user->client;
+    guac_telnet_client* telnet_client = (guac_telnet_client*) client->data;
+
+    /* Report clipboard stream end within recording */
+    if (telnet_client->recording != NULL)
+        guac_recording_report_clipboard_end(telnet_client->recording, stream);
 
     /* Nothing to do - clipboard is implemented within client */
 

--- a/src/protocols/telnet/settings.c
+++ b/src/protocols/telnet/settings.c
@@ -56,6 +56,7 @@ const char* GUAC_TELNET_CLIENT_ARGS[] = {
     "recording-exclude-output",
     "recording-exclude-mouse",
     "recording-include-keys",
+    "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
     "read-only",
@@ -196,6 +197,16 @@ enum TELNET_ARGS_IDX {
      * as passwords, credit card numbers, etc.
      */
     IDX_RECORDING_INCLUDE_KEYS,
+
+    /**
+     * Whether clipboard paste data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_CLIPBOARD,
 
     /**
      * Whether the specified screen recording path should automatically be
@@ -506,6 +517,11 @@ guac_telnet_settings* guac_telnet_parse_args(guac_user* user,
     settings->recording_include_keys =
         guac_user_parse_args_boolean(user, GUAC_TELNET_CLIENT_ARGS, argv,
                 IDX_RECORDING_INCLUDE_KEYS, false);
+
+    /* Parse clipboard inclusion flag */
+    settings->recording_include_clipboard =
+        guac_user_parse_args_boolean(user, GUAC_TELNET_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_CLIPBOARD, false);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/telnet/settings.h
+++ b/src/protocols/telnet/settings.h
@@ -251,6 +251,16 @@ typedef struct guac_telnet_settings {
     bool recording_include_keys;
 
     /**
+     * Whether clipboard paste data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    bool recording_include_clipboard;
+
+    /**
      * Whether existing files should be appended to when creating a new recording.
      * Disabled by default.
      */

--- a/src/protocols/telnet/telnet.c
+++ b/src/protocols/telnet/telnet.c
@@ -537,7 +537,8 @@ void* guac_telnet_client_thread(void* data) {
                 !settings->recording_exclude_mouse,
                 0, /* Touch events not supported */
                 settings->recording_include_keys,
-                settings->recording_write_existing);
+                settings->recording_write_existing,
+                settings->recording_include_clipboard);
     }
 
     /* Create terminal options with required parameters */

--- a/src/protocols/vnc/clipboard.c
+++ b/src/protocols/vnc/clipboard.c
@@ -92,6 +92,10 @@ int guac_vnc_clipboard_handler(guac_user* user, guac_stream* stream,
     stream->blob_handler = guac_vnc_clipboard_blob_handler;
     stream->end_handler = guac_vnc_clipboard_end_handler;
 
+    /* Report clipboard within recording */
+    if (vnc_client->recording != NULL)
+        guac_recording_report_clipboard(vnc_client->recording, stream, mimetype);
+
     return 0;
 }
 
@@ -105,6 +109,12 @@ int guac_vnc_clipboard_blob_handler(guac_user* user, guac_stream* stream,
     guac_common_clipboard* clipboard = vnc_client->clipboard;
     if (clipboard == NULL)
         return 0;
+
+    guac_vnc_client* vnc_client = (guac_vnc_client*) user->client->data;
+
+    /* Report clipboard blob within recording */
+    if (vnc_client->recording != NULL)
+        guac_recording_report_clipboard_blob(vnc_client->recording, stream, data, length);
 
     /* Append new data */
     guac_common_clipboard_append(clipboard, (char*) data, length);
@@ -130,6 +140,10 @@ int guac_vnc_clipboard_end_handler(guac_user* user, guac_stream* stream) {
     const char* input = clipboard->buffer;
     char* output = output_data;
     guac_iconv_write* writer = vnc_client->clipboard_writer;
+
+    /* Report clipboard stream end within recording */
+    if (vnc_client->recording != NULL)
+        guac_recording_report_clipboard_end(vnc_client->recording, stream);
 
     /* Convert clipboard contents */
     guac_iconv(GUAC_READ_UTF8, &input, clipboard->length,

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -87,6 +87,7 @@ const char* GUAC_VNC_CLIENT_ARGS[] = {
     "recording-exclude-output",
     "recording-exclude-mouse",
     "recording-include-keys",
+    "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
     "clipboard-buffer-size",
@@ -352,6 +353,16 @@ enum VNC_ARGS_IDX {
      * as passwords, credit card numbers, etc.
      */
     IDX_RECORDING_INCLUDE_KEYS,
+
+    /**
+     * Whether clipboard paste data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_CLIPBOARD,
 
     /**
      * Whether the specified screen recording path should automatically be
@@ -675,6 +686,11 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
     settings->recording_include_keys =
         guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_RECORDING_INCLUDE_KEYS, false);
+
+    /* Parse clipboard inclusion flag */
+    settings->recording_include_clipboard =
+        guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_CLIPBOARD, false);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -313,6 +313,16 @@ typedef struct guac_vnc_settings {
     bool recording_include_keys;
 
     /**
+     * Whether clipboard paste data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    bool recording_include_clipboard;
+
+    /**
      * Whether existing files should be appended to when creating a new recording.
      * Disabled by default.
      */

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -587,7 +587,8 @@ void* guac_vnc_client_thread(void* data) {
                 !settings->recording_exclude_mouse,
                 0, /* Touch events not supported */
                 settings->recording_include_keys,
-                settings->recording_write_existing);
+                settings->recording_write_existing,
+                settings->recording_include_clipboard);
     }
 
     /* Create display */


### PR DESCRIPTION
This PR introduces new `recording-include-clipboard` into all supported protocols that dumps the `clipboard` instruction, along with the relevant stream blobs, into recording.

Few key notes:
- because clipboard can contain sensitive data, it's opt-in in the same way as `recording-include-keys` and administrators need to explicitly set the parameter to `true`
- as the recording components are responsible for handling the recording dumps, `guac_recording_create` includes the new parameter (i've opted for making it the last argument, but let me know if I should switch it to be next to the `include_keys`)
- the keyboard dumps are hooked into user clipboard handler, so should only handle changes from user side and not from the server side
- as clipboard instruction merely creates stream, even the simplest paste is essentially at least 3 instructions (clipboard, 1+ blobs, end), which can be seen like this in some testing recording
```
$ sed 's/;/\n/g' recording-clipboard | grep clipboard -A 2
9.clipboard,1.0,10.text/plain
4.blob,1.0,20.UHVsbCBjb21wbGV0ZQ==
3.end,1.0
```



Once this PR is approved from technical perspective, I will create respective PRs for guacamole-client and guacamole-manual to accomodate for both documentation change as well the client side option