### PR TITLE
GUACAMOLE-2077: Immediately flush mouse cursor position updates to connected users.

### DIFF
--- a/src/libguac/display-flush.c
+++ b/src/libguac/display-flush.c
@@ -85,10 +85,12 @@ static void* LFR_guac_display_broadcast_cursor_state(guac_user* user, void* data
     guac_display* display = (guac_display*) data;
 
     /* Send cursor state only if the user is not moving the cursor */
-    if (user != display->last_frame.cursor_user)
+    if (user != display->last_frame.cursor_user) {
         guac_protocol_send_mouse(user->socket,
                 display->last_frame.cursor_x, display->last_frame.cursor_y,
                 display->last_frame.cursor_mask, display->last_frame.timestamp);
+        guac_socket_flush(user->socket);
+    }
 
     return NULL;
 


### PR DESCRIPTION
Without this additional `guac_socket_flush()`, updates to the mouse position are seen by connected users only when the `guac_socket` is incidentally flushed by a frame or accumulation of data.