### PR TITLE
GUACAMOLE-2063: Ensure state flag lock is acquired before checking flag value.

### DIFF
--- a/src/libguac/display-render-thread.c
+++ b/src/libguac/display-render-thread.c
@@ -141,7 +141,8 @@ static void* guac_display_render_loop(void* data) {
             }
 
             /* Use explicit frame boundaries whenever available */
-            if (render_thread->state.value & GUAC_DISPLAY_RENDER_THREAD_STATE_FRAME_READY) {
+            if (guac_flag_timedwait_and_lock(&render_thread->state,
+                        GUAC_DISPLAY_RENDER_THREAD_STATE_FRAME_READY, 0)) {
 
                 rendered_frames = render_thread->frames;
                 render_thread->frames = 0;

--- a/src/libguac/display-render-thread.c
+++ b/src/libguac/display-render-thread.c
@@ -144,7 +144,7 @@ static void* guac_display_render_loop(void* data) {
             if (guac_flag_timedwait_and_lock(&render_thread->state,
                         GUAC_DISPLAY_RENDER_THREAD_STATE_FRAME_READY, 0)) {
 
-                rendered_frames = render_thread->frames;
+                rendered_frames += render_thread->frames;
                 render_thread->frames = 0;
 
                 guac_flag_clear(&render_thread->state,

--- a/src/libguac/flag.c
+++ b/src/libguac/flag.c
@@ -139,6 +139,17 @@ int guac_flag_timedwait_and_lock(guac_flag* event_flag,
 
     guac_flag_lock(event_flag);
 
+    /* Short path: skip wait completely when possible */
+    if (!msec_timeout) {
+
+        int retval = event_flag->value & flags;
+        if (!retval)
+            guac_flag_unlock(event_flag);
+
+        return retval;
+
+    }
+
     struct timespec ts_timeout;
     clock_gettime(CLOCK_MONOTONIC, &ts_timeout);
 


### PR DESCRIPTION
From [the relevant comment in JIRA](https://issues.apache.org/jira/browse/GUACAMOLE-2063?focusedCommentId=17954770&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17954770):

> Part of the fix already committed needs to acquire the proper lock before checking `render_thread->state.value`. As reported by Coverity, the following block of code:
>
> ```c
> /* Use explicit frame boundaries whenever available */
> if (render_thread->state.value & GUAC_DISPLAY_RENDER_THREAD_STATE_FRAME_READY) {
>
>     rendered_frames = render_thread->frames;
>     render_thread->frames = 0;
>
>     guac_flag_clear(&render_thread->state,
>               GUAC_DISPLAY_RENDER_THREAD_STATE_FRAME_READY
>             | GUAC_DISPLAY_RENDER_THREAD_STATE_FRAME_MODIFIED);
>     guac_flag_unlock(&render_thread->state);
>     break;
>
> }
> ```
>
> presumes that the lock for the `render_thread->state` flag has been acquired, yet this isn't the case any longer. The block was moved outside the portion of code that holds the lock.

This change:

* Corrects the handling of the flag comparison, acquiring the lock through `guac_flag_timedwait_and_lock()` instead of checking the flag value directly.
* Optimizes the `guac_flag_timedwait_and_lock()` case where `msec_timeout` is 0, as that's now happening pretty frequently.