### PR TITLE
GUACAMOLE-1026: Mark FreeRDP 3.x as currently experimental.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ ARG BUILD_JOBS
 # The directory that will house the guacamole-server source during the build 
 ARG BUILD_DIR=/tmp/guacamole-server
 
-# FreeRDP version (default to version 3)
-ARG FREERDP_VERSION=3
+# FreeRDP version (default to version 2)
+ARG FREERDP_VERSION=2
 
 # The final install location for guacamole-server and all dependencies. NOTE:
 # This value is hard-coded in the entrypoint. Any change to this value must be

--- a/configure.ac
+++ b/configure.ac
@@ -738,6 +738,18 @@ OLDCPPFLAGS="$CPPFLAGS"
 
 if test "x$with_rdp" != "xno"
 then
+    freerdp_version="(2.x)"
+    have_freerdp=yes
+    PKG_CHECK_MODULES([RDP], [freerdp2 freerdp-client2 winpr2],
+                      [CPPFLAGS="${RDP_CFLAGS} -Werror $CPPFLAGS"]
+                      [AS_IF([test "x${FREERDP_PLUGIN_DIR}" = "x"],
+                             [FREERDP_PLUGIN_DIR="`$PKG_CONFIG --variable=libdir freerdp2`/freerdp2"])],
+                      [freerdp_version=
+                       have_freerdp=no])
+fi
+
+if test "x$with_rdp" != "xno" -a "x${have_freerdp}" = "xno"
+then
     freerdp_version="(3.x)"
     have_freerdp=yes
     PKG_CHECK_MODULES([RDP], [freerdp3 freerdp-client3 winpr3],
@@ -746,25 +758,10 @@ then
                              [FREERDP_PLUGIN_DIR="`$PKG_CONFIG --variable=libdir freerdp3`/freerdp3"])],
                       [AC_MSG_WARN([
   --------------------------------------------
-   Unable to find FreeRDP3 (libfreerdp3 / libfreerdp-client3 / libwinpr3).
-   Checking for FreeRDP2.
-  --------------------------------------------])
-                       have_freerdp=no])
-fi
-
-if test "x$with_rdp" != "xno" -a "x${have_freerdp}" = "xno"
-then
-    freerdp_version="(2.x)"
-    have_freerdp=yes
-    PKG_CHECK_MODULES([RDP], [freerdp2 freerdp-client2 winpr2],
-                      [CPPFLAGS="${RDP_CFLAGS} -Werror $CPPFLAGS"]
-                      [AS_IF([test "x${FREERDP_PLUGIN_DIR}" = "x"],
-                             [FREERDP_PLUGIN_DIR="`$PKG_CONFIG --variable=libdir freerdp2`/freerdp2"])],
-                      [AC_MSG_WARN([
-  --------------------------------------------
-   Unable to find FreeRDP2 (libfreerdp2 / libfreerdp-client2 / libwinpr2)
+   Unable to find FreeRDP.
    RDP will be disabled.
   --------------------------------------------])
+                       freerdp_version=
                        have_freerdp=no])
 fi
 
@@ -1540,3 +1537,12 @@ $PACKAGE_NAME version $PACKAGE_VERSION
 
 Type \"make\" to compile $PACKAGE_NAME.
 "
+
+if test "x$freerdp_version" = "x(3.x)"
+then
+    AC_MSG_WARN([
+  --------------------------------------------
+    Support for FreeRDP 3.x is currently experimental. Some features, like
+    RemoteApp, have known issues. If not testing, consider using FreeRDP 2.x.
+  --------------------------------------------])
+fi


### PR DESCRIPTION
This change alters the guacamole-server build such that it prefers FreeRDP 2.x and warns that support for 3.x is currently experimental if only 3.x is available.

The Docker build has also been modified to install FreeRDP 2.x instead of 3.x.