### PR TITLE
GUACAMOLE-1971: Safely multiply values to be used for memory allocation.

### DIFF
--- a/src/protocols/rdp/pointer.c
+++ b/src/protocols/rdp/pointer.c
@@ -30,6 +30,7 @@
 #include <freerdp/freerdp.h>
 #include <freerdp/gdi/gdi.h>
 #include <guacamole/client.h>
+#include <guacamole/mem.h>
 #include <winpr/crt.h>
 
 BOOL guac_rdp_pointer_new(rdpContext* context, rdpPointer* pointer) {
@@ -42,7 +43,8 @@ BOOL guac_rdp_pointer_new(rdpContext* context, rdpPointer* pointer) {
             rdp_client->display, pointer->width, pointer->height);
 
     /* Allocate data for image */
-    unsigned char* data = GUAC_ALIGNED_MALLOC(pointer->width * pointer->height * 4, 16);
+    unsigned char* data = GUAC_ALIGNED_MALLOC(guac_mem_ckd_mul_or_die(pointer->width, 
+            pointer->height, 4), 16);
 
     cairo_surface_t* surface;
 


### PR DESCRIPTION
CodeQL has flagged a potential integer overflow so I used `guac_mem_ckd_mul_or_die()` to safely multiple the values.