### PR TITLE
GUACAMOLE-2035: Add start-up period to guacd health check in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -328,7 +328,7 @@ ENV LC_ALL=C.UTF-8
 ENV LD_LIBRARY_PATH=${PREFIX_DIR}/lib
 
 # Checks the operating status every 5 minutes with a timeout of 5 seconds
-HEALTHCHECK --interval=5m --timeout=5s CMD nc -z 127.0.0.1 4822 || exit 1
+HEALTHCHECK --interval=5m --timeout=5s --start-period=15s CMD nc -z 127.0.0.1 4822 || exit 1
 
 # Create a new user guacd
 ARG UID=1000


### PR DESCRIPTION
Added start-period to docker healthcheck. Should fix containers being stuck in `starting` state for a long time causing issues with certain docker compose setups.

Without the start-period parameter the healthcheck seems to run only after the set interval of 5 minutes. This is way too long if you use the guacamole container within a stack and the depends_on condition "service_healthy". The deployment of the stack will abort.

Tested this fix on my own setup and it fixes the problem for me. Might be useful for others as well.