### PR TITLE
GUACAMOLE-1196: Fix compile issues with older VNC client versions where screen isn't defined.

### DIFF
--- a/src/protocols/vnc/display.c
+++ b/src/protocols/vnc/display.c
@@ -201,13 +201,13 @@ static rfbBool guac_vnc_send_desktop_size(rfbClient* client, int width, int heig
     /* Get the Guacamole client data */
     guac_client* gc = rfbClientGetClientData(client, GUAC_VNC_CLIENT_KEY);
 
+#ifdef LIBVNC_CLIENT_HAS_SCREEN
     guac_client_log(gc, GUAC_LOG_TRACE,
             "Current screen size is %ix%i; setting new size %ix%i\n",
             rfbClientSwap16IfLE(client->screen.width),
             rfbClientSwap16IfLE(client->screen.height),
             width, height);
 
-#ifdef LIBVNC_CLIENT_HAS_SCREEN
     /* Don't send an update if the requested dimensions are identical to current dimensions. */
     if (client->screen.width == rfbClientSwap16IfLE(width) && client->screen.height == rfbClientSwap16IfLE(height)) {
         guac_client_log(gc, GUAC_LOG_WARNING, "Screen size has not changed, not sending update.");


### PR DESCRIPTION
Fix for compilation error related to #544:
```c
In file included from display.h:25,
                 from display.c:23:
display.c: In function ‘guac_vnc_send_desktop_size’:
display.c:206:39: error: ‘rfbClient’ {aka ‘struct _rfbClient’} has no member named ‘screen’
  206 |             rfbClientSwap16IfLE(client->screen.width),
      |                                       ^~
display.c:206:39: error: ‘rfbClient’ {aka ‘struct _rfbClient’} has no member named ‘screen’
  206 |             rfbClientSwap16IfLE(client->screen.width),
      |                                       ^~
display.c:206:39: error: ‘rfbClient’ {aka ‘struct _rfbClient’} has no member named ‘screen’
  206 |             rfbClientSwap16IfLE(client->screen.width),
      |                                       ^~
display.c:207:39: error: ‘rfbClient’ {aka ‘struct _rfbClient’} has no member named ‘screen’
  207 |             rfbClientSwap16IfLE(client->screen.height),
      |                                       ^~
display.c:207:39: error: ‘rfbClient’ {aka ‘struct _rfbClient’} has no member named ‘screen’
  207 |             rfbClientSwap16IfLE(client->screen.height),
      |                                       ^~
display.c:207:39: error: ‘rfbClient’ {aka ‘struct _rfbClient’} has no member named ‘screen’
  207 |             rfbClientSwap16IfLE(client->screen.height),
      |                                       ^~
make[2]: *** [Makefile:618: libguac_client_vnc_la-display.lo] Error 1
```

