### PR TITLE
GUACAMOLE-2107: Fix the error handling within the guac_tcp_connect() function.

### DIFF
--- a/src/libguac/tcp.c
+++ b/src/libguac/tcp.c
@@ -25,6 +25,7 @@
 #include <fcntl.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <string.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -50,7 +51,7 @@ int guac_tcp_connect(const char* hostname, const char* port, const int timeout) 
     if ((retval = getaddrinfo(hostname, port, &hints, &addresses))) {
         guac_error = GUAC_STATUS_INVALID_ARGUMENT;
         guac_error_message = "Error parsing address or port.";
-        return retval;
+        return -1;
     }
 
     /* Attempt connection to each address until success */
@@ -83,6 +84,7 @@ int guac_tcp_connect(const char* hostname, const char* port, const int timeout) 
             guac_error = GUAC_STATUS_INVALID_ARGUMENT;
             guac_error_message = "Failed to retrieve socket options.";
             close(fd);
+            fd = -1;
             continue;
         }
 
@@ -91,6 +93,7 @@ int guac_tcp_connect(const char* hostname, const char* port, const int timeout) 
             guac_error = GUAC_STATUS_INVALID_ARGUMENT;
             guac_error_message = "Failed to set non-blocking socket.";
             close(fd);
+            fd = -1;
             continue;
         }
 
@@ -108,12 +111,46 @@ int guac_tcp_connect(const char* hostname, const char* port, const int timeout) 
                 FD_SET(fd, &fdset);
                 
                 retval = select(fd + 1, NULL, &fdset, NULL, &tv);
+
+                if (retval > 0) {
+                    int so_error = 0;
+                    socklen_t so_error_len = sizeof(so_error);
+                    retval = getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &so_error_len);
+
+                    // Error occurs retrieving the socket status, so we set it
+                    // and move on.
+                    if (retval < 0) {
+                        guac_error = GUAC_STATUS_INVALID_ARGUMENT;
+                        guac_error_message = "Failed to retrieve socket status.";
+                        close(fd);
+                        fd = -1;
+                        continue;
+                    }
+                    
+                    // This indicates that the connection is successful, so we
+                    // break so that the socket can be immediately returned.
+                    if (so_error == 0) {
+                        break;
+                    }
+
+                    // There's a socket error, so we retrieve it and move to 
+                    // the next address.
+                    else {
+                        guac_error = GUAC_STATUS_REFUSED;
+                        guac_error_message = strerror(so_error);
+                        close(fd);
+                        fd = -1;
+                        continue;
+                    }
+                }
+
             }
             
             else {
                 guac_error = GUAC_STATUS_REFUSED;
                 guac_error_message = "Unable to connect via socket.";
                 close(fd);
+                fd = -1;
                 continue;
             }
         }
@@ -125,6 +162,7 @@ int guac_tcp_connect(const char* hostname, const char* port, const int timeout) 
                 guac_error = GUAC_STATUS_INVALID_ARGUMENT;
                 guac_error_message = "Failed to reset socket options.";
                 close(fd);
+                fd = -1;
                 continue;
             }
 
@@ -142,7 +180,7 @@ int guac_tcp_connect(const char* hostname, const char* port, const int timeout) 
 
         /* Some error has occurred - free resources before next iteration. */
         close(fd);
-
+        fd = -1;
     }
 
     /* Free addrinfo */
@@ -152,6 +190,7 @@ int guac_tcp_connect(const char* hostname, const char* port, const int timeout) 
     if (current_address == NULL) {
         guac_error = GUAC_STATUS_REFUSED;
         guac_error_message = "Unable to connect to remote host.";
+        fd = -1;
     }
 
     /* Return the fd, or the error message if the socket connection failed. */


### PR DESCRIPTION
This pull request makes a couple of changes within the `guac_tcp_connect()` function that correct issues that cause the Wake-on-LAN functionality to break, and probably also break other protocols that rely on this function:
* The function returned either the socket that was connected, or various error codes from other calls to functions like `connect()`, `select()`, etc. The callers of `guac_tcp_connect()` rely on the return value being either a socket or a negative integer upon failure, so I've updated many of the instances of the `fd` variable that might get returned to be -1 in the instances where it would be returned.
* The simple call to the `select()` function for waiting for a timeout when attempting to connect to a non-blocking socket requires a bit more checking to see if it has succeeded or failed, which involves querying the socket with `getsockopt()` and looking at the error message.