### PR TITLE
GUACAMOLE-1196: Correct checks for RFB resize message support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -658,7 +658,7 @@ if test "x${have_libvncserver}" = "xyes"
 then
 
     have_vnc_size_msg=yes
-    AC_CHECK_DECL([rfbSetDesktopSizeMsg],
+    AC_CHECK_TYPE([rfbSetDesktopSizeMsg],
                      [], [have_vnc_size_msg=no],
                      [[#include <rfb/rfbproto.h>]])
 

--- a/src/protocols/vnc/display.c
+++ b/src/protocols/vnc/display.c
@@ -284,15 +284,9 @@ void* guac_vnc_display_set_owner_size(guac_user* owner, void* data) {
     rfbClient* rfb_client = (rfbClient*) data;
 
     guac_user_log(owner, GUAC_LOG_DEBUG, "Sending VNC display size for owner's display.");
-    
-#ifdef LIBVNC_CLIENT_HAS_SIZE_MSG
-    guac_user_log(owner, GUAC_LOG_DEBUG, "Sending VNC display size for owner's display.");
 
     /* Set the display size. */
     guac_vnc_display_set_size(rfb_client, owner->info.optimal_width, owner->info.optimal_height);
-#else
-    guac_user_log(owner, GUAC_LOG_WARNING, "VNC client lacks support for sending display size.");
-#endif // LIBVNC_CLIENT_HAS_SIZE_MSG
 
     /* Always return NULL. */
     return NULL;


### PR DESCRIPTION
Correct a couple of my mistakes - first, I used the wrong check in `configure.ac` to test for the definition of the data type, and then I forgot to commit a change to `display.c` in the last pull request. This fixes both issues, and I've tested the compile on both Rocky 8 with libvnc < 0.9.13, and on Rocky 9 with a self-compiled libvnc from git.