### PR TITLE
GUACAMOLE-1196: Fix VNC resizing behavior.

### DIFF
--- a/src/protocols/vnc/display.c
+++ b/src/protocols/vnc/display.c
@@ -189,12 +189,6 @@ static rfbBool guac_vnc_send_desktop_size(rfbClient* client, int width, int heig
             width, height);
 
 #ifdef LIBVNC_CLIENT_HAS_SCREEN
-    /* Don't send an update if the sreen appears to be uninitialized. */
-    if (client->screen.width == 0 || client->screen.height == 0) {
-        guac_client_log(gc, GUAC_LOG_ERROR, "Screen has not been initialized, cannot send resize.");
-        return FALSE;
-    }
-
     /* Don't send an update if the requested dimensions are identical to current dimensions. */
     if (client->screen.width == rfbClientSwap16IfLE(width) && client->screen.height == rfbClientSwap16IfLE(height)) {
         guac_client_log(gc, GUAC_LOG_WARNING, "Screen size has not changed, not sending update.");

--- a/src/protocols/vnc/vnc.h
+++ b/src/protocols/vnc/vnc.h
@@ -48,6 +48,12 @@
 #include <pthread.h>
 
 /**
+ * The ID of the RFB client screen. If multi-screen support is added, more than
+ * one ID will be needed as well.
+ */
+#define GUAC_VNC_SCREEN_ID 1
+
+/**
  * VNC-specific client data.
  */
 typedef struct guac_vnc_client {


### PR DESCRIPTION
VNC resizing was not working for me - I'm getting this message every time I attempt to resize the window, as well as on initial load:

`ERROR:	Screen has not been initialized, cannot send resize.`

I dug into it, and I found two problems:

1. The RFB client screen ID was never set, which caused any message from the server specifying a screen size to be ignored by the client.
2. The guacamole display was never resized after sending the resize request to the VNC server.

I've fixed these two issues, though I'm not sure if this is the cleanest way of doing it. 
@necouchman mind having a look? I know you're much more familliar with this code than me.