### PR TITLE
GUACAMOLE-377: Add missing include for errno.

### DIFF
--- a/src/terminal/terminal-handlers.c
+++ b/src/terminal/terminal-handlers.c
@@ -31,6 +31,7 @@
 #include <guacamole/protocol.h>
 #include <guacamole/socket.h>
 
+#include <errno.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <wchar.h>


### PR DESCRIPTION
This is otherwise currently breaking the build on Rocky Linux and presumably others.