### PR TITLE
GUACAMOLE-377: Fix issue where display content is not updated when switching back to normal buffer.

### DIFF
--- a/src/terminal/terminal-handlers.c
+++ b/src/terminal/terminal-handlers.c
@@ -1070,6 +1070,13 @@ int guac_terminal_csi(guac_terminal* term, unsigned char c) {
                         guac_terminal_scrollbar_set_bounds(term->scrollbar,
                                 -guac_terminal_get_available_scroll(term), 0);
 
+                        /* Redraw normal buffer content */
+                        guac_terminal_redraw_default_layer(term);
+                        
+                        /* Clear selection */
+                        term->text_selected = false;
+                        term->selection_committed = false;
+
                     }
 
                     /* Clear normal buffer only if we were previously using

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -2125,10 +2125,7 @@ void guac_terminal_apply_color_scheme(guac_terminal* terminal,
     display->default_background = default_char->attributes.background;
 
     /* Redraw terminal text and background */
-    guac_terminal_repaint_default_layer(terminal, client->socket);
-    __guac_terminal_redraw_rect(terminal, 0, 0,
-            terminal->term_height - 1,
-            terminal->term_width - 1);
+    guac_terminal_redraw_default_layer(terminal);
 
     /* Acquire exclusive access to terminal */
     guac_terminal_lock(terminal);
@@ -2151,7 +2148,6 @@ const char* guac_terminal_get_color_scheme(guac_terminal* terminal) {
 void guac_terminal_apply_font(guac_terminal* terminal, const char* font_name,
         int font_size, int dpi) {
 
-    guac_client* client = terminal->client;
     guac_terminal_display* display = terminal->display;
 
     if (guac_terminal_display_set_font(display, font_name, font_size, dpi))
@@ -2163,10 +2159,7 @@ void guac_terminal_apply_font(guac_terminal* terminal, const char* font_name,
             terminal->outer_height);
 
     /* Redraw terminal text and background */
-    guac_terminal_repaint_default_layer(terminal, client->socket);
-    __guac_terminal_redraw_rect(terminal, 0, 0,
-            terminal->term_height - 1,
-            terminal->term_width - 1);
+    guac_terminal_redraw_default_layer(terminal);
 
     /* Acquire exclusive access to terminal */
     guac_terminal_lock(terminal);
@@ -2231,4 +2224,13 @@ void guac_terminal_remove_user(guac_terminal* terminal, guac_user* user) {
 
     /* Remove the user from the terminal cursor */
     guac_common_cursor_remove_user(terminal->cursor, user);
+}
+
+void guac_terminal_redraw_default_layer(guac_terminal* terminal) {
+
+    /* Redraw terminal text and background */
+    guac_terminal_repaint_default_layer(terminal, terminal->client->socket);
+    __guac_terminal_redraw_rect(terminal, 0, 0,
+            terminal->term_height - 1,
+            terminal->term_width - 1);
 }

--- a/src/terminal/terminal/terminal-priv.h
+++ b/src/terminal/terminal/terminal-priv.h
@@ -682,4 +682,12 @@ void guac_terminal_copy_rows(guac_terminal* terminal,
  */
 void guac_terminal_flush(guac_terminal* terminal);
 
+/**
+ * Redraw default layer text and background.
+ *
+ * @param terminal
+ *      The terminal to redraw.
+ */
+void guac_terminal_redraw_default_layer(guac_terminal* terminal);
+
 #endif


### PR DESCRIPTION
The contents of the alternative buffer are still visible when returning to the normal buffer.

Example with vi:
![image](https://github.com/user-attachments/assets/b0a3dcc1-c32c-4ac5-b120-a52d8857a7eb)
  
After close it (selection remains too):
![image](https://github.com/user-attachments/assets/d45c4f3b-00c4-4714-b2ae-365a0569f6ea)

I reused `guac_terminal_redraw_default_layer` function on `apply_color_scheme` and `apply_font` functions because the code is the same.