### PR TITLE
GUACAMOLE-2117: Improvements to terminal selection behavior.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1435,6 +1435,7 @@ AC_CONFIG_FILES([Makefile
                  src/common-ssh/Makefile
                  src/common-ssh/tests/Makefile
                  src/terminal/Makefile
+                 src/terminal/tests/Makefile
                  src/libguac/Makefile
                  src/libguac/tests/Makefile
                  src/guacd/Makefile

--- a/src/terminal/.gitignore
+++ b/src/terminal/.gitignore
@@ -1,0 +1,5 @@
+
+# Auto-generated test runner and binary
+_generated_runner.c
+test_terminal
+

--- a/src/terminal/Makefile.am
+++ b/src/terminal/Makefile.am
@@ -27,6 +27,7 @@ AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES = libguac-terminal.la
+SUBDIRS = . tests
 
 libguac_terminalincdir = $(includedir)/guacamole/terminal
 
@@ -40,6 +41,7 @@ noinst_HEADERS =                 \
     terminal/palette.h           \
     terminal/scrollbar.h         \
     terminal/select.h            \
+    terminal/selection-point.h   \
     terminal/terminal-priv.h     \
     terminal/terminal-handlers.h \
     terminal/types.h             \
@@ -59,6 +61,7 @@ libguac_terminal_la_SOURCES =   \
     palette.c                   \
     scrollbar.c                 \
     select.c                    \
+    selection-point.c           \
     terminal.c                  \
     terminal-handlers.c         \
     terminal-stdin-stream.c     \

--- a/src/terminal/selection-point.c
+++ b/src/terminal/selection-point.c
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "terminal/selection-point.h"
+
+#include <stdbool.h>
+
+bool guac_terminal_selection_point_is_after(
+    const guac_terminal_selection_point *a,
+    const guac_terminal_selection_point *b) {
+
+    if (a->row == b->row) {
+        if (a->column == b->column) {
+            if (a->side == b->side) {
+                /* If two points are the same, neither is after the other */
+                return false;
+            }
+            /* If points differ by side, a is after b if it's on the right */
+            return a->side == GUAC_TERMINAL_COLUMN_SIDE_RIGHT;
+
+        }
+        /* If points differ by column, a is after b if it's column is larger */
+        return a->column > b->column;
+
+    }
+    /* If points differ by row, a is after b if it's row is larger */
+    return a->row > b->row;
+
+}
+
+bool guac_terminal_selection_points_enclose_text(
+    const guac_terminal_selection_point *start,
+    const guac_terminal_selection_point *end) {
+    
+    /* Different rows will always contain a character */
+    if (start->row != end->row) {
+        return true;
+    }
+
+    /* First check if the starting point completely contains a character */
+    int start_char_end = start->char_starting_column + start->char_width - 1;
+    if ((start->side == GUAC_TERMINAL_COLUMN_SIDE_LEFT &&
+        start->column == start->char_starting_column) &&
+        ((end->column > start_char_end) ||
+         (end->column == start_char_end && end->side == GUAC_TERMINAL_COLUMN_SIDE_RIGHT)))
+        return true;
+
+    /* Otherwise check the next character after start */
+    int end_char_end = end->char_starting_column + end->char_width - 1;
+    int second_char_start = start_char_end + 1;
+    if (second_char_start < end->char_starting_column ||
+        (second_char_start == end->char_starting_column &&
+        end->column == end_char_end && end->side == GUAC_TERMINAL_COLUMN_SIDE_RIGHT))
+        return true;
+
+    return false;
+
+}
+
+int guac_terminal_selection_point_round_up(
+    const guac_terminal_selection_point *point) {
+
+    if (point->column == point->char_starting_column &&
+        point->side == GUAC_TERMINAL_COLUMN_SIDE_LEFT)
+        return point->column;
+    
+    return point->char_starting_column + point->char_width;
+}
+
+int guac_terminal_selection_point_round_down(
+    const guac_terminal_selection_point *point) {
+
+    int end_char_column = point->char_starting_column + point->char_width - 1;
+    if (point->column == end_char_column &&
+        point->side == GUAC_TERMINAL_COLUMN_SIDE_RIGHT)
+        return end_char_column;
+    
+    return point->char_starting_column - 1;
+}

--- a/src/terminal/terminal/select.h
+++ b/src/terminal/terminal/select.h
@@ -27,6 +27,7 @@
  */
 
 #include "terminal.h"
+#include "selection-point.h"
 
 #include <stdbool.h>
 
@@ -59,8 +60,12 @@ void guac_terminal_select_redraw(guac_terminal* terminal);
  * @param column
  *     The column number of the character at the start of the text selection,
  *     where the first (left-most) column in the terminal is column 0.
+ * 
+ * @param side
+ *      Which specific side of the column are we starting on.
  */
-void guac_terminal_select_start(guac_terminal* terminal, int row, int column);
+void guac_terminal_select_start(guac_terminal* terminal, int row, int column,
+        guac_terminal_column_side side);
 
 /**
  * Updates the end of text selection at the given row and column. This function
@@ -80,8 +85,12 @@ void guac_terminal_select_start(guac_terminal* terminal, int row, int column);
  *     The column number of the character at the current end of the text
  *     selection, where the first (left-most) column in the terminal is
  *     column 0.
+ * 
+ * @param side
+ *      Which specific side of the column are we selecting to.
  */
-void guac_terminal_select_update(guac_terminal* terminal, int row, int column);
+void guac_terminal_select_update(guac_terminal* terminal, int row, int column,
+        guac_terminal_column_side side);
 
 /**
  * Resumes selecting text, expanding the existing selected region from the
@@ -101,9 +110,12 @@ void guac_terminal_select_update(guac_terminal* terminal, int row, int column);
  * @param column
  *     The column number of the character to include within the text selection,
  *     where the first (left-most) column in the terminal is column 0.
+ * 
+ * @param side
+ *      Which specific side of the column to resume selecting from.
  */
-void guac_terminal_select_resume(guac_terminal* terminal, int row, int column);
-
+void guac_terminal_select_resume(guac_terminal* terminal, int row, int column,
+        guac_terminal_column_side side);
 /**
  * Ends text selection, removing any highlight and storing the selected
  * character data within the clipboard associated with the given terminal. If

--- a/src/terminal/terminal/selection-point.h
+++ b/src/terminal/terminal/selection-point.h
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GUAC_TERMINAL_SELECTION_POINT_H
+#define GUAC_TERMINAL_SELECTION_POINT_H
+
+/**
+ * Function definitions related to selection points in the terminal.
+ *
+ * @file selection-point.h
+ */
+
+#include <stdbool.h>
+
+/**
+ * Specific side of a terminal column.
+ */
+typedef enum guac_terminal_column_side {
+
+    /**
+     * Left side of the column.
+     */
+    GUAC_TERMINAL_COLUMN_SIDE_LEFT,
+
+    /**
+     * Right side of the column.
+     */
+    GUAC_TERMINAL_COLUMN_SIDE_RIGHT
+
+} guac_terminal_column_side;
+
+/**
+ * A reference to a specific point within a terminal window,
+ * with additional data about the charater pointed to.
+ */
+typedef struct guac_terminal_selection_point {
+
+    /**
+     * The row value of the pointer.
+     */
+    int row;
+
+    /**
+     * The column value of the pointer.
+     */
+    int column;
+
+    /**
+     * The specific side of the column pointed to
+     */
+    guac_terminal_column_side side;
+
+    /**
+     * The starting column of the character pointed to
+     */
+    int char_starting_column;
+
+    /**
+     * The width of the character pointed to
+     */
+    int char_width;
+
+} guac_terminal_selection_point;
+
+/**
+ * Determine if a point comes after another. This uses the right-to-left
+ * language convention, so a point is considered coming after if it is
+ * further right or down from the original point.
+ *
+ * @param a
+ *     Point being tested.
+ *
+ * @param b
+ *     Point being compared to.
+ *     
+ * @return
+ *     True if point a comes after b, false otherwise.
+ */
+bool guac_terminal_selection_point_is_after(
+    const guac_terminal_selection_point *a,
+    const guac_terminal_selection_point *b);
+
+/**
+ * Determine if two points enclose at least one character. 
+ * Enclosing is defined as a range stretching from the 
+ * furthest left to furthest right of any character.
+ * 
+ * This function assumes that start comes before end, otherwise
+ * behavior is undefined.
+ *
+ * @param start
+ *     Starting point of the range.
+ *
+ * @param end
+ *     Ending point of the range.
+ *     
+ * @return
+ *     True if range from start to end contains at least
+ *     one complete character, false otherwise.
+ */
+bool guac_terminal_selection_points_enclose_text(
+    const guac_terminal_selection_point *start,
+    const guac_terminal_selection_point *end);
+
+/**
+ * Produce a rounded column value based on the position 
+ * of the point within the character. This means if we are
+ * anywhere except the furthest left spot in the character,
+ * we will return the starting column for the next character.
+ *
+ * @param point
+ *     Point to round up.
+ *
+ * @return
+ *     Column value for the start of the selection.
+ */
+int guac_terminal_selection_point_round_up(
+    const guac_terminal_selection_point *point);
+
+/**
+ * Produce a rounded column value based on the position 
+ * of the point within the character. This means if we are
+ * anywhere except the furthest right spot in the character,
+ * we will return the ending column for the previous character.
+ *
+ * @param point
+ *     Point to round down.
+ *
+ * @return
+ *     Column value for the end of the selection.
+ */
+int guac_terminal_selection_point_round_down(
+    const guac_terminal_selection_point *point);
+
+#endif

--- a/src/terminal/terminal/terminal-priv.h
+++ b/src/terminal/terminal/terminal-priv.h
@@ -27,6 +27,7 @@
 #include "scrollbar.h"
 #include "terminal.h"
 #include "typescript.h"
+#include "selection-point.h"
 
 #include <guacamole/flag.h>
 
@@ -366,34 +367,34 @@ struct guac_terminal {
     bool selection_committed;
 
     /**
-     * The row that the selection starts at.
+     * The starting point of a selection
+     */
+    guac_terminal_selection_point selection_start;
+
+    /**
+     * The normalized row that the selection starts at.
      */
     int selection_start_row;
 
     /**
-     * The column that the selection starts at.
+     * The normalized column that the selection starts at.
      */
     int selection_start_column;
 
     /**
-     * The width of the character at selection start.
+     * The ending point of a selection
      */
-    int selection_start_width;
+    guac_terminal_selection_point selection_end;
 
     /**
-     * The row that the selection ends at.
+     * The normalized row that the selection ends at.
      */
     int selection_end_row;
 
     /**
-     * The column that the selection ends at.
+     * The normalized column that the selection ends at.
      */
     int selection_end_column;
-
-    /**
-     * The width of the character at selection end.
-     */
-    int selection_end_width;
 
     /**
      * Whether the cursor (arrow) keys should send cursor sequences

--- a/src/terminal/tests/Makefile.am
+++ b/src/terminal/tests/Makefile.am
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# NOTE: Parts of this file (Makefile.am) are automatically transcluded verbatim
+# into Makefile.in. Though the build system (GNU Autotools) automatically adds
+# its own license boilerplate to the generated Makefile.in, that boilerplate
+# does not apply to the transcluded portions of Makefile.am which are licensed
+# to you by the ASF under the Apache License, Version 2.0, as described above.
+#
+
+AUTOMAKE_OPTIONS = foreign 
+ACLOCAL_AMFLAGS = -I m4
+
+#
+# Unit tests for terminal 
+#
+
+check_PROGRAMS = test_terminal
+TESTS = $(check_PROGRAMS)
+
+test_terminal_SOURCES =            \
+    selection-point/enclose-text.c \
+    selection-point/point-after.c  \
+    selection-point/rounding.c
+
+test_terminal_CFLAGS =      \
+    -Werror -Wall -pedantic \
+    @TERMINAL_INCLUDE@
+
+test_terminal_LDADD =  \
+    @CUNIT_LIBS@       \
+    @TERMINAL_LTLIB@
+
+#
+# Autogenerate test runner
+#
+
+GEN_RUNNER = $(top_srcdir)/util/generate-test-runner.pl
+CLEANFILES = _generated_runner.c
+
+_generated_runner.c: $(test_terminal_SOURCES)
+	$(AM_V_GEN) $(GEN_RUNNER) $(test_terminal_SOURCES) > $@
+
+nodist_test_terminal_SOURCES = \
+    _generated_runner.c
+
+# Use automake's TAP test driver for running any tests
+LOG_DRIVER =                \
+    env AM_TAP_AWK='$(AWK)' \
+    $(SHELL) $(top_srcdir)/build-aux/tap-driver.sh
+

--- a/src/terminal/tests/selection-point/enclose-text.c
+++ b/src/terminal/tests/selection-point/enclose-text.c
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "terminal/selection-point.h"
+
+#include <CUnit/CUnit.h>
+#include <stdlib.h>
+
+/**
+ * Verifies that guac_terminal_selection_points_enclose_text() correctly 
+ * calculates if the range contains a full character.
+ */
+void test_selection_point__enclose_text() {
+
+    guac_terminal_selection_point a = {
+        .column = 1,
+        .row = 1,
+        .side = GUAC_TERMINAL_COLUMN_SIDE_LEFT,
+        .char_starting_column = 1,
+        .char_width = 1
+    };
+    guac_terminal_selection_point b = {
+        .column = 1,
+        .row = 1,
+        .side = GUAC_TERMINAL_COLUMN_SIDE_LEFT,
+        .char_starting_column = 1,
+        .char_width = 1
+    };
+
+    CU_ASSERT(!guac_terminal_selection_points_enclose_text(&a, &b));
+
+    b.side = GUAC_TERMINAL_COLUMN_SIDE_RIGHT;
+    CU_ASSERT(guac_terminal_selection_points_enclose_text(&a, &b));
+
+    a.side = GUAC_TERMINAL_COLUMN_SIDE_RIGHT;
+    CU_ASSERT(!guac_terminal_selection_points_enclose_text(&a, &b));
+
+    b.column = 2;
+    b.char_starting_column = 2;
+    b.side = GUAC_TERMINAL_COLUMN_SIDE_LEFT;
+    CU_ASSERT(!guac_terminal_selection_points_enclose_text(&a, &b));
+
+    b.side = GUAC_TERMINAL_COLUMN_SIDE_RIGHT;
+    CU_ASSERT(guac_terminal_selection_points_enclose_text(&a, &b));
+
+    b.column = 3;
+    b.char_starting_column = 3;
+    b.side = GUAC_TERMINAL_COLUMN_SIDE_LEFT;
+    CU_ASSERT(guac_terminal_selection_points_enclose_text(&a, &b));
+
+}
+
+/**
+ * Verifies that guac_terminal_selection_points_enclose_text() correctly 
+ * calculates if the range contains a full character with wide characters.
+ */
+void test_selection_point__enclose_wide_text() {
+
+    guac_terminal_selection_point a = {
+        .column = 1,
+        .row = 1,
+        .side = GUAC_TERMINAL_COLUMN_SIDE_LEFT,
+        .char_starting_column = 1,
+        .char_width = 2 
+    };
+    guac_terminal_selection_point b = {
+        .column = 1,
+        .row = 1,
+        .side = GUAC_TERMINAL_COLUMN_SIDE_LEFT,
+        .char_starting_column = 1,
+        .char_width = 2 
+    };
+
+    /* Check point within a single character */
+    CU_ASSERT(!guac_terminal_selection_points_enclose_text(&a, &b));
+
+    b.side = GUAC_TERMINAL_COLUMN_SIDE_RIGHT;
+    CU_ASSERT(!guac_terminal_selection_points_enclose_text(&a, &b));
+
+    b.column = 2;
+    b.side = GUAC_TERMINAL_COLUMN_SIDE_LEFT;
+    CU_ASSERT(!guac_terminal_selection_points_enclose_text(&a, &b));
+
+    b.side = GUAC_TERMINAL_COLUMN_SIDE_RIGHT;
+    CU_ASSERT(guac_terminal_selection_points_enclose_text(&a, &b));
+
+    /* Check with points on neighboring characters */
+    b.column = 3;
+    b.char_starting_column = 3;
+    CU_ASSERT(guac_terminal_selection_points_enclose_text(&a, &b));
+
+    a.side = GUAC_TERMINAL_COLUMN_SIDE_RIGHT;
+    CU_ASSERT(!guac_terminal_selection_points_enclose_text(&a, &b));
+
+    a.column = 2;
+    a.side = GUAC_TERMINAL_COLUMN_SIDE_LEFT;
+    CU_ASSERT(!guac_terminal_selection_points_enclose_text(&a, &b));
+
+    a.side = GUAC_TERMINAL_COLUMN_SIDE_RIGHT;
+    CU_ASSERT(!guac_terminal_selection_points_enclose_text(&a, &b));
+
+    b.column = 4;
+    b.side = GUAC_TERMINAL_COLUMN_SIDE_LEFT;
+    CU_ASSERT(!guac_terminal_selection_points_enclose_text(&a, &b));
+
+    b.side = GUAC_TERMINAL_COLUMN_SIDE_RIGHT;
+    CU_ASSERT(guac_terminal_selection_points_enclose_text(&a, &b));
+
+}

--- a/src/terminal/tests/selection-point/point-after.c
+++ b/src/terminal/tests/selection-point/point-after.c
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "terminal/selection-point.h"
+
+#include <CUnit/CUnit.h>
+#include <stdlib.h>
+
+/**
+ * Verifies that guac_terminal_selection_point_is_after() correctly
+ * determins the order of two points.
+ */
+void test_selection_point__is_point_after() {
+
+    guac_terminal_selection_point a = {
+        .column = 1,
+        .row = 1,
+        .side = GUAC_TERMINAL_COLUMN_SIDE_LEFT,
+    };
+    guac_terminal_selection_point b = {
+        .column = 1,
+        .row = 1,
+        .side = GUAC_TERMINAL_COLUMN_SIDE_LEFT,
+    };
+
+    /* a and b are the same, so neither are after the other */
+    CU_ASSERT(!guac_terminal_selection_point_is_after(&a, &b));
+    CU_ASSERT(!guac_terminal_selection_point_is_after(&b, &a));
+
+    /* b is after a but with same column */
+    b.side = GUAC_TERMINAL_COLUMN_SIDE_RIGHT;
+    CU_ASSERT(!guac_terminal_selection_point_is_after(&a, &b));
+    CU_ASSERT(guac_terminal_selection_point_is_after(&b, &a));
+
+    /* b is after a but with different columns */
+    b.column = 2;
+    CU_ASSERT(!guac_terminal_selection_point_is_after(&a, &b));
+    CU_ASSERT(guac_terminal_selection_point_is_after(&b, &a));
+
+}

--- a/src/terminal/tests/selection-point/rounding.c
+++ b/src/terminal/tests/selection-point/rounding.c
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "terminal/selection-point.h"
+
+#include <CUnit/CUnit.h>
+#include <stdlib.h>
+
+/**
+ * Verifies that guac_terminal_selection_point_round_down() and
+ * guac_terminal_selection_point_round_up() both correctly
+ * calculate normalized column values for a point.
+ */
+void test_selection_point__rounding() {
+
+    guac_terminal_selection_point a = {
+        .column = 1,
+        .row = 1,
+        .side = GUAC_TERMINAL_COLUMN_SIDE_LEFT,
+        .char_starting_column = 1,
+        .char_width = 1
+    };
+   
+    CU_ASSERT_EQUAL(0, guac_terminal_selection_point_round_down(&a));
+    CU_ASSERT_EQUAL(1, guac_terminal_selection_point_round_up(&a));
+
+    a.side = GUAC_TERMINAL_COLUMN_SIDE_RIGHT;
+    CU_ASSERT_EQUAL(1, guac_terminal_selection_point_round_down(&a));
+    CU_ASSERT_EQUAL(2, guac_terminal_selection_point_round_up(&a));
+
+}
+
+/**
+ * Verifies that guac_terminal_selection_point_round_down() and
+ * guac_terminal_selection_point_round_up() both correctly
+ * calculate normalized column values for points with wide characters.
+ */
+void test_selection_point__rounding_wide() {
+
+    guac_terminal_selection_point a = {
+        .column = 1,
+        .row = 1,
+        .side = GUAC_TERMINAL_COLUMN_SIDE_LEFT,
+        .char_starting_column = 1,
+        .char_width = 2 
+    };
+   
+    CU_ASSERT_EQUAL(0, guac_terminal_selection_point_round_down(&a));
+    CU_ASSERT_EQUAL(1, guac_terminal_selection_point_round_up(&a));
+
+    a.side = GUAC_TERMINAL_COLUMN_SIDE_RIGHT;
+    CU_ASSERT_EQUAL(0, guac_terminal_selection_point_round_down(&a));
+    CU_ASSERT_EQUAL(3, guac_terminal_selection_point_round_up(&a));
+
+    a.side = GUAC_TERMINAL_COLUMN_SIDE_LEFT;
+    a.column = 2;
+    CU_ASSERT_EQUAL(0, guac_terminal_selection_point_round_down(&a));
+    CU_ASSERT_EQUAL(3, guac_terminal_selection_point_round_up(&a));
+
+    a.side = GUAC_TERMINAL_COLUMN_SIDE_RIGHT;
+    CU_ASSERT_EQUAL(2, guac_terminal_selection_point_round_down(&a));
+    CU_ASSERT_EQUAL(3, guac_terminal_selection_point_round_up(&a));
+
+}


### PR DESCRIPTION
Proposing changes to the selection behavior in the terminal emulator.

1. Require that a you fully drag across a character to select it.  Should help eliminate inadvertent sections when simply clicking around.
2. By dragging back to original point where selection started, you can effectively cancel the selection.