### PR TITLE
GUACAMOLE-377: Address performance regression primarily affecting RDP.

### DIFF
--- a/src/libguac/display-flush.c
+++ b/src/libguac/display-flush.c
@@ -278,7 +278,9 @@ static int PFW_LFW_guac_display_frame_complete(guac_display* display) {
         display->last_frame.cursor_mask = display->pending_frame.cursor_mask;
         guac_client_foreach_user(client, LFR_guac_display_broadcast_cursor_state, display);
 
-        retval = 1;
+        /* NOTE: We DO NOT set retval here, as flushing a frame due purely to
+         * mouse position changes can cause slowdowns apparently from the sheer
+         * quantity of frames */
 
     }
 

--- a/src/libguac/display-flush.c
+++ b/src/libguac/display-flush.c
@@ -176,6 +176,12 @@ static int PFW_LFW_guac_display_frame_complete(guac_display* display) {
 
         }
 
+        /* Even if nothing has changed in the pending frame, we have to at
+         * least flush that fact to the last frame (otherwise, the last frame
+         * may contain stale dirty rects) */
+        else
+            current->last_frame.dirty = (guac_rect) { 0 };
+
         /* Commit any change in layer size */
         if (current->pending_frame.width != current->last_frame.width
                 || current->pending_frame.height != current->last_frame.height) {


### PR DESCRIPTION
These changes address two issues that were affecting the performance of Guacamole after the introduction of `guac_display`, particularly RDP:

* The dirty rects of the last frame were not being updated when the corresponding dirty rects of the pending frame were empty.

  It's correct to not flush updated image data if the dirty rects are empty, but the rects tracking the state of the last frame need to be correctly updated to match the state of the pending frame, even if that state is empty. Doing otherwise results in unnecessary updates being transmitted to the client, since `guac_display` incorrectly believes that things were changed in the last frame.

* Sending a new `sync` for each movement of the mouse can at least cause client-side slowdowns. There may be things that can be improved in the client.

Opening as a draft for now as that last issue involving `sync` seems to correlate strongly with our usage of `requestAnimationFrame()`:

* When `window.requestAnimationFrame` has been manually set to `null` via dev tools, things suddenly become fast.
* If the browser window is in the background (and thus usage of `requestAnimationFrame()` is disabled), things are also fast.