### PR TITLE
GUACAMOLE-???: Terminal's OSC parser to not stop on unhandled characters

### DIFF
--- a/src/terminal/terminal-handlers.c
+++ b/src/terminal/terminal-handlers.c
@@ -1605,13 +1605,9 @@ int guac_terminal_osc(guac_terminal* term, unsigned char c) {
     }
 
     /* Stop on ECMA-48 ST (String Terminator */
-    else if (c == 0x9C || c == 0x5C || c == 0x07)
-        term->char_handler = guac_terminal_echo;
-
-    /* Stop on unrecognized character */
-    else {
+    else if (c == 0x9C || c == 0x5C || c == 0x07) {
         guac_client_log(term->client, GUAC_LOG_DEBUG,
-                "Unexpected character in OSC: 0x%X", c);
+                        "Unhandled OSC command: %d", operation);
         term->char_handler = guac_terminal_echo;
     }
 


### PR DESCRIPTION
** I haven't made a ticket yet because I'm still waiting for my JIRA
   account to be created
** untested; maybe someone else can test this by running the printf
   command below?

As reported in https://github.com/fish-shell/fish-shell/issues/11749,
Guacamole's terminal fails to parse some OSC sequences.
For example, running this command (in a shell like Bash):

	printf '\033]133;A;special_key=1\007'

echoes part of the sequence which is incorrect.

Almost every other terminal ignores such sequences, even if they
don't handle them. This allows apps to add new features without
probing for support (which is not always possible or reliable).

This behavior was introduced in c56412f6 (GUAC-734: Return to echo
after HTS. Return to echo on unexpected characters within OSC.,
2014-06-11) for unknown reasons -- I don't know how to find that ticket
(it's not GUACAMOLE-734).
