### PR TITLE
GUACAMOLE-1256: Workaround for the terminal scroll down issue.

### DIFF
--- a/src/terminal/display.c
+++ b/src/terminal/display.c
@@ -258,6 +258,7 @@ guac_terminal_display* guac_terminal_display_alloc(guac_client* client,
     display->width = 0;
     display->height = 0;
     display->operations = NULL;
+    display->unflushed_set = false;
 
     /* Initially nothing selected */
     display->text_selected = false;
@@ -430,6 +431,12 @@ void guac_terminal_display_copy_rows(guac_terminal_display* display,
     guac_terminal_operation* src = &(display->operations[src_offset]);
     guac_terminal_operation* dst = &(display->operations[dst_offset]);
 
+    /* Flush operations if there are any unflushed SET operations. This is
+     * necessary to ensure that the copy operation does not conflict with any
+     * SET operations that may have been performed since the last flush. */
+    if (display->unflushed_set)
+        guac_terminal_display_flush_operations(display);
+
     /* Copy data */
     memmove(dst, src, guac_mem_ckd_mul_or_die(sizeof(guac_terminal_operation),
                 display->width, (end_row - start_row + 1)));
@@ -483,7 +490,7 @@ void guac_terminal_display_set_columns(guac_terminal_display* display, int row,
         /* Flush pending copy operation before adding new SET operation. This
          * avoid operation conflicts that cause inconsistent display. */
         if (current->type == GUAC_CHAR_COPY)
-            guac_terminal_display_flush(display);
+            guac_terminal_display_flush_operations(display);
 
         /* Set operation */
         current->type      = GUAC_CHAR_SET;
@@ -493,6 +500,13 @@ void guac_terminal_display_set_columns(guac_terminal_display* display, int row,
         current += character->width;
 
     }
+
+    /* Marks whether there are unflushed GUAC_CHAR_SET operations when the
+     * operation is not on the first or last row because flushing new lines
+     * added has a high performance cost. This flag is used to determine
+     * whether a flush is necessary before performing copy operations. */
+    if (row > 0 && row < display->height - 1)
+        display->unflushed_set = true;
 
 }
 
@@ -857,6 +871,9 @@ void __guac_terminal_display_flush_set(guac_terminal_display* display) {
 
         }
     }
+
+    /* Mark that all SET operations have been flushed */
+    display->unflushed_set = 0;
 
 }
 void guac_terminal_display_flush_operations(guac_terminal_display* display) {

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -868,15 +868,6 @@ void guac_terminal_scroll_up(guac_terminal* term,
 void guac_terminal_scroll_down(guac_terminal* term,
         int start_row, int end_row, int amount) {
 
-    /*
-     * We must flush all pending operations here because 
-     * guac_terminal_copy_rows will set new GUAC_CHAR_COPY for
-     * cells of shifted rows meanwhile preceding GUAC_CHAR_SET for these cells
-     * are not actually done yet. The GUAC_CHAR_COPY operation has the highest
-     * priority, so if we do not 'flush' here, wrong content will be copied.
-     */
-    guac_terminal_display_flush_operations(term->display);
-
     guac_terminal_copy_rows(term, start_row, end_row - amount, amount);
 
     /* Clear new area */

--- a/src/terminal/terminal/display.h
+++ b/src/terminal/terminal/display.h
@@ -225,6 +225,12 @@ typedef struct guac_terminal_display {
      */
     int selection_end_column;
 
+    /**
+     * Whether there are GUAC_CHAR_SET operations that need to be flushed
+     * to the display.
+     */
+    bool unflushed_set;
+
 } guac_terminal_display;
 
 /**


### PR DESCRIPTION
**Vim** scroll down (i.e. scrolling to the beginning of text) is completely broken. It is annoying. We should call `guac_terminal_display_flush` before `guac_terminal_copy_rows`. Otherwise we have a wrong order of GUAC_CHAR_COPY/GUAC_CHAR_SET operations. I am aware that there was already an attempt to flush at the end of `guac_terminal_scroll_down` but it actually did not work. Then, it was removed as a part of the fix for performance degradation when dumping big text files. I believe `guac_terminal_scroll_down` is not called in that case. It mainly affects going to the beginning of text files using the **UP ARROW** key.