### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,7 +197,7 @@ RUN apk add --no-cache                \
     xargs apk add --no-cache < ${PREFIX_DIR}/DEPENDENCIES
 
 # Checks the operating status every 5 minutes with a timeout of 5 seconds
-HEALTHCHECK --interval=5m --timeout=5s CMD nc -z 127.0.0.1 4822 || exit 1
+HEALTHCHECK --interval=5m --timeout=5s --start-period=15s CMD nc -z 127.0.0.1 4822 || exit 1
 
 # Create a new user guacd
 ARG UID=1000


### PR DESCRIPTION
Added start-period to docker healthcheck. Should fix containers being stuck in `starting` state for a long time causing issues with certain docker compose setups