### PR TITLE
feat: Added Elestio as one-click deploy option

### DIFF
--- a/README
+++ b/README
@@ -32,6 +32,15 @@ proxy which translates between arbitrary protocols and the Guacamole protocol.
 
 
 ------------------------------------------------------------
+ Self-Hosting guacamole-server
+------------------------------------------------------------
+
+Elestio provides an option to deploy fully managed option of software. Elestio 
+manages the migrations, backups, version changes and security of the application.
+Get started here: https://elest.io/open-source/guacamole
+
+
+------------------------------------------------------------
  Required dependencies
 ------------------------------------------------------------
 


### PR DESCRIPTION
Hey team,
I am Kaiwalya, Developer Advocate at Elestio. Elestio has been providing options of fully deploying and managing Guacamole server application as shown [here](https://elest.io/open-source/guacamole). I think it would be a great idea if we can add it to official readme/documentation here.
🔔 In addition to this, if you are interested we provide partnership opportunities with tools we support by **revenue share** upon addition of this method in docs. If you would like to collaborate, just shoot me an email at [kaiwalya@elest.io](mailto:kaiwalya@elest.io) :)