### PR TITLE
GUACAMOLE-2063: Address lock slowdown primarily affecting RDP.

### DIFF
--- a/src/protocols/rdp/channels/cliprdr.c
+++ b/src/protocols/rdp/channels/cliprdr.c
@@ -78,7 +78,6 @@ static UINT guac_rdp_cliprdr_send_format_list(CliprdrClientContext* cliprdr) {
     assert(clipboard != NULL);
 
     guac_client* client = clipboard->client;
-    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
 
     /* We support CP-1252 and UTF-16 text */
     CLIPRDR_FORMAT_LIST format_list = {
@@ -98,10 +97,7 @@ static UINT guac_rdp_cliprdr_send_format_list(CliprdrClientContext* cliprdr) {
 
     guac_client_log(client, GUAC_LOG_TRACE, "CLIPRDR: Sending format list");
 
-    pthread_mutex_lock(&(rdp_client->message_lock));
-    int retval = cliprdr->ClientFormatList(cliprdr, &format_list);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
-    return retval;
+    return cliprdr->ClientFormatList(cliprdr, &format_list);
 
 }
 
@@ -126,9 +122,6 @@ static UINT guac_rdp_cliprdr_send_capabilities(CliprdrClientContext* cliprdr) {
     guac_rdp_clipboard* clipboard = (guac_rdp_clipboard*) cliprdr->custom;
     assert(clipboard != NULL);
 
-    guac_client* client = clipboard->client;
-    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
-
     /* We support CP-1252 and UTF-16 text */
     CLIPRDR_GENERAL_CAPABILITY_SET cap_set = {
         .capabilitySetType = CB_CAPSTYPE_GENERAL, /* CLIPRDR specification requires that this is CB_CAPSTYPE_GENERAL, the only defined set type */
@@ -142,11 +135,7 @@ static UINT guac_rdp_cliprdr_send_capabilities(CliprdrClientContext* cliprdr) {
         .capabilitySets = (CLIPRDR_CAPABILITY_SET*) &cap_set
     };
 
-    pthread_mutex_lock(&(rdp_client->message_lock));
-    int retval = cliprdr->ClientCapabilities(cliprdr, &caps);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
-
-    return retval;
+    return cliprdr->ClientCapabilities(cliprdr, &caps);
 
 }
 
@@ -218,7 +207,6 @@ static UINT guac_rdp_cliprdr_send_format_data_request(
     assert(clipboard != NULL);
 
     guac_client* client = clipboard->client;
-    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
 
     /* Create new data request */
     CLIPRDR_FORMAT_DATA_REQUEST data_request = {
@@ -232,11 +220,7 @@ static UINT guac_rdp_cliprdr_send_format_data_request(
     guac_client_log(client, GUAC_LOG_TRACE, "CLIPRDR: Sending format data request.");
 
     /* Send request */
-    pthread_mutex_lock(&(rdp_client->message_lock));
-    int retval = cliprdr->ClientFormatDataRequest(cliprdr, &data_request);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
-
-    return retval;
+    return cliprdr->ClientFormatDataRequest(cliprdr, &data_request);
 
 }
 
@@ -299,8 +283,6 @@ static UINT guac_rdp_cliprdr_format_list(CliprdrClientContext* cliprdr,
     assert(clipboard != NULL);
 
     guac_client* client = clipboard->client;
-    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
-
     guac_client_log(client, GUAC_LOG_TRACE, "CLIPRDR: Received format list.");
 
     CLIPRDR_FORMAT_LIST_RESPONSE format_list_response = {
@@ -314,9 +296,7 @@ static UINT guac_rdp_cliprdr_format_list(CliprdrClientContext* cliprdr,
 #endif
     };
     /* Report successful processing of format list */
-    pthread_mutex_lock(&(rdp_client->message_lock));
     cliprdr->ClientFormatListResponse(cliprdr, &format_list_response);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
     /* Prefer Unicode (in this case, UTF-16) */
     if (guac_rdp_cliprdr_format_supported(format_list, CF_UNICODETEXT))
@@ -420,9 +400,7 @@ static UINT guac_rdp_cliprdr_format_data_request(CliprdrClientContext* cliprdr,
 
     guac_client_log(client, GUAC_LOG_TRACE, "CLIPRDR: Sending format data response.");
 
-    pthread_mutex_lock(&(rdp_client->message_lock));
     UINT result = cliprdr->ClientFormatDataResponse(cliprdr, &data_response);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
     guac_mem_free(start);
     return result;

--- a/src/protocols/rdp/channels/common-svc.c
+++ b/src/protocols/rdp/channels/common-svc.c
@@ -90,16 +90,12 @@ void guac_rdp_common_svc_write(guac_rdp_common_svc* svc,
         return;
     }
 
-    guac_rdp_client* rdp_client = (guac_rdp_client*) svc->client->data;
-
     /* NOTE: The wStream sent via pVirtualChannelWriteEx will automatically be
      * freed later with a call to Stream_Free() when handling the
      * corresponding write cancel/completion event. */
-    pthread_mutex_lock(&(rdp_client->message_lock));
     svc->_entry_points.pVirtualChannelWriteEx(svc->_init_handle,
             svc->_open_handle, Stream_Buffer(output_stream),
             Stream_GetPosition(output_stream), output_stream);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
 }
 

--- a/src/protocols/rdp/channels/disp.c
+++ b/src/protocols/rdp/channels/disp.c
@@ -237,14 +237,7 @@ void guac_rdp_disp_update_size(guac_rdp_disp* disp,
 
         /* Send display update notification if display channel is connected */
         if (disp->disp != NULL) {
-
-            guac_client* client = disp->client;
-            guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
-
-            pthread_mutex_lock(&(rdp_client->message_lock));
             disp->disp->SendMonitorLayout(disp->disp, 1, monitors);
-            pthread_mutex_unlock(&(rdp_client->message_lock));
-
         }
 
     }

--- a/src/protocols/rdp/channels/rail.c
+++ b/src/protocols/rdp/channels/rail.c
@@ -75,9 +75,7 @@ static UINT guac_rdp_rail_complete_handshake(RailClientContext* rail) {
 
     /* Send client handshake response */
     guac_client_log(client, GUAC_LOG_TRACE, "Sending RAIL handshake.");
-    pthread_mutex_lock(&(rdp_client->message_lock));
     status = rail->ClientHandshake(rail, &handshake);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
     if (status != CHANNEL_RC_OK)
         return status;
@@ -90,9 +88,7 @@ static UINT guac_rdp_rail_complete_handshake(RailClientContext* rail) {
 
     /* Send client status */
     guac_client_log(client, GUAC_LOG_TRACE, "Sending RAIL client status.");
-    pthread_mutex_lock(&(rdp_client->message_lock));
     status = rail->ClientInformation(rail, &client_status);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
     if (status != CHANNEL_RC_OK)
         return status;
@@ -137,9 +133,7 @@ static UINT guac_rdp_rail_complete_handshake(RailClientContext* rail) {
 
     /* Send client system parameters */
     guac_client_log(client, GUAC_LOG_TRACE, "Sending RAIL client system parameters.");
-    pthread_mutex_lock(&(rdp_client->message_lock));
     status = rail->ClientSystemParam(rail, &sysparam);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
     if (status != CHANNEL_RC_OK)
         return status;
@@ -153,9 +147,7 @@ static UINT guac_rdp_rail_complete_handshake(RailClientContext* rail) {
 
     /* Execute desired RemoteApp command */
     guac_client_log(client, GUAC_LOG_TRACE, "Executing remote application.");
-    pthread_mutex_lock(&(rdp_client->message_lock));
     status = rail->ClientExecute(rail, &exec);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
     return status;
 

--- a/src/protocols/rdp/channels/rdpei.c
+++ b/src/protocols/rdp/channels/rdpei.c
@@ -148,9 +148,6 @@ void guac_rdp_rdpei_load_plugin(rdpContext* context) {
 int guac_rdp_rdpei_touch_update(guac_rdp_rdpei* rdpei, int id, int x, int y,
         double force) {
 
-    guac_client* client = rdpei->client;
-    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
-
     int contact_id; /* Ignored */
 
     /* Track touches only if channel is connected */
@@ -193,30 +190,20 @@ int guac_rdp_rdpei_touch_update(guac_rdp_rdpei* rdpei, int id, int x, int y,
         if (!touch->active)
             return 1;
 
-        pthread_mutex_lock(&(rdp_client->message_lock));
         context->TouchEnd(context, id, x, y, &contact_id);
-        pthread_mutex_unlock(&(rdp_client->message_lock));
-
         touch->active = 0;
 
     }
 
     /* Signal the start of a touch if this is the first we've seen it */
     else if (!touch->active) {
-
-        pthread_mutex_lock(&(rdp_client->message_lock));
         context->TouchBegin(context, id, x, y, &contact_id);
-        pthread_mutex_unlock(&(rdp_client->message_lock));
-
         touch->active = 1;
-
     }
 
     /* Established touches need only be updated */
     else {
-        pthread_mutex_lock(&(rdp_client->message_lock));
         context->TouchUpdate(context, id, x, y, &contact_id);
-        pthread_mutex_unlock(&(rdp_client->message_lock));
     }
 
     return 0;

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -217,14 +217,8 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
     /* Redirect FreeRDP log messages to guac_client_log() */
     guac_rdp_redirect_wlog(client);
 
-    /* Recursive attribute for locks */
-    pthread_mutexattr_init(&(rdp_client->attributes));
-    pthread_mutexattr_settype(&(rdp_client->attributes),
-            PTHREAD_MUTEX_RECURSIVE);
-
     /* Init required locks */
     guac_rwlock_init(&(rdp_client->lock));
-    pthread_mutex_init(&(rdp_client->message_lock), &(rdp_client->attributes));
 
     /* Set handlers */
     client->join_handler = guac_rdp_user_join_handler;
@@ -309,7 +303,6 @@ int guac_rdp_client_free_handler(guac_client* client) {
         guac_rdp_audio_buffer_free(rdp_client->audio_input);
 
     guac_rwlock_destroy(&(rdp_client->lock));
-    pthread_mutex_destroy(&(rdp_client->message_lock));
 
     /* Free client data */
     guac_mem_free(rdp_client);

--- a/src/protocols/rdp/gdi.c
+++ b/src/protocols/rdp/gdi.c
@@ -138,6 +138,10 @@ BOOL guac_rdp_gdi_end_paint(rdpContext* context) {
 
 paint_complete:
 
+    /* Clear GDI state for future draws */
+    gdi->primary->hdc->hwnd->invalid->null = TRUE;
+    gdi->primary->hdc->hwnd->ninvalid = 0;
+
     /* There will be no further drawing operations */
     rdp_client->current_context = NULL;
     guac_display_layer_close_raw(default_layer, current_context);

--- a/src/protocols/rdp/input.c
+++ b/src/protocols/rdp/input.c
@@ -56,10 +56,8 @@ int guac_rdp_user_mouse_handler(guac_user* user, int x, int y, int mask) {
 
     /* If button mask unchanged, just send move event */
     if (mask == rdp_client->mouse_button_mask) {
-        pthread_mutex_lock(&(rdp_client->message_lock));
         GUAC_RDP_CONTEXT(rdp_inst)->input->MouseEvent(
                 GUAC_RDP_CONTEXT(rdp_inst)->input, PTR_FLAGS_MOVE, x, y);
-        pthread_mutex_unlock(&(rdp_client->message_lock));
     }
 
     /* Otherwise, send events describing button change */
@@ -80,10 +78,8 @@ int guac_rdp_user_mouse_handler(guac_user* user, int x, int y, int mask) {
             if (released_mask & 0x02) flags |= PTR_FLAGS_BUTTON3;
             if (released_mask & 0x04) flags |= PTR_FLAGS_BUTTON2;
 
-            pthread_mutex_lock(&(rdp_client->message_lock));
             GUAC_RDP_CONTEXT(rdp_inst)->input->MouseEvent(
                     GUAC_RDP_CONTEXT(rdp_inst)->input, flags, x, y);
-            pthread_mutex_unlock(&(rdp_client->message_lock));
 
         }
 
@@ -99,10 +95,8 @@ int guac_rdp_user_mouse_handler(guac_user* user, int x, int y, int mask) {
             if (pressed_mask & 0x10) flags |= PTR_FLAGS_WHEEL | PTR_FLAGS_WHEEL_NEGATIVE | 0x88;
 
             /* Send event */
-            pthread_mutex_lock(&(rdp_client->message_lock));
             GUAC_RDP_CONTEXT(rdp_inst)->input->MouseEvent(
                     GUAC_RDP_CONTEXT(rdp_inst)->input, flags, x, y);
-            pthread_mutex_unlock(&(rdp_client->message_lock));
 
         }
 
@@ -111,18 +105,14 @@ int guac_rdp_user_mouse_handler(guac_user* user, int x, int y, int mask) {
 
             /* Down */
             if (pressed_mask & 0x08) {
-                pthread_mutex_lock(&(rdp_client->message_lock));
                 GUAC_RDP_CONTEXT(rdp_inst)->input->MouseEvent(
                         GUAC_RDP_CONTEXT(rdp_inst)->input, PTR_FLAGS_WHEEL | 0x78, x, y);
-                pthread_mutex_unlock(&(rdp_client->message_lock));
             }
 
             /* Up */
             if (pressed_mask & 0x10) {
-                pthread_mutex_lock(&(rdp_client->message_lock));
                 GUAC_RDP_CONTEXT(rdp_inst)->input->MouseEvent(
                         GUAC_RDP_CONTEXT(rdp_inst)->input, PTR_FLAGS_WHEEL | PTR_FLAGS_WHEEL_NEGATIVE | 0x88, x, y);
-                pthread_mutex_unlock(&(rdp_client->message_lock));
             }
 
         }

--- a/src/protocols/rdp/keyboard.c
+++ b/src/protocols/rdp/keyboard.c
@@ -106,10 +106,8 @@ static void guac_rdp_send_key_event(guac_rdp_client* rdp_client,
         return;
 
     /* Send actual key */
-    pthread_mutex_lock(&(rdp_client->message_lock));
     GUAC_RDP_CONTEXT(rdp_inst)->input->KeyboardEvent(
             GUAC_RDP_CONTEXT(rdp_inst)->input, flags | pressed_flags, scancode);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
 }
 
@@ -136,10 +134,8 @@ static void guac_rdp_send_unicode_event(guac_rdp_client* rdp_client,
         return;
 
     /* Send Unicode event */
-    pthread_mutex_lock(&(rdp_client->message_lock));
     GUAC_RDP_CONTEXT(rdp_inst)->input->UnicodeKeyboardEvent(
             GUAC_RDP_CONTEXT(rdp_inst)->input, 0, codepoint);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
 }
 
@@ -166,10 +162,8 @@ static void guac_rdp_send_synchronize_event(guac_rdp_client* rdp_client,
         return;
 
     /* Synchronize lock key states */
-    pthread_mutex_lock(&(rdp_client->message_lock));
     GUAC_RDP_CONTEXT(rdp_inst)->input->SynchronizeEvent(
             GUAC_RDP_CONTEXT(rdp_inst)->input, flags);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
 }
 

--- a/src/protocols/rdp/plugins/guacai/guacai-messages.c
+++ b/src/protocols/rdp/plugins/guacai/guacai-messages.c
@@ -247,8 +247,6 @@ static void guac_rdp_ai_send_formatchange(IWTSVirtualChannel* channel,
 void guac_rdp_ai_process_version(guac_client* client,
         IWTSVirtualChannel* channel, wStream* stream) {
 
-    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
-
     /* Verify we have at least 4 bytes available (UINT32) */
     if (Stream_GetRemainingLength(stream) < 4) {
         guac_client_log(client, GUAC_LOG_WARNING, "Audio input Version PDU "
@@ -271,9 +269,7 @@ void guac_rdp_ai_process_version(guac_client* client,
     Stream_Write_UINT32(response, 1); /* Version */
 
     /* Send response */
-    pthread_mutex_lock(&(rdp_client->message_lock));
     channel->Write(channel, (UINT32) Stream_GetPosition(response), Stream_Buffer(response), NULL);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
     Stream_Free(response, TRUE);
 
 }
@@ -316,34 +312,26 @@ void guac_rdp_ai_process_formats(guac_client* client,
                 format.channels, format.bps / 8);
 
         /* Accept single format */
-        pthread_mutex_lock(&(rdp_client->message_lock));
         guac_rdp_ai_send_incoming_data(channel);
         guac_rdp_ai_send_formats(channel, &format, 1);
-        pthread_mutex_unlock(&(rdp_client->message_lock));
         return;
 
     }
 
     /* No formats available */
     guac_client_log(client, GUAC_LOG_WARNING, "AUDIO_INPUT: No WAVE format.");
-    pthread_mutex_lock(&(rdp_client->message_lock));
     guac_rdp_ai_send_incoming_data(channel);
     guac_rdp_ai_send_formats(channel, NULL, 0);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
 }
 
 void guac_rdp_ai_flush_packet(guac_rdp_audio_buffer* audio_buffer, int length) {
 
-    guac_client* client = audio_buffer->client;
-    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
     IWTSVirtualChannel* channel = (IWTSVirtualChannel*) audio_buffer->data;
 
     /* Send data over channel */
-    pthread_mutex_lock(&(rdp_client->message_lock));
     guac_rdp_ai_send_incoming_data(channel);
     guac_rdp_ai_send_data(channel, audio_buffer->packet, length);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
 }
 
@@ -374,10 +362,8 @@ void guac_rdp_ai_process_open(guac_client* client,
             audio_buffer->out_format.bps);
 
     /* Success */
-    pthread_mutex_lock(&(rdp_client->message_lock));
     guac_rdp_ai_send_formatchange(channel, initial_format);
     guac_rdp_ai_send_open_reply(channel, 0);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
     /* Begin receiving audio data */
     guac_rdp_audio_buffer_begin(audio_buffer, packet_frames,

--- a/src/protocols/rdp/print-job.c
+++ b/src/protocols/rdp/print-job.c
@@ -604,9 +604,6 @@ static void guac_rdp_print_job_read_filename(guac_rdp_print_job* job,
 int guac_rdp_print_job_write(guac_rdp_print_job* job,
         void* buffer, int length) {
 
-    guac_client* client = job->client;
-    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
-
     /* Create print job, if not yet created */
     if (job->bytes_received == 0) {
 
@@ -626,21 +623,11 @@ int guac_rdp_print_job_write(guac_rdp_print_job* job,
      * generic RDP message lock as this may be a lengthy operation that depends
      * on other threads sending outstanding messages (resulting in deadlock if
      * those messages are blocked) */
-    int unlock_status = pthread_mutex_unlock(&(rdp_client->message_lock));
-    int write_status = write(job->input_fd, buffer, length);
-
-    /* Restore RDP message lock state */
-    if (!unlock_status)
-        pthread_mutex_lock(&(rdp_client->message_lock));
-
-    return write_status;
+    return write(job->input_fd, buffer, length);
 
 }
 
 void guac_rdp_print_job_free(guac_rdp_print_job* job) {
-
-    guac_client* client = job->client;
-    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
 
     /* No more input will be provided */
     close(job->input_fd);
@@ -649,12 +636,7 @@ void guac_rdp_print_job_free(guac_rdp_print_job* job) {
      * RDP message lock as this may be a lengthy operation that depends on
      * other threads sending outstanding messages (resulting in deadlock if
      * those messages are blocked) */
-    int unlock_status = pthread_mutex_unlock(&(rdp_client->message_lock));
     pthread_join(job->output_thread, NULL);
-
-    /* Restore RDP message lock state */
-    if (!unlock_status)
-        pthread_mutex_lock(&(rdp_client->message_lock));
 
     /* Destroy lock */
     pthread_mutex_destroy(&(job->state_lock));

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -466,30 +466,6 @@ static int rdp_guac_client_wait_for_messages(guac_client* client,
 }
 
 /**
- * Handles any queued RDP-related events, including inbound RDP messages that
- * have been received, updating the Guacamole display accordingly.
- *
- * @param rdp_client
- *     The guac_rdp_client of the RDP connection whose current messages should
- *     be handled.
- *
- * @return
- *     True (non-zero) if messages were handled successfully, false (zero)
- *     otherwise.
- */
-static int guac_rdp_handle_events(guac_rdp_client* rdp_client) {
-
-    /* Actually handle messages (this may result in drawing to the
-     * guac_display, resizing the display buffer, etc.) */
-    pthread_mutex_lock(&(rdp_client->message_lock));
-    int retval = freerdp_check_event_handles(GUAC_RDP_CONTEXT(rdp_client->rdp_inst));
-    pthread_mutex_unlock(&(rdp_client->message_lock));
-
-    return retval;
-
-}
-
-/**
  * Connects to an RDP server as described by the guac_rdp_settings structure
  * associated with the given client, allocating and freeing all objects
  * directly related to the RDP connection. It is expected that all objects
@@ -614,7 +590,7 @@ static int guac_rdp_handle_connection(guac_client* client) {
 
         /* Handle any queued FreeRDP events (this may result in RDP messages
          * being sent), aborting later if FreeRDP event handling fails */
-        if (!guac_rdp_handle_events(rdp_client))
+        if (!freerdp_check_event_handles(GUAC_RDP_CONTEXT(rdp_client->rdp_inst)))
             wait_result = -1;
 
         /* Test whether the RDP server is closing the connection */
@@ -645,9 +621,7 @@ static int guac_rdp_handle_connection(guac_client* client) {
     }
 
     /* Disconnect client and channels */
-    pthread_mutex_lock(&(rdp_client->message_lock));
     freerdp_disconnect(rdp_inst);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
 
     /* Stop render loop */
     guac_display_render_thread_destroy(rdp_client->render_thread);

--- a/src/protocols/rdp/rdp.h
+++ b/src/protocols/rdp/rdp.h
@@ -189,23 +189,12 @@ typedef struct guac_rdp_client {
     guac_common_list* available_svc;
 
     /**
-     * Common attributes for locks.
-     */
-    pthread_mutexattr_t attributes;
-
-    /**
      * Lock which is used to synchronizes access to RDP data structures
      * between user input and client threads. It prevents input handlers
      * from running when RDP data structures are allocated or freed
      * by the client thread.
      */
     guac_rwlock lock;
-
-    /**
-     * Lock which synchronizes the sending of each RDP message, ensuring
-     * attempts to send RDP messages never overlap.
-     */
-    pthread_mutex_t message_lock;
 
     /**
      * A pointer to the RAIL interface provided by the RDP client when rail is

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -1535,6 +1535,9 @@ void guac_rdp_push_settings(guac_client* client,
     freerdp_settings_set_bool(rdp_settings, FreeRDP_FrameMarkerCommandEnabled, TRUE);
     freerdp_settings_set_bool(rdp_settings, FreeRDP_SurfaceFrameMarkerEnabled, TRUE);
 
+    /* NOTE: FreeRDP 3.x does not provide an explicit setting for asynchronous
+     * input event handling */
+
     /* Enable RemoteFX / Graphics Pipeline */
     if (guac_settings->enable_gfx) {
 


### PR DESCRIPTION
These changes address the following issues mainly affecting the performance of RDP connections:

* Repeated checking of the `ops` lock within the render thread leads to unnecessary contention when `GUAC_DISPLAY_RENDER_THREAD_STATE_FRAME_MODIFIED` is typically signaled frequently within a single frame. We can instead sleep between checks when there is no explicit frame boundary.
* The `message_lock` leads to contention with handling of instructions like "mouse" and "sync", leading to a feedback loop of lag adjustments, but `message_lock` appears to no longer be needed (need to verify this).
* We were erroneously _not_ resetting FreeRDP's invalid region (dirty rect) within the GDI, leading to unnecessary reevaluation of regions of the display that have not changed.

Opening as a draft while checking:

- [ ] Is there anything further we can do to avoid slowdown between individual GDI drawing operations, or is this unavoidable?
- [ ] Is there anything we can do to avoid lag when using FreeRDP 3.x, which apparently does not provide the same `AsyncInput` setting as FreeRDP 2.x?
- [ ] Is it truly safe to completely eliminate the `message_lock` for both FreeRDP 2.x and 3.x?