### PR TITLE
GUACAMOLE-1981: Add configure argument for systemd user

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -230,6 +230,14 @@ AC_ARG_WITH(systemd_dir,
 AM_CONDITIONAL([ENABLE_SYSTEMD], [test "x${systemd_dir}" != "x"])
 AC_SUBST(systemd_dir)
 
+# Systemd user
+AC_ARG_WITH(systemd_user,
+            [AS_HELP_STRING([--with-systemd-user=<username>],
+                            [the user configured in the systemd unit to run guacd @<:@default=daemon@:>@])],
+            [systemd_user=$withval],
+            [systemd_user=daemon])
+AC_SUBST(systemd_user)
+
 # guacd config file
 AC_ARG_WITH(guacd_conf,
             [AS_HELP_STRING([--with-guacd-conf=<path>],
@@ -1484,6 +1492,7 @@ AM_COND_IF([ENABLE_INIT], [build_init="${init_dir}"], [build_init=no])
 #
 
 AM_COND_IF([ENABLE_SYSTEMD], [build_systemd="${systemd_dir}"], [build_systemd=no])
+AM_COND_IF([ENABLE_SYSTEMD], [build_systemd_user="${systemd_user}"], [build_systemd_user=no])
 
 #
 # FreeRDP plugins
@@ -1535,6 +1544,7 @@ $PACKAGE_NAME version $PACKAGE_VERSION
    FreeRDP plugins: ${build_rdp_plugins}
    Init scripts: ${build_init}
    Systemd units: ${build_systemd}
+   Systemd user: ${build_systemd_user}
 
 Type \"make\" to compile $PACKAGE_NAME.
 "

--- a/src/guacd/Makefile.am
+++ b/src/guacd/Makefile.am
@@ -87,9 +87,12 @@ endif
 # Systemd service
 if ENABLE_SYSTEMD
 systemddir = @systemd_dir@
+systemduser = @systemd_user@
 systemd_DATA = systemd/guacd.service
 
 systemd/guacd.service: systemd/guacd.service.in
-	sed -e 's,[@]sbindir[@],$(sbindir),g' < systemd/guacd.service.in > systemd/guacd.service
+	sed -e 's,[@]sbindir[@],$(sbindir),g' \
+	 -e 's,[@]systemduser[@],$(systemduser),g' \
+	 < systemd/guacd.service.in > systemd/guacd.service
 endif
 

--- a/src/guacd/systemd/guacd.service.in
+++ b/src/guacd/systemd/guacd.service.in
@@ -21,7 +21,7 @@ Documentation=man:guacd(8)
 After=network.target
 
 [Service]
-User=daemon
+User=@systemduser@
 ExecStart=@sbindir@/guacd -f
 Restart=on-abnormal
 


### PR DESCRIPTION
This adds an additional configure argument `--with-systemd-user`.

I've tried to follow the pattern of how other configure arguments and variables are defined. The indentation style for the changes in Makefile.am is taken from [an example in the Automake manual](https://www.gnu.org/software/automake/manual/html_node/Scripts.html), using an additional space character to indent a multi-line command.

Here are some examples which show the additional configure output:
```
$ ./configure --help | grep -A2 with-systemd-user
  --with-systemd-user=<username>
                          the user configured in the systemd unit to run guacd
                          [default=daemon]

$ 2>/dev/null ./configure | grep -B1 'Systemd user:'
   Systemd units: no
   Systemd user: no

$ 2>/dev/null ./configure --with-systemd-dir=/etc/systemd/system | grep -B1 'Systemd user:'
   Systemd units: /etc/systemd/system
   Systemd user: daemon

$ 2>/dev/null ./configure --with-systemd-dir=/etc/systemd/system --with-systemd-user=guacd | grep -B1 'Systemd user:'
   Systemd units: /etc/systemd/system
   Systemd user: guacd
```

