### PR TITLE
GUACAMOLE-377: Remove use of END_FRAME operation from guac_display.

### DIFF
--- a/src/libguac/display-flush.c
+++ b/src/libguac/display-flush.c
@@ -379,11 +379,12 @@ void guac_display_end_multiple_frames(guac_display* display, int frames) {
     guac_rwlock_release_lock(&display->last_frame.lock);
 
     /* Not all frames are graphical. If we end up with a frame containing
-     * nothing but layer property changes, then we must still send a frame
-     * boundary even though there is no display plan to optimize. */
+     * nothing but layer property changes, then we must still send at least one
+     * operation to awaken the workers and flush layer changes, even though
+     * there is no display plan to optimize. */
     if (plan == NULL && frame_nonempty) {
         guac_display_plan_operation end_frame_op = {
-            .type = GUAC_DISPLAY_PLAN_END_FRAME
+            .type = GUAC_DISPLAY_PLAN_OPERATION_NOP
         };
         guac_fifo_enqueue(&display->ops, &end_frame_op);
     }

--- a/src/libguac/display-plan.c
+++ b/src/libguac/display-plan.c
@@ -305,7 +305,7 @@ guac_display_plan* PFW_LFR_guac_display_plan_create(guac_display* display) {
     guac_display_plan* plan = guac_mem_alloc(sizeof(guac_display_plan));
     plan->display = display;
     plan->frame_end = frame_end;
-    plan->length = guac_mem_ckd_add_or_die(op_count, 1);
+    plan->length = op_count;
     plan->ops = guac_mem_alloc(plan->length, sizeof(guac_display_plan_operation));
 
     /* Convert the dirty rectangles stored in each layer's cells to individual
@@ -358,12 +358,6 @@ guac_display_plan* PFW_LFR_guac_display_plan_create(guac_display* display) {
     /* At this point, the number of operations added should exactly match the
      * predicted quantity */
     GUAC_ASSERT(added_ops == op_count);
-
-    /* Worker threads must be aware of end-of-frame to know when to send sync,
-     * etc. Noticing that the operation queue is empty is insufficient, as the
-     * queue may become empty while a frame is in progress if the worker
-     * threads happen to be processing things quickly. */
-    current_op->type = GUAC_DISPLAY_PLAN_END_FRAME;
 
     return plan;
 

--- a/src/libguac/display-plan.h
+++ b/src/libguac/display-plan.h
@@ -141,12 +141,7 @@ typedef enum guac_display_plan_operation_type {
     /**
      * Draw arbitrary image data to the destination rect.
      */
-    GUAC_DISPLAY_PLAN_OPERATION_IMG,
-
-    /**
-     * Finish the frame, sending the frame boundary to all connected users.
-     */
-    GUAC_DISPLAY_PLAN_END_FRAME
+    GUAC_DISPLAY_PLAN_OPERATION_IMG
 
 } guac_display_plan_operation_type;
 


### PR DESCRIPTION
The `END_FRAME` operation was previously used to notify workers that the frame has ended, but since the receiving worker needs to check and push that operation back onto the queue if other workers are still busy, it's essentially unnecessary _and_ results in several workers spinning as they pass `END_FRAME` around until all others are done.

It's sufficient to simply check whether the operation queue is empty and no other workers are active.

Recommend ignoring whitespace in the diff - much of this is a change in indentation.