### PR TITLE
GUACAMOLE-600: Refactor guac_socket_tcp_connect() to guac_tcp_connect(), as it does not involve guac_socket.

### DIFF
--- a/src/common-ssh/ssh.c
+++ b/src/common-ssh/ssh.c
@@ -24,8 +24,8 @@
 #include <guacamole/client.h>
 #include <guacamole/fips.h>
 #include <guacamole/mem.h>
-#include <guacamole/socket-tcp.h>
 #include <guacamole/string.h>
+#include <guacamole/tcp.h>
 #include <libssh2.h>
 
 #ifdef LIBSSH2_USES_GCRYPT
@@ -417,7 +417,7 @@ guac_common_ssh_session* guac_common_ssh_create_session(guac_client* client,
         int timeout, int keepalive, const char* host_key,
         guac_ssh_credential_handler* credential_handler) {
 
-    int fd = guac_socket_tcp_connect(hostname, port, timeout);
+    int fd = guac_tcp_connect(hostname, port, timeout);
     if (fd < 0) {
         guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
             "Failed to open TCP connection to %s on %s.", hostname, port);

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -70,11 +70,11 @@ libguacinc_HEADERS =                  \
     guacamole/socket-constants.h      \
     guacamole/socket.h                \
     guacamole/socket-fntypes.h        \
-    guacamole/socket-tcp.h            \
     guacamole/socket-types.h          \
     guacamole/stream.h                \
     guacamole/stream-types.h          \
     guacamole/string.h                \
+    guacamole/tcp.h                   \
     guacamole/timestamp.h             \
     guacamole/timestamp-types.h       \
     guacamole/unicode.h               \
@@ -129,9 +129,9 @@ libguac_la_SOURCES =   \
     socket-broadcast.c \
     socket-fd.c        \
     socket-nest.c      \
-    socket-tcp.c       \
     socket-tee.c       \
     string.c           \
+    tcp.c              \
     timestamp.c        \
     unicode.c          \
     user.c             \

--- a/src/libguac/guacamole/tcp.h
+++ b/src/libguac/guacamole/tcp.h
@@ -17,17 +17,25 @@
  * under the License.
  */
 
-#ifndef __GUAC_SOCKET_TCP_H
-#define __GUAC_SOCKET_TCP_H
+#ifndef GUAC_TCP_H
+#define GUAC_TCP_H
+
+/**
+ * Provides convenience functions for establishing low-level TCP connections.
+ *
+ * @file tcp.h
+ */
 
 #include "config.h"
 
 #include <stddef.h>
 
 /**
- * Given a hostname or IP address and port, attempt to connect to that
- * system, returning an open socket if the connection succeeds, or a negative
- * value if it fails. If it fails the errno variable will be set.
+ * Given a hostname or IP address and port, attempt to connect to that system,
+ * returning the file descriptor of an open socket if the connection succeeds,
+ * or a negative value if it fails. The returned file descriptor must
+ * eventually be freed with a call to close(). If this function fails,
+ * guac_error will be set appropriately.
  *
  * @param hostname
  *     The hostname or IP address to which to attempt connections.
@@ -42,6 +50,6 @@
  *     A valid socket if the connection succeeds, or a negative integer if it
  *     fails.
  */
-int guac_socket_tcp_connect(const char* hostname, const char* port, const int timeout);
+int guac_tcp_connect(const char* hostname, const char* port, const int timeout);
 
-#endif // __GUAC_SOCKET_TCP_H
+#endif // GUAC_TCP_H

--- a/src/libguac/tcp.c
+++ b/src/libguac/tcp.c
@@ -19,7 +19,7 @@
 
 #include "config.h"
 #include "guacamole/error.h"
-#include "guacamole/socket.h"
+#include "guacamole/tcp.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -27,8 +27,9 @@
 #include <netinet/in.h>
 #include <sys/select.h>
 #include <sys/socket.h>
+#include <unistd.h>
 
-int guac_socket_tcp_connect(const char* hostname, const char* port, const int timeout) {
+int guac_tcp_connect(const char* hostname, const char* port, const int timeout) {
 
     int retval;
 

--- a/src/libguac/wol.c
+++ b/src/libguac/wol.c
@@ -20,7 +20,7 @@
 #include "config.h"
 
 #include "guacamole/error.h"
-#include "guacamole/socket-tcp.h"
+#include "guacamole/tcp.h"
 #include "guacamole/timestamp.h"
 #include "guacamole/wol.h"
 
@@ -204,7 +204,7 @@ int guac_wol_wake_and_wait(const char* mac_addr, const char* broadcast_addr,
         const char* hostname, const char* port, const int timeout) {
 
     /* Attempt to connect, first. */
-    int sockfd = guac_socket_tcp_connect(hostname, port, timeout);
+    int sockfd = guac_tcp_connect(hostname, port, timeout);
 
     /* If connection succeeds, no need to wake the system. */
     if (sockfd > 0) {
@@ -225,7 +225,7 @@ int guac_wol_wake_and_wait(const char* mac_addr, const char* broadcast_addr,
     /* Try to connect on the specified TCP port and hostname or IP. */
     for (int i = 0; i < retries; i++) {
 
-        sockfd = guac_socket_tcp_connect(hostname, port, timeout);
+        sockfd = guac_tcp_connect(hostname, port, timeout);
 
         /* Connection succeeded - close socket and exit. */
         if (sockfd > 0) {

--- a/src/protocols/telnet/telnet.c
+++ b/src/protocols/telnet/telnet.c
@@ -27,7 +27,7 @@
 #include <guacamole/mem.h>
 #include <guacamole/protocol.h>
 #include <guacamole/recording.h>
-#include <guacamole/socket-tcp.h>
+#include <guacamole/tcp.h>
 #include <guacamole/timestamp.h>
 #include <guacamole/wol-constants.h>
 #include <guacamole/wol.h>
@@ -386,7 +386,7 @@ static telnet_t* __guac_telnet_create_session(guac_client* client) {
     guac_telnet_client* telnet_client = (guac_telnet_client*) client->data;
     guac_telnet_settings* settings = telnet_client->settings;
 
-    int fd = guac_socket_tcp_connect(settings->hostname, settings->port, settings->timeout);
+    int fd = guac_tcp_connect(settings->hostname, settings->port, settings->timeout);
 
     /* Open telnet session */
     telnet_t* telnet = telnet_init(__telnet_options, __guac_telnet_event_handler, 0, client);


### PR DESCRIPTION
This change slightly alters the `guac_socket_tcp_connect()` function and corresponding header such that:

* It does not reuse the `guac_socket_*` namespace (these functions don't involve `guac_socket`).
* The documentation notes that `guac_error` is used to communicate error details.
* The header file includes a `@file` comment (apparently necessary for Doxygen to include the docs at all).