### PR TITLE
GUACAMOLE-377: Handle the NOP plan operation entirely in the display …

### DIFF
--- a/src/libguac/display-plan.c
+++ b/src/libguac/display-plan.c
@@ -415,10 +415,6 @@ void guac_display_plan_apply(guac_display_plan* plan) {
 
                 break;
 
-            /* Simply ignore and drop NOP */
-            case GUAC_DISPLAY_PLAN_OPERATION_NOP:
-                break;
-
             /* All other operations should be handled by the workers */
             default:
                 guac_fifo_enqueue(&display->ops, op);


### PR DESCRIPTION
This avoids having pending operations ignored, which can lead to delayed display (linked to https://github.com/apache/guacamole-server/pull/584 changes).
See the discussion in this thread: https://lists.apache.org/thread/831qnzw5wkkj1rrz3tr9r6l0y5cm6kdn

Maybe it can wait until 1.6.1, I'm not sure the impact will be significant.
