### PR TITLE
GUACAMOLE-1196: Fix compile issues with older VNC client versions where screen isn't defined.

### DIFF
--- a/src/protocols/vnc/display.c
+++ b/src/protocols/vnc/display.c
@@ -51,11 +51,17 @@ void guac_vnc_update(rfbClient* client, int x, int y, int w, int h) {
     guac_client* gc = rfbClientGetClientData(client, GUAC_VNC_CLIENT_KEY);
     guac_vnc_client* vnc_client = (guac_vnc_client*) gc->data;
 
+#ifdef LIBVNC_CLIENT_HAS_SCREEN
+    int new_height = rfbClientSwap16IfLE(client->screen.height);
+    int new_width  = rfbClientSwap16IfLE(client->screen.width);
+#else
+    int new_height = rfbClientSwap16IfLE(client->height);
+    int new_width  = rfbClientSwap16IfLE(client->width);
+#endif
+
     /* Resize the surface if VNC screen size has changed */
     int old_height = vnc_client->display->default_surface->height;
     int old_width  = vnc_client->display->default_surface->width;
-    int new_height = rfbClientSwap16IfLE(client->screen.height);
-    int new_width  = rfbClientSwap16IfLE(client->screen.width);
     if (
             new_height > 0 && new_width > 0
             && (new_height != old_height || new_width != old_width)


### PR DESCRIPTION
Third time's the charm, I hope.

@necouchman already had all the proper configure checks in his code but I somehow managed to leave them out🤦‍♂️. 