### PR TITLE
GUACAMOLE-2113: Improve warning when WoL is enabled but no MAC address is provided

### DIFF
--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -1331,8 +1331,8 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
         
         /* If WoL has been requested but no MAC address given, log a warning. */
         if(strcmp(argv[IDX_WOL_MAC_ADDR], "") == 0) {
-            guac_user_log(user, GUAC_LOG_WARNING, "WoL requested, but no MAC "
-                    "address specified.  WoL will not be sent.");
+            guac_user_log(user, GUAC_LOG_WARNING, "WoL was enabled, but no "
+                    "MAC address was provided. WoL will not be sent.");
             settings->wol_send_packet = 0;
         }
         

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -1331,7 +1331,7 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
         
         /* If WoL has been requested but no MAC address given, log a warning. */
         if(strcmp(argv[IDX_WOL_MAC_ADDR], "") == 0) {
-            guac_user_log(user, GUAC_LOG_WARNING, "WoL requested but no MAC ",
+            guac_user_log(user, GUAC_LOG_WARNING, "WoL requested, but no MAC "
                     "address specified.  WoL will not be sent.");
             settings->wol_send_packet = 0;
         }

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -574,7 +574,7 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
         
         if (strcmp(argv[IDX_WOL_MAC_ADDR], "") == 0) {
             guac_user_log(user, GUAC_LOG_WARNING, "WoL was enabled, but no "
-                    "MAC address was provide.  WoL will not be sent.");
+                    "MAC address was provided. WoL will not be sent.");
             settings->wol_send_packet = false;
         }
         

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -573,7 +573,7 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
     if (settings->wol_send_packet) {
         
         if (strcmp(argv[IDX_WOL_MAC_ADDR], "") == 0) {
-            guac_user_log(user, GUAC_LOG_WARNING, "WoL was enabled, but no ",
+            guac_user_log(user, GUAC_LOG_WARNING, "WoL was enabled, but no "
                     "MAC address was provide.  WoL will not be sent.");
             settings->wol_send_packet = false;
         }

--- a/src/protocols/telnet/settings.c
+++ b/src/protocols/telnet/settings.c
@@ -539,8 +539,8 @@ guac_telnet_settings* guac_telnet_parse_args(guac_user* user,
         
         /* If WoL has been enabled but no MAC provided, log warning and disable. */
         if(strcmp(argv[IDX_WOL_MAC_ADDR], "") == 0) {
-            guac_user_log(user, GUAC_LOG_WARNING, "Wake on LAN was requested, "
-                    "but no MAC address was specified.  WoL will not be sent.");
+            guac_user_log(user, GUAC_LOG_WARNING, "WoL was enabled, but no "
+                    "MAC address was provided. WoL will not be sent.");
             settings->wol_send_packet = false;
         }
         

--- a/src/protocols/telnet/settings.c
+++ b/src/protocols/telnet/settings.c
@@ -539,7 +539,7 @@ guac_telnet_settings* guac_telnet_parse_args(guac_user* user,
         
         /* If WoL has been enabled but no MAC provided, log warning and disable. */
         if(strcmp(argv[IDX_WOL_MAC_ADDR], "") == 0) {
-            guac_user_log(user, GUAC_LOG_WARNING, "Wake on LAN was requested, ",
+            guac_user_log(user, GUAC_LOG_WARNING, "Wake on LAN was requested, "
                     "but no MAC address was specified.  WoL will not be sent.");
             settings->wol_send_packet = false;
         }

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -698,8 +698,8 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
         
         /* If WoL has been enabled but no MAC provided, log warning and disable. */
         if(strcmp(argv[IDX_WOL_MAC_ADDR], "") == 0) {
-            guac_user_log(user, GUAC_LOG_WARNING, "Wake on LAN was requested, "
-                    "but no MAC address was specified.  WoL will not be sent.");
+            guac_user_log(user, GUAC_LOG_WARNING, "WoL was enabled, but no "
+                    "MAC address was provided. WoL will not be sent.");
             settings->wol_send_packet = false;
         }
         

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -698,7 +698,7 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
         
         /* If WoL has been enabled but no MAC provided, log warning and disable. */
         if(strcmp(argv[IDX_WOL_MAC_ADDR], "") == 0) {
-            guac_user_log(user, GUAC_LOG_WARNING, "Wake on LAN was requested, ",
+            guac_user_log(user, GUAC_LOG_WARNING, "Wake on LAN was requested, "
                     "but no MAC address was specified.  WoL will not be sent.");
             settings->wol_send_packet = false;
         }


### PR DESCRIPTION
Proposed fix for [GUACAMOLE-2113](https://issues.apache.org/jira/browse/GUACAMOLE-2113)

- Removed extra comma(,) in guac_user_log function calls so that the full message is logged.
- Added a comma for clarity with in the log message for RDP.

Results after local testing:
```
For VNC
guacd[273689]: WARNING: Wake on LAN was requested, but no MAC address was specified.  WoL will not be sent.

For SSH
guacd[299356]: WARNING: WoL was enabled, but no MAC address was provided.  WoL will not be sent.

For Telnet
guacd[298001]: WARNING: Wake on LAN was requested, but no MAC address was specified.  WoL will not be sent.

For RDP
guacd[299506]: WARNING: WoL requested, but no MAC address specified.  WoL will not be sent.
```