### PR TITLE
GUACAMOLE-925: Add Russian keymap support "ru-ru-qwerty"

### DIFF
--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -246,6 +246,7 @@ rdp_keymaps =                                \
     $(srcdir)/keymaps/pt_br_qwerty.keymap    \
     $(srcdir)/keymaps/pt_pt_qwerty.keymap    \
     $(srcdir)/keymaps/ro_ro_qwerty.keymap    \
+    $(srcdir)/keymaps/ru_ru_qwerty.keymap    \
     $(srcdir)/keymaps/sv_se_qwerty.keymap    \
     $(srcdir)/keymaps/da_dk_qwerty.keymap    \
     $(srcdir)/keymaps/tr_tr_qwerty.keymap

--- a/src/protocols/rdp/keymaps/ru_ru_qwerty.keymap
+++ b/src/protocols/rdp/keymaps/ru_ru_qwerty.keymap
@@ -1,0 +1,63 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+parent  "base"
+name    "ru-ru-qwerty"
+# We use the "KBD_US" layout because we switch the language, not the layout
+freerdp "KBD_US"
+
+# Let's define the scan codes of the main Latin keys
+# 
+map -caps -shift 0x10..0x1B 0x2B ~ "qwertyuiop[]\"
+map -caps -shift 0x1E..0x28      ~ "asdfghjkl;'"
+map -caps -shift 0x2C..0x35      ~ "zxcvbnm,./"
+
+map -caps +shift 0x10..0x1B 0x2B ~ "QWERTYUIOP{}|"
+map -caps +shift 0x1E..0x28      ~ "ASDFGHJKL:""
+map -caps +shift 0x2C..0x35      ~ "ZXCVBNM<>?"
+
+map +caps -shift 0x10..0x1B 0x2B ~ "QWERTYUIOP[]\"
+map +caps -shift 0x1E..0x28      ~ "ASDFGHJKL;'"
+map +caps -shift 0x2C..0x35      ~ "ZXCVBNM,./"
+
+map +caps +shift 0x10..0x1B 0x2B ~ "qwertyuiop{}|"
+map +caps +shift 0x1E..0x28      ~ "asdfghjkl:""
+map +caps +shift 0x2C..0x35      ~ "zxcvbnm<>?"
+
+# Let's define the scan codes of the main Russian keys
+#
+map -caps -shift 0x29 0x02..0x0D ~ "ё1234567890-="
+map -caps -shift 0x10..0x1B 0x2B ~ "йцукенгшщзхъ\"
+map -caps -shift 0x1E..0x28      ~ "фывапролджэ"
+map -caps -shift 0x2C..0x35      ~ "ячсмитьбю."
+
+map -caps +shift 0x29 0x02..0x0D ~ "Ё!"№;%:?*()_+"
+map -caps +shift 0x10..0x1B 0x2B ~ "ЙЦУКЕНГШЩЗХЪ/"
+map -caps +shift 0x1E..0x28      ~ "ФЫВАПРОЛДЖЭ"
+map -caps +shift 0x2C..0x35      ~ "ЯЧСМИТЬБЮ,"
+
+map +caps -shift 0x29 0x02..0x0D ~ "Ё1234567890-="
+map +caps -shift 0x10..0x1B 0x2B ~ "ЙЦУКЕНГШЩЗХЪ\"
+map +caps -shift 0x1E..0x28      ~ "ФЫВАПРОЛДЖЭ"
+map +caps -shift 0x2C..0x35      ~ "ЯЧСМИТЬБЮ,"
+
+map +caps +shift 0x29 0x02..0x0D ~ "ё!"№;%:?*()_+"
+map +caps +shift 0x10..0x1B 0x2B ~ "йцукенгшщзхъ/"
+map +caps +shift 0x1E..0x28      ~ "фывапролджэ"
+map +caps +shift 0x2C..0x35      ~ "ячсмитьбю,"


### PR DESCRIPTION
The keymap "ru_ru_qwerty.keymap" has been added to the "Makefile.am" file to support the Russian keyboard layout.
The file "ru_ru_qwerty.keymap" has been added to support the Russian keyboard layout.