### PR TITLE
GUACAMOLE-1256: Fix a display issue when scrolling up in vi as well as latency in less.

### DIFF
--- a/src/terminal/display.c
+++ b/src/terminal/display.c
@@ -480,6 +480,11 @@ void guac_terminal_display_set_columns(guac_terminal_display* display, int row,
     /* For each column in range */
     for (int col = start_column; col <= end_column; col += character->width) {
 
+        /* Flush pending copy operation before adding new SET operation. This
+         * avoid operation conflicts that cause inconsistent display. */
+        if (current->type == GUAC_CHAR_COPY)
+            guac_terminal_display_flush(display);
+
         /* Set operation */
         current->type      = GUAC_CHAR_SET;
         current->character = *character;

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -875,10 +875,6 @@ void guac_terminal_scroll_down(guac_terminal* term,
             start_row, 0,
             start_row + amount - 1, term->term_width - 1);
 
-    /* Flush display copy before the cursor commit override operation
-     * type for visible cursor row and breaks display. */
-    guac_terminal_display_flush(term->display);
-
 }
 
 int guac_terminal_clear_columns(guac_terminal* term,


### PR DESCRIPTION
Allows better synchronization between the buffer and the display, which avoids "mixed" displayed data when highlighting braces, parentheses and others in vi.
Seems to fix a latency issue when scrolling up in less.
