### PR TITLE
GUACAMOLE-1196: Correct VNC resize to conform to the RFB standard.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -653,55 +653,36 @@ then
 fi
 
 #
-# libVNCserver support for the rfbSetDesktopSizeMsg message, which allows the
-# VNC client to send its dimensions to the server, requesting that the server
-# resize itself to match. If libvnc lacks this message, remote resize will
-# be completely disabled.
+# libVNCserver support for the rfbSetDesktopSizeMsg message and the screen
+# data structure, both of which are required in order to properly request that
+# a remote server resize its screen to match the dimensions that the client
+# sends. If libvnc lacks either this message or the screen data structure
+# remote resize will be completely disabled.
 #
 
 if test "x${have_libvncserver}" = "xyes"
 then
 
-    have_vnc_size_msg=yes
+    have_vnc_resize_support=yes
     AC_CHECK_TYPE([rfbSetDesktopSizeMsg],
-                     [], [have_vnc_size_msg=no],
+                     [], [have_vnc_resize_support=no],
                      [[#include <rfb/rfbproto.h>]])
 
-    if test "x${have_vnc_size_msg}" = "xno"
+    AC_CHECK_MEMBERS([rfbClient.screen],
+                     [], [have_vnc_resize_support=no],
+                     [[#include <rfb/rfbclient.h>]])
+
+    if test "x${have_vnc_resize_support}" = "xno"
     then
         AC_MSG_WARN([
       --------------------------------------------------------
-       No support for rfbSetDesktopSizeMsg in libvncclient.
-       VNC support for remote display resize will be disabled.
+       The libvncclient library lacks support for either the
+       rfbSetDesktopSizeMsg message or for extended screen
+       support. Resizing of remote displays will be disabled.
       --------------------------------------------------------])
     else
-        AC_DEFINE([LIBVNC_HAS_SIZE_MSG],,
+        AC_DEFINE([LIBVNC_HAS_RESIZE_SUPPORT],,
                   [Whether VNC client will support sending desktop size messages.])
-    fi
-
-fi
-
-#
-# libVNCserver support for the screen structure, which allows for tracking
-# multiple screens that are part of a larger frame buffer display. If this
-# feature is missing, the VNC client may still attempt to send the display
-# resize messages, but will assume that there is a one-to-one relationship
-# between the screen size and the frame buffer size (which is currently safe
-# for Guacamole, as it lacks multi-monitor/screen support).
-#
-
-if test "x${have_libvncserver}" = "xyes"
-then
-
-    have_vnc_screen=yes
-    AC_CHECK_MEMBERS([rfbClient.screen],
-                     [], [have_vnc_screen=no],
-                     [[#include <rfb/rfbclient.h>]])
-
-    if test "x${have_vnc_screen}" = "xyes"
-    then
-        AC_DEFINE([LIBVNC_CLIENT_HAS_SCREEN],,
-                  [Whether rfbClient contains the screen data structure.])
     fi
 
 fi

--- a/src/protocols/vnc/input.c
+++ b/src/protocols/vnc/input.c
@@ -64,7 +64,7 @@ int guac_vnc_user_key_handler(guac_user* user, int keysym, int pressed) {
     return 0;
 }
 
-#ifdef LIBVNC_HAS_SIZE_MSG
+#ifdef LIBVNC_HAS_RESIZE_SUPPORT
 int guac_vnc_user_size_handler(guac_user* user, int width, int height) {
 
     guac_user_log(user, GUAC_LOG_TRACE, "Running user size handler.");
@@ -78,4 +78,4 @@ int guac_vnc_user_size_handler(guac_user* user, int width, int height) {
     return 0;
 
 }
-#endif //LIBVNC_HAS_SIZE_MSG
+#endif // LIBVNC_HAS_RESIZE_SUPPORT

--- a/src/protocols/vnc/user.c
+++ b/src/protocols/vnc/user.c
@@ -89,11 +89,14 @@ int guac_vnc_user_join_handler(guac_user* user, int argc, char** argv) {
             user->file_handler = guac_vnc_sftp_file_handler;
 #endif
 
-#ifdef LIBVNC_HAS_SIZE_MSG
+#ifdef LIBVNC_HAS_RESIZE_SUPPORT
         /* If user is owner, set size handler. */
         if (user->owner && !settings->disable_display_resize)
             user->size_handler = guac_vnc_user_size_handler;
-#endif // LIBVNC_HAS_SIZE_MSG
+#else
+        guac_user_log(user, GUAC_LOG_WARNING,
+                "The libvncclient library does not support remote resize.");
+#endif // LIBVNC_HAS_RESIZE_SUPPORT
 
     }
 

--- a/src/protocols/vnc/vnc.h
+++ b/src/protocols/vnc/vnc.h
@@ -164,6 +164,19 @@ typedef struct guac_vnc_client {
      */
     guac_iconv_write* clipboard_writer;
 
+#ifdef LIBVNC_HAS_RESIZE_SUPPORT
+    /**
+     * Whether or not the server has sent the required message to initialize
+     * the screen data in the client.
+     */
+    bool rfb_screen_initialized;
+
+    /**
+     * Whether or not the client has sent it's starting size to the server.
+     */
+    bool rfb_initial_resize;
+#endif
+
 } guac_vnc_client;
 
 /**


### PR DESCRIPTION
This pull request brings the VNC resize support in Guacamole in line with the RFB standard:
* The client must receive an `ExtendedDesktopSize` rectangle message from the server before trying to send its size to the server. Unless and until this has been received, no `SetDesktopSize` message can be sent, and sending it will either be ignored by the server or cause the server to drop the connection. In libvncclient, the receipt of this message initializes the `client->screen` data structure, so we test for that in order to find out if the message has been sent and we are allowed to send the client size to the server.
* This makes the initial sizing of the remote desktop to the client size a bit challenging, since we cannot send that initial message until we've received and processed at least one message from the server. So, I had to shift around the stuff in main client thread a bit, add a couple of flag members to the `guac_vnc_client` data structure to track this. If there's a better way to do this, do not hesitate to suggest it.
* I also simplified the `configure.ac` checks and resulting definitions so that both the `rfbSetDesktopSizeMsg` and `client->screen` items need to be present for it to be enabled.

If I recall correctly during testing, there were some VNC servers that supported resizing even though they did not initialize or support the `screen` members, and so some of the changes we had made in trying to get this to work intentionally ignored that and tried to send the `SetDesktopSize` message, anyway. Unfortunately, ignoring that breaks connections for the VNC servers that truly do not support `screen` and `SetDesktopSize`, so it seems like it is likely best to just follow the RFB standard and the way the libvncclient implements that standard and go this route.

Final note, it does look like the `SendDesktopSize()` function in libvncclient is still broken, at least, in the version being pulled in by the Alpine Linux distro for the Docker image, and I couldn't get that to work with a VNC server that I know supports resizing properly. So, I've fallen back to not using that built-in function, and, instead, implementing one that does more or less the same things, but 1) actually works, and 2) can log things in a way that the Guacamole admins can see.