### PR TITLE
GUACAMOLE-1026: Use LoadChannels callback method to load plugins with FreeRDP3.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1141,6 +1141,30 @@ then
     [AC_MSG_RESULT([no])])
 fi
 
+if test "x${have_freerdp}" = "xyes"
+then
+    AC_MSG_CHECKING([whether freerdp instance supports LoadChannels])
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+        #include <freerdp/freerdp.h>
+
+        /* Mock LoadChannels function with the expected signature */
+        BOOL load_channels(freerdp* instance) {
+            return TRUE;
+        }
+
+        int main() {
+            freerdp* instance = freerdp_new();
+            instance->LoadChannels = load_channels;
+            freerdp_free(instance);
+            return 0;
+        }
+    ]])],
+    [AC_MSG_RESULT([yes])]
+    [AC_DEFINE([RDP_INST_HAS_LOAD_CHANNELS],,
+               [Defined if freerdp instance supports LoadChannels])],
+    [AC_MSG_RESULT([no])])
+fi
+
 # Restore CPPFLAGS, removing FreeRDP-specific options needed for testing
 CPPFLAGS="$OLDCPPFLAGS"
 


### PR DESCRIPTION
Plugins were not working properly when building Guacamole with FreeRDP3 due to a change in how they are loaded. This PR implements the LoadChannels callback function for loading plugins.

https://github.com/FreeRDP/FreeRDP/wiki/FreeRDP3-migration-notes
> Channel loading has been moved from PreConnect to LoadChannels. This has a default implementation in client/common and only step required is removing calls to freerdp_client_load_addins