### PR TITLE
GUACAMOLE-2143: Improve process management to prevent zombie process accumulation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -150,7 +150,7 @@ AC_SUBST(UUID_LIBS)
 AC_SUBST(CUNIT_LIBS)
 
 # Library functions
-AC_CHECK_FUNCS([clock_gettime gettimeofday memmove memset select strdup nanosleep])
+AC_CHECK_FUNCS([clock_gettime gettimeofday memmove memset select strdup nanosleep prctl])
 
 AC_CHECK_DECL([png_get_io_ptr],
     [AC_DEFINE([HAVE_PNG_GET_IO_PTR],,
@@ -696,7 +696,7 @@ then
 fi
 
 #
-# libVNCserver support for the requestedResize member, which enables the 
+# libVNCserver support for the requestedResize member, which enables the
 # client to pause frame buffer updates during a resize operation. If support
 # for this is missing, Guacamole may still attempt to send the resize requests
 # to the remote display, but there may be odd display behavior just before,

--- a/src/guacd/daemon.c
+++ b/src/guacd/daemon.c
@@ -43,6 +43,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <syslog.h>
+#ifdef HAVE_PRCTL
+#include <sys/prctl.h>
+#endif
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -133,7 +136,7 @@ static int daemonize() {
 
     /* Change to root directory */
     if (chdir(GUACD_ROOT) < 0) {
-        guacd_log(GUAC_LOG_ERROR, 
+        guacd_log(GUAC_LOG_ERROR,
                 "Unable to change working directory to "
                 GUACD_ROOT);
         return 1;
@@ -145,7 +148,7 @@ static int daemonize() {
     || redirect_fd(STDOUT_FILENO, O_WRONLY)
     || redirect_fd(STDERR_FILENO, O_WRONLY)) {
 
-        guacd_log(GUAC_LOG_ERROR, 
+        guacd_log(GUAC_LOG_ERROR,
                 "Unable to redirect standard file descriptors to "
                 GUACD_DEV_NULL);
         return 1;
@@ -482,7 +485,7 @@ int main(int argc, char* argv[]) {
             fprintf(pidf, "%d\n", getpid());
             fclose(pidf);
         }
-        
+
         /* Fail if could not write PID file*/
         else {
             guacd_log(GUAC_LOG_ERROR, "Could not write PID file: %s", strerror(errno));
@@ -507,6 +510,14 @@ int main(int argc, char* argv[]) {
     struct sigaction signal_stop_action = { .sa_handler = signal_stop_handler };
     sigaction(SIGINT, &signal_stop_action, NULL);
     sigaction(SIGTERM, &signal_stop_action, NULL);
+
+#ifdef HAVE_PRCTL
+    /* Adopt any orphan processes from clients so we can properly terminate and reap */
+    prctl(PR_SET_CHILD_SUBREAPER, 1);
+#else
+    guacd_log(GUAC_LOG_INFO, "prctl not available on this platform. "
+            "Orphan child processes may pile up in the process table.");
+#endif
 
     /* Log listening status */
     guacd_log(GUAC_LOG_INFO, "Listening on host %s, port %s", bound_address, bound_port);

--- a/src/guacd/proc.c
+++ b/src/guacd/proc.c
@@ -325,8 +325,8 @@ static void signal_stop_handler(int signal) {
 static void guacd_exec_proc(guacd_proc* proc, const char* protocol) {
 
     int result = 1;
-   
-    /* Set process group ID to match PID */ 
+
+    /* Set process group ID to match PID */
     if (setpgid(0, 0)) {
         guacd_log(GUAC_LOG_ERROR, "Cannot set PGID for connection process: %s",
                 strerror(errno));
@@ -371,7 +371,7 @@ static void guacd_exec_proc(guacd_proc* proc, const char* protocol) {
         owner = 0;
 
     }
-    
+
 cleanup_client:
 
     /* Request client to stop/disconnect */
@@ -496,8 +496,8 @@ guacd_proc* guacd_create_proc(const char* protocol) {
  */
 static void guacd_proc_kill(guacd_proc* proc) {
 
-    /* Request orderly termination of process */
-    if (kill(proc->pid, SIGTERM))
+    /* Request orderly termination of process group */
+    if (kill(-proc->pid, SIGTERM))
         guacd_log(GUAC_LOG_DEBUG, "Unable to request termination of "
                 "client process: %s ", strerror(errno));
 


### PR DESCRIPTION
## Problem
Guacamole daemon was not properly cleaning up orphaned client sub-processes, leading to zombie processes that accumulate over time and consume system resources.

## Root Cause
- Daemon did not adopt orphaned processes when parent client processes terminated unexpectedly
- Process termination only killed individual processes instead of entire process groups
- This left child processes running as orphans that couldn't be properly reaped

## Solution
Implemented comprehensive process lifecycle management:

1. **Added subreaper capability**: Configure daemon with `prctl(PR_SET_CHILD_SUBREAPER, 1)` to automatically adopt any orphaned client processes
2. **Process group termination**: Changed termination signal from `kill(proc->pid, SIGTERM)` to `kill(-proc->pid, SIGTERM)` to terminate entire process groups
3. **Proper cleanup chain**: Ensures all child processes are properly reaped when connections terminate

## Impact
- Prevents zombie process accumulation
- Improves system resource management
- Ensures clean process termination in all scenarios
- Maintains compatibility with existing process group creation (`setpgid(0, 0)`)