### PR TITLE
GUACAMOLE-1980: Bump libguac soversion for changes since 1.5.5 (interfaces changed).

### DIFF
--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -191,7 +191,7 @@ libguac_la_CFLAGS = \
     -Werror -Wall -pedantic
 
 libguac_la_LDFLAGS =     \
-    -version-info 24:0:0 \
+    -version-info 25:0:0 \
     -no-undefined        \
     @CAIRO_LIBS@         \
     @DL_LIBS@            \


### PR DESCRIPTION
This change updates the libguac soversion (`-version-info`) to match the changes made since 1.5.5, following the libtool documentation for maintaining this value: 

https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html