### PR TITLE
GUACAMOLE-2072: RAIL plugin should be loaded in the LoadPlugins callback.

### DIFF
--- a/src/protocols/rdp/channels/rail.c
+++ b/src/protocols/rdp/channels/rail.c
@@ -64,24 +64,6 @@ static UINT guac_rdp_rail_complete_handshake(RailClientContext* rail) {
     guac_client* client = (guac_client*) rail->custom;
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
 
-    RAIL_HANDSHAKE_ORDER handshake = {
-
-        /* Build number 7600 (0x1DB0) apparently represents Windows 7 and
-         * compatibility with RDP 7.0. As of this writing, this is the same
-         * build number sent for RAIL connections by xfreerdp. */
-        .buildNumber = 7600
-
-    };
-
-    /* Send client handshake response */
-    guac_client_log(client, GUAC_LOG_TRACE, "Sending RAIL handshake.");
-    pthread_mutex_lock(&(rdp_client->message_lock));
-    status = rail->ClientHandshake(rail, &handshake);
-    pthread_mutex_unlock(&(rdp_client->message_lock));
-
-    if (status != CHANNEL_RC_OK)
-        return status;
-
     RAIL_CLIENT_STATUS_ORDER client_status = {
         .flags =
                 TS_RAIL_CLIENTSTATUS_ALLOWLOCALMOVESIZE

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -100,6 +100,20 @@ static BOOL rdp_freerdp_load_channels(freerdp* instance) {
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
     guac_rdp_settings* settings = rdp_client->settings;
 
+    /* Load RAIL plugin if RemoteApp in use */
+    if (settings->remote_app != NULL)
+        guac_rdp_rail_load_plugin(context);
+
+    /* Load SVC plugin instances for all static channels */
+    if (settings->svc_names != NULL) {
+
+        char** current = settings->svc_names;
+        do {
+            guac_rdp_pipe_svc_load_plugin(context, *current);
+        } while (*(++current) != NULL);
+
+    }
+
     /* Load "disp" plugin for display update */
     if (settings->resize_method == GUAC_RESIZE_DISPLAY_UPDATE)
         guac_rdp_disp_load_plugin(context);
@@ -177,20 +191,6 @@ static BOOL rdp_freerdp_pre_connect(freerdp* instance) {
 
     /* Init FreeRDP add-in provider */
     freerdp_register_addin_provider(freerdp_channels_load_static_addin_entry, 0);
-
-    /* Load RAIL plugin if RemoteApp in use */
-    if (settings->remote_app != NULL)
-        guac_rdp_rail_load_plugin(context);
-
-    /* Load SVC plugin instances for all static channels */
-    if (settings->svc_names != NULL) {
-
-        char** current = settings->svc_names;
-        do {
-            guac_rdp_pipe_svc_load_plugin(context, *current);
-        } while (*(++current) != NULL);
-
-    }
 
     /* Init FreeRDP internal GDI implementation */
     if (!gdi_init(instance, guac_rdp_get_native_pixel_format(FALSE)))

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -1684,6 +1684,7 @@ void guac_rdp_push_settings(guac_client* client,
         freerdp_settings_set_bool(rdp_settings, FreeRDP_Workarea, TRUE);
         freerdp_settings_set_bool(rdp_settings, FreeRDP_RemoteApplicationMode, TRUE);
         freerdp_settings_set_bool(rdp_settings, FreeRDP_RemoteAppLanguageBarSupported, TRUE);
+        freerdp_settings_set_bool(rdp_settings, FreeRDP_HiDefRemoteApp, guac_settings->enable_gfx);
         freerdp_settings_set_string(rdp_settings, FreeRDP_RemoteApplicationProgram, guac_strdup(guac_settings->remote_app));
         freerdp_settings_set_string(rdp_settings, FreeRDP_ShellWorkingDirectory, guac_strdup(guac_settings->remote_app_dir));
         freerdp_settings_set_string(rdp_settings, FreeRDP_RemoteApplicationCmdLine, guac_strdup(guac_settings->remote_app_args));
@@ -1919,6 +1920,7 @@ void guac_rdp_push_settings(guac_client* client,
         rdp_settings->Workarea = TRUE;
         rdp_settings->RemoteApplicationMode = TRUE;
         rdp_settings->RemoteAppLanguageBarSupported = TRUE;
+        rdp_settings->HiDefRemoteApp = guac_settings->enable_gfx;
         rdp_settings->RemoteApplicationProgram = guac_strdup(guac_settings->remote_app);
         rdp_settings->ShellWorkingDirectory = guac_strdup(guac_settings->remote_app_dir);
         rdp_settings->RemoteApplicationCmdLine = guac_strdup(guac_settings->remote_app_args);


### PR DESCRIPTION
This is likely the first of a couple of changes to correct issues with RAIL support in FreeRDP3 and in Guacamole's support of GFX. I finally stumbled upon the reason that the FreeRDP3 changes had broken RAIL support - the RAIL plugin was being loaded _only_ the `PreConnect` callback (`rdp_freerdp_pre_connect()`), and not in the `LoadChannels` callback (`rdp_freerdp_load_channels()`). The change in FreeRDP (https://github.com/FreeRDP/FreeRDP/commit/ef8c9e48e8acf61e16cb9fd547799067c87b20da) that broke this unified the reloading of channels into a single function that disconnected and closed all of the channels and then used the `LoadChannels` callback to reload all of them. Since RAIL was not being processed through that callback, it would get dropped but never reconnected. This moves the processing of the RAIL plugin, along with any user-defined static plugins, to the `LoadChannels` callback, which keeps it connected in recent FreeRDP 3.x versions.

I think these changes are solid and ready to be merged - it's pretty simple, and seems to fix at least the RAIL plugin connection issue. That said, I'm still seeing some issues with RAIL when GFX support is enabled (hangs/disconnects/freezes) that don't occur when you disable GFX support, so I think there may be additional items to address related to the intersection of GFX + RAIL.