### PR TITLE
GUACAMOLE-1997: Fix issue on screen resize with freerdp >= 3.8.0.

### DIFF
--- a/src/protocols/rdp/gdi.c
+++ b/src/protocols/rdp/gdi.c
@@ -99,7 +99,14 @@ BOOL guac_rdp_gdi_end_paint(rdpContext* context) {
 
     guac_display_layer* default_layer = guac_display_default_layer(rdp_client->display);
     guac_display_layer_raw_context* current_context = rdp_client->current_context;
-    GUAC_ASSERT(current_context != NULL);
+
+    /* Handle the case where EndPaint was called without a preceding BeginPaint.
+     * This can occur during screen resize events in "display-update" mode with
+     * FreeRDP version 3.8.0 or later, where EndPaint is called to ensure the
+     * update-lock is released and data is flushed before resizing. See the
+     * associated FreeRDP PR: https://github.com/FreeRDP/FreeRDP/pull/10488 */
+    if (current_context == NULL)
+        return TRUE;
 
     /* Ignore paint if GDI output is suppressed */
     if (gdi->suppressOutput)


### PR DESCRIPTION
With freerdp >= 3.8.0, we can't resize with "display-update":

 ```
guacd[609180]: DEBUG:   Display update channel will be used for display size changes.
guacd[609180]: DEBUG:   {Microsoft::Windows::RDS::DisplayControl:16} OnOpen=(nil), OnClose=0x7f40b610b150
guacd[609180]: DEBUG:   Server resized display to 768x583
GUAC_ASSERT in guac_rdp_gdi_end_paint() failed at gdi.c:102.
guacd[609080]: INFO:    Connection "$3ec11dae-60d9-4820-9028-01a10f4e95f4" removed.
guacd[609080]: DEBUG:   Unable to request termination of client process: No such process 
guacd[609080]: DEBUG:   All child processes for connection "$3ec11dae-60d9-4820-9028-01a10f4e95f4" have been terminated. 
```

Caused by this bugfix in freerdp: https://github.com/FreeRDP/FreeRDP/pull/10488
Freerdp triggers EndPaint first when resizing to ensure there are no unfinished BeginPaints.
