### PR TITLE
GUACAMOLE-1969: Report Clipboard History.

### DIFF
--- a/src/libguac/guacamole/recording.h
+++ b/src/libguac/guacamole/recording.h
@@ -49,6 +49,11 @@
 #define GUAC_COMMON_RECORDING_MAX_NAME_LENGTH 2048
 
 /**
+ * The block size to use when sending clipboard data in a recording.
+ */
+#define GUAC_RECORDING_CLIPBOARD_BLOCK_SIZE 4096
+
+/**
  * An in-progress session recording, attached to a guac_client instance such
  * that output Guacamole instructions may be dynamically intercepted and
  * written to a file.
@@ -60,6 +65,12 @@ typedef struct guac_recording {
      * to any particular user.
      */
     guac_socket* socket;
+
+    /**
+     * The stream used for recording clipboard data. This stream is allocated
+     * once during recording creation and reused for all clipboard events.
+     */
+    guac_stream* clipboard_stream;
 
     /**
      * Non-zero if output which is broadcast to each connected client
@@ -286,7 +297,7 @@ void guac_recording_report_key(guac_recording* recording,
  * @param mimetype
  *     The clipboard data mimetype
  */
-void guac_recording_report_clipboard(guac_recording* recording,
+void guac_recording_report_clipboard_begin(guac_recording* recording,
         guac_stream* stream, char* mimetype);
 
 /**
@@ -319,5 +330,22 @@ void guac_recording_report_clipboard_blob(guac_recording* recording,
 void guac_recording_report_clipboard_end(guac_recording* recording,
         guac_stream* stream);
 
-#endif
+/**
+ * Reports clipboard data within the recording.
+ *
+ * @param recording
+ *     The guac_recording to write clipboard data to.
+ *
+ * @param mimetype
+ *     The mimetype of the clipboard data (e.g., "text/plain").
+ *
+ * @param data
+ *     The clipboard data buffer.
+ *
+ * @param length
+ *     The length of the clipboard data in bytes.
+ */
+void guac_recording_report_clipboard(guac_recording* recording,
+        const char* mimetype, const char* data, int length);
 
+#endif

--- a/src/libguac/guacamole/recording.h
+++ b/src/libguac/guacamole/recording.h
@@ -95,6 +95,15 @@ typedef struct guac_recording {
      */
     int include_keys;
 
+    /**
+     * Non-zero if clipboard data should be included in the session
+     * recording, zero otherwise. Including clipboard data within the recording may
+     * be necessary in certain auditing contexts, but should only be done with
+     * caution. Clipboard can easily contain sensitive information, such as
+     * passwords, credit card numbers, etc.
+     */
+    int include_clipboard;
+
 } guac_recording;
 
 /**
@@ -152,6 +161,13 @@ typedef struct guac_recording {
  *     Non-zero if writing to an existing file should be allowed, or zero
  *     otherwise.
  *
+ * @param include_clipboard
+ *     Non-zero if clipboard data should be included in the session
+ *     recording, zero otherwise. Including clipboard data within the recording may
+ *     be necessary in certain auditing contexts, but should only be done with
+ *     caution. Clipboard can easily contain sensitive information, such as
+ *     passwords, credit card numbers, etc.
+ *
  * @return
  *     A new guac_recording structure representing the in-progress
  *     recording if the recording file has been successfully created and a
@@ -160,7 +176,7 @@ typedef struct guac_recording {
 guac_recording* guac_recording_create(guac_client* client,
         const char* path, const char* name, int create_path,
         int include_output, int include_mouse, int include_touch,
-        int include_keys, int allow_write_existing);
+        int include_keys, int allow_write_existing, int include_clipboard);
 
 /**
  * Frees the resources associated with the given in-progress recording. Note
@@ -255,6 +271,53 @@ void guac_recording_report_touch(guac_recording* recording,
  */
 void guac_recording_report_key(guac_recording* recording,
         int keysym, int pressed);
+
+/**
+ * Reports a clipboard instruction within the recording.
+ * The full structure consists of clipboard instruction, one or more
+ * blob instructions and end instruction.
+ *
+ * @param recording
+ *     The guac_recording associated with the clipboard instruction.
+ *
+ * @param stream
+ *     The guac_stream allocated for the clipboard instruction.
+ *
+ * @param mimetype
+ *     The clipboard data mimetype
+ */
+void guac_recording_report_clipboard(guac_recording* recording,
+        guac_stream* stream, char* mimetype);
+
+/**
+ * Report a clipboard blob within the recording.
+ *
+ * @param recording
+ *     The guac_recording associated with the clipboard instruction.
+ *
+ * @param stream
+ *     The guac_stream associated with the clipboard instruction.
+ *
+ * @param data
+ *     The clipboard blob data.
+ *
+ * @param length
+ *     Length of the blob data.
+ */
+void guac_recording_report_clipboard_blob(guac_recording* recording,
+        guac_stream* stream, void* data, int length);
+
+/**
+ * Report a clipboard end instruction within the recording.
+ *
+ * @param recording
+ *     The guac_recording associated with the clipboard instruction.
+ *
+ * @param stream
+ *     The guac_stream associated with the clipboard instruction.
+ */
+void guac_recording_report_clipboard_end(guac_recording* recording,
+        guac_stream* stream);
 
 #endif
 

--- a/src/libguac/recording.c
+++ b/src/libguac/recording.c
@@ -78,6 +78,11 @@ guac_recording* guac_recording_create(guac_client* client,
     recording->include_keys = include_keys;
     recording->include_clipboard = include_clipboard;
 
+    if (include_clipboard)
+        recording->clipboard_stream = guac_client_alloc_stream(client);
+    else
+        recording->clipboard_stream = NULL;
+
     /* Replace client socket with wrapped recording socket only if including
      * output within the recording */
     if (include_output)
@@ -134,7 +139,7 @@ void guac_recording_report_key(guac_recording* recording,
 
 }
 
-void guac_recording_report_clipboard(guac_recording* recording, guac_stream* stream, char* mimetype) {
+void guac_recording_report_clipboard_begin(guac_recording* recording, guac_stream* stream, char* mimetype) {
     /* Report clipboard only if recording should contain it */
     if (recording->include_clipboard)
         guac_protocol_send_clipboard(recording->socket, stream, mimetype);
@@ -150,4 +155,36 @@ void guac_recording_report_clipboard_end(guac_recording* recording, guac_stream*
     /* Report clipboard only if recording should contain it */
     if (recording->include_clipboard)
         guac_protocol_send_end(recording->socket, stream);
+}
+
+void guac_recording_report_clipboard(guac_recording* recording,
+        const char* mimetype, const char* data, int length) {
+
+    /* Report clipboard only if recording should contain clipboard changes */
+    if (!recording->include_clipboard || !recording->clipboard_stream)
+        return;
+
+    guac_socket* socket = recording->socket;
+    guac_stream* stream = recording->clipboard_stream;
+
+    const char* current = data;
+    int remaining = length;
+
+    guac_protocol_send_clipboard(socket, stream, mimetype);
+
+    while (remaining > 0) {
+
+        int block_size = GUAC_RECORDING_CLIPBOARD_BLOCK_SIZE;
+        if (remaining < block_size)
+            block_size = remaining;
+
+        guac_protocol_send_blob(socket, stream, current, block_size);
+
+        remaining -= block_size;
+        current += block_size;
+
+    }
+
+    guac_protocol_send_end(socket, stream);
+
 }

--- a/src/libguac/recording.c
+++ b/src/libguac/recording.c
@@ -42,7 +42,7 @@
 guac_recording* guac_recording_create(guac_client* client,
         const char* path, const char* name, int create_path,
         int include_output, int include_mouse, int include_touch,
-        int include_keys, int allow_write_existing) {
+        int include_keys, int allow_write_existing, int include_clipboard) {
 
     char filename[GUAC_COMMON_RECORDING_MAX_NAME_LENGTH];
 
@@ -76,6 +76,7 @@ guac_recording* guac_recording_create(guac_client* client,
     recording->include_mouse = include_mouse;
     recording->include_touch = include_touch;
     recording->include_keys = include_keys;
+    recording->include_clipboard = include_clipboard;
 
     /* Replace client socket with wrapped recording socket only if including
      * output within the recording */
@@ -133,3 +134,20 @@ void guac_recording_report_key(guac_recording* recording,
 
 }
 
+void guac_recording_report_clipboard(guac_recording* recording, guac_stream* stream, char* mimetype) {
+    /* Report clipboard only if recording should contain it */
+    if (recording->include_clipboard)
+        guac_protocol_send_clipboard(recording->socket, stream, mimetype);
+}
+
+void guac_recording_report_clipboard_blob(guac_recording* recording, guac_stream* stream, void* data, int length) {
+    /* Report clipboard only if recording should contain it */
+    if (recording->include_clipboard)
+        guac_protocol_send_blob(recording->socket, stream, data, length);
+}
+
+void guac_recording_report_clipboard_end(guac_recording* recording, guac_stream* stream) {
+    /* Report clipboard only if recording should contain it */
+    if (recording->include_clipboard)
+        guac_protocol_send_end(recording->socket, stream);
+}

--- a/src/protocols/kubernetes/clipboard.c
+++ b/src/protocols/kubernetes/clipboard.c
@@ -39,6 +39,10 @@ int guac_kubernetes_clipboard_handler(guac_user* user, guac_stream* stream,
     stream->blob_handler = guac_kubernetes_clipboard_blob_handler;
     stream->end_handler = guac_kubernetes_clipboard_end_handler;
 
+    /* Report clipboard within recording */
+    if (kubernetes_client->recording != NULL)
+        guac_recording_report_clipboard(kubernetes_client->recording, stream, mimetype);
+
     return 0;
 }
 
@@ -49,6 +53,10 @@ int guac_kubernetes_clipboard_blob_handler(guac_user* user,
     guac_kubernetes_client* kubernetes_client =
         (guac_kubernetes_client*) client->data;
 
+    /* Report clipboard blob within recording */
+    if (kubernetes_client->recording != NULL)
+        guac_recording_report_clipboard_blob(kubernetes_client->recording, stream, data, length);
+
     /* Append new data */
     guac_terminal_clipboard_append(kubernetes_client->term, data, length);
 
@@ -57,6 +65,14 @@ int guac_kubernetes_clipboard_blob_handler(guac_user* user,
 
 int guac_kubernetes_clipboard_end_handler(guac_user* user,
         guac_stream* stream) {
+
+    guac_client* client = user->client;
+    guac_kubernetes_client* kubernetes_client =
+        (guac_kubernetes_client*) client->data;
+
+    /* Report clipboard blob within recording */
+    if (kubernetes_client->recording != NULL)
+        guac_recording_report_clipboard_end(kubernetes_client->recording, stream);
 
     /* Nothing to do - clipboard is implemented within client */
 

--- a/src/protocols/kubernetes/clipboard.c
+++ b/src/protocols/kubernetes/clipboard.c
@@ -41,7 +41,7 @@ int guac_kubernetes_clipboard_handler(guac_user* user, guac_stream* stream,
 
     /* Report clipboard within recording */
     if (kubernetes_client->recording != NULL)
-        guac_recording_report_clipboard(kubernetes_client->recording, stream, mimetype);
+        guac_recording_report_clipboard_begin(kubernetes_client->recording, stream, mimetype);
 
     return 0;
 }
@@ -78,4 +78,3 @@ int guac_kubernetes_clipboard_end_handler(guac_user* user,
 
     return 0;
 }
-

--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -238,7 +238,8 @@ void* guac_kubernetes_client_thread(void* data) {
                 !settings->recording_exclude_mouse,
                 0, /* Touch events not supported */
                 settings->recording_include_keys,
-                settings->recording_write_existing);
+                settings->recording_write_existing,
+                settings->recording_include_clipboard);
     }
 
     /* Create terminal options with required parameters */

--- a/src/protocols/kubernetes/settings.c
+++ b/src/protocols/kubernetes/settings.c
@@ -52,6 +52,7 @@ const char* GUAC_KUBERNETES_CLIENT_ARGS[] = {
     "recording-exclude-output",
     "recording-exclude-mouse",
     "recording-include-keys",
+    "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
     "read-only",
@@ -214,6 +215,16 @@ enum KUBERNETES_ARGS_IDX {
      * as passwords, credit card numbers, etc.
      */
     IDX_RECORDING_INCLUDE_KEYS,
+
+    /**
+     * Whether clipboard data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_CLIPBOARD,
 
     /**
      * Whether the specified screen recording path should automatically be
@@ -416,6 +427,11 @@ guac_kubernetes_settings* guac_kubernetes_parse_args(guac_user* user,
     settings->recording_include_keys =
         guac_user_parse_args_boolean(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
                 IDX_RECORDING_INCLUDE_KEYS, false);
+
+    /* Parse clipboard inclusion flag */
+    settings->recording_include_clipboard =
+        guac_user_parse_args_boolean(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_CLIPBOARD, false);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/kubernetes/settings.h
+++ b/src/protocols/kubernetes/settings.h
@@ -246,6 +246,16 @@ typedef struct guac_kubernetes_settings {
     bool recording_include_keys;
 
     /**
+     * Whether clipboard data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    bool recording_include_clipboard;
+
+    /**
      * Whether existing files should be appended to when creating a new recording.
      * Disabled by default.
      */

--- a/src/protocols/rdp/channels/cliprdr.c
+++ b/src/protocols/rdp/channels/cliprdr.c
@@ -695,6 +695,11 @@ int guac_rdp_clipboard_handler(guac_user* user, guac_stream* stream,
     /* Clear any current contents, assigning the mimetype the data which will
      * be received */
     guac_common_clipboard_reset(clipboard->clipboard, mimetype);
+
+    /* Report clipboard within recording */
+    if (rdp_client->recording != NULL)
+        guac_recording_report_clipboard(rdp_client->recording, stream, mimetype);
+
     return 0;
 
 }
@@ -710,6 +715,10 @@ int guac_rdp_clipboard_blob_handler(guac_user* user, guac_stream* stream,
     guac_rdp_clipboard* clipboard = rdp_client->clipboard;
     if (clipboard == NULL)
         return 0;
+
+    /* Report clipboard blob within recording */
+    if (rdp_client->recording != NULL)
+        guac_recording_report_clipboard_blob(rdp_client->recording, stream, data, length);
 
     /* Append received data to current clipboard contents */
     guac_common_clipboard_append(clipboard->clipboard, (char*) data, length);
@@ -727,6 +736,10 @@ int guac_rdp_clipboard_end_handler(guac_user* user, guac_stream* stream) {
     guac_rdp_clipboard* clipboard = rdp_client->clipboard;
     if (clipboard == NULL)
         return 0;
+
+    /* Report clipboard stream end within recording */
+    if (rdp_client->recording != NULL)
+        guac_recording_report_clipboard_end(rdp_client->recording, stream);
 
     /* Terminate clipboard data with NULL */
     guac_common_clipboard_append(clipboard->clipboard, "", 1);

--- a/src/protocols/rdp/channels/cliprdr.c
+++ b/src/protocols/rdp/channels/cliprdr.c
@@ -521,6 +521,13 @@ static UINT guac_rdp_cliprdr_format_data_response(CliprdrClientContext* cliprdr,
         guac_common_clipboard_reset(clipboard->clipboard, "text/plain");
         guac_common_clipboard_append(clipboard->clipboard, received_data, length);
         guac_common_clipboard_send(clipboard->clipboard, client);
+
+        /* Record clipboard if recording is active */
+        if (rdp_client->recording != NULL)
+            guac_recording_report_clipboard(rdp_client->recording,
+                    clipboard->clipboard->mimetype,
+                    clipboard->clipboard->buffer,
+                    clipboard->clipboard->length);
     }
 
     guac_mem_free(received_data);
@@ -698,7 +705,8 @@ int guac_rdp_clipboard_handler(guac_user* user, guac_stream* stream,
 
     /* Report clipboard within recording */
     if (rdp_client->recording != NULL)
-        guac_recording_report_clipboard(rdp_client->recording, stream, mimetype);
+        guac_recording_report_clipboard_begin(rdp_client->recording, stream,
+                mimetype);
 
     return 0;
 

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -938,7 +938,8 @@ void* guac_rdp_client_thread(void* data) {
                 !settings->recording_exclude_mouse,
                 !settings->recording_exclude_touch,
                 settings->recording_include_keys,
-                settings->recording_write_existing);
+                settings->recording_write_existing,
+                settings->recording_include_clipboard);
     }
 
     /* Continue handling connections until error or client disconnect */

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -125,6 +125,7 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
     "recording-exclude-mouse",
     "recording-exclude-touch",
     "recording-include-keys",
+    "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
     "resize-method",
@@ -580,6 +581,16 @@ enum RDP_ARGS_IDX {
      * as passwords, credit card numbers, etc.
      */
     IDX_RECORDING_INCLUDE_KEYS,
+
+    /**
+     * Whether clipboard data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_CLIPBOARD,
 
     /**
      * Whether the specified screen recording path should automatically be
@@ -1205,6 +1216,11 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     settings->recording_include_keys =
         guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
                 IDX_RECORDING_INCLUDE_KEYS, 0);
+
+    /* Parse clipboard inclusion flag */
+    settings->recording_include_clipboard =
+        guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_CLIPBOARD, false);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/rdp/settings.h
+++ b/src/protocols/rdp/settings.h
@@ -590,6 +590,16 @@ typedef struct guac_rdp_settings {
     int recording_include_keys;
 
     /**
+     * Whether clipboard data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    bool recording_include_clipboard;
+
+    /**
      * Non-zero if existing files should be appended to when creating a new 
      * recording. Disabled by default.
      */

--- a/src/protocols/ssh/clipboard.c
+++ b/src/protocols/ssh/clipboard.c
@@ -38,21 +38,36 @@ int guac_ssh_clipboard_handler(guac_user* user, guac_stream* stream,
     stream->blob_handler = guac_ssh_clipboard_blob_handler;
     stream->end_handler = guac_ssh_clipboard_end_handler;
 
+    /* Report clipboard within recording */
+    if (ssh_client->recording != NULL)
+        guac_recording_report_clipboard(ssh_client->recording, stream, mimetype);
+
     return 0;
 }
 
 int guac_ssh_clipboard_blob_handler(guac_user* user, guac_stream* stream,
         void* data, int length) {
-
-    /* Append new data */
     guac_client* client = user->client;
     guac_ssh_client* ssh_client = (guac_ssh_client*) client->data;
+
+    /* Report clipboard blob within recording */
+    if (ssh_client->recording != NULL)
+        guac_recording_report_clipboard_blob(ssh_client->recording, stream, data, length);
+
+    /* Append new data */
     guac_terminal_clipboard_append(ssh_client->term, data, length);
 
     return 0;
 }
 
 int guac_ssh_clipboard_end_handler(guac_user* user, guac_stream* stream) {
+
+    guac_client* client = user->client;
+    guac_ssh_client* ssh_client = (guac_ssh_client*) client->data;
+
+    /* Report clipboard stream end within recording */
+    if (ssh_client->recording != NULL)
+        guac_recording_report_clipboard_end(ssh_client->recording, stream);
 
     /* Nothing to do - clipboard is implemented within client */
 

--- a/src/protocols/ssh/clipboard.c
+++ b/src/protocols/ssh/clipboard.c
@@ -40,7 +40,8 @@ int guac_ssh_clipboard_handler(guac_user* user, guac_stream* stream,
 
     /* Report clipboard within recording */
     if (ssh_client->recording != NULL)
-        guac_recording_report_clipboard(ssh_client->recording, stream, mimetype);
+        guac_recording_report_clipboard_begin(ssh_client->recording, stream,
+                mimetype);
 
     return 0;
 }
@@ -73,4 +74,3 @@ int guac_ssh_clipboard_end_handler(guac_user* user, guac_stream* stream) {
 
     return 0;
 }
-

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -67,6 +67,7 @@ const char* GUAC_SSH_CLIENT_ARGS[] = {
     "recording-exclude-output",
     "recording-exclude-mouse",
     "recording-include-keys",
+    "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
     "read-only",
@@ -253,6 +254,16 @@ enum SSH_ARGS_IDX {
      * as passwords, credit card numbers, etc.
      */
     IDX_RECORDING_INCLUDE_KEYS,
+
+    /**
+     * Whether clipboard data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_CLIPBOARD,
 
     /**
      * Whether the specified screen recording path should automatically be
@@ -535,6 +546,11 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
     settings->recording_include_keys =
         guac_user_parse_args_boolean(user, GUAC_SSH_CLIENT_ARGS, argv,
                 IDX_RECORDING_INCLUDE_KEYS, false);
+
+    /* Parse clipboard inclusion flag */
+    settings->recording_include_clipboard =
+        guac_user_parse_args_boolean(user, GUAC_SSH_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_CLIPBOARD, false);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -273,6 +273,16 @@ typedef struct guac_ssh_settings {
     bool recording_include_keys;
 
     /**
+     * Whether clipboard data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    bool recording_include_clipboard;
+
+    /**
      * Whether existing files should be appended to when creating a new recording.
      * Disabled by default.
      */

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -292,7 +292,8 @@ void* ssh_client_thread(void* data) {
                 !settings->recording_exclude_mouse,
                 0, /* Touch events not supported */
                 settings->recording_include_keys,
-                settings->recording_write_existing);
+                settings->recording_write_existing,
+                settings->recording_include_clipboard);
     }
 
     /* Create terminal options with required parameters */

--- a/src/protocols/telnet/clipboard.c
+++ b/src/protocols/telnet/clipboard.c
@@ -40,7 +40,8 @@ int guac_telnet_clipboard_handler(guac_user* user, guac_stream* stream,
 
     /* Report clipboard within recording */
     if (telnet_client->recording != NULL)
-        guac_recording_report_clipboard(telnet_client->recording, stream, mimetype);
+        guac_recording_report_clipboard_begin(telnet_client->recording, stream,
+                mimetype);
 
     return 0;
 }
@@ -74,4 +75,3 @@ int guac_telnet_clipboard_end_handler(guac_user* user, guac_stream* stream) {
 
     return 0;
 }
-

--- a/src/protocols/telnet/clipboard.c
+++ b/src/protocols/telnet/clipboard.c
@@ -38,21 +38,37 @@ int guac_telnet_clipboard_handler(guac_user* user, guac_stream* stream,
     stream->blob_handler = guac_telnet_clipboard_blob_handler;
     stream->end_handler = guac_telnet_clipboard_end_handler;
 
+    /* Report clipboard within recording */
+    if (telnet_client->recording != NULL)
+        guac_recording_report_clipboard(telnet_client->recording, stream, mimetype);
+
     return 0;
 }
 
 int guac_telnet_clipboard_blob_handler(guac_user* user, guac_stream* stream,
         void* data, int length) {
 
-    /* Append new data */
     guac_client* client = user->client;
     guac_telnet_client* telnet_client = (guac_telnet_client*) client->data;
+
+    /* Report clipboard blob within recording */
+    if (telnet_client->recording != NULL)
+        guac_recording_report_clipboard_blob(telnet_client->recording, stream, data, length);
+
+    /* Append new data */
     guac_terminal_clipboard_append(telnet_client->term, data, length);
 
     return 0;
 }
 
 int guac_telnet_clipboard_end_handler(guac_user* user, guac_stream* stream) {
+
+    guac_client* client = user->client;
+    guac_telnet_client* telnet_client = (guac_telnet_client*) client->data;
+
+    /* Report clipboard stream end within recording */
+    if (telnet_client->recording != NULL)
+        guac_recording_report_clipboard_end(telnet_client->recording, stream);
 
     /* Nothing to do - clipboard is implemented within client */
 

--- a/src/protocols/telnet/settings.c
+++ b/src/protocols/telnet/settings.c
@@ -58,6 +58,7 @@ const char* GUAC_TELNET_CLIENT_ARGS[] = {
     "recording-exclude-output",
     "recording-exclude-mouse",
     "recording-include-keys",
+    "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
     "read-only",
@@ -199,6 +200,16 @@ enum TELNET_ARGS_IDX {
      * as passwords, credit card numbers, etc.
      */
     IDX_RECORDING_INCLUDE_KEYS,
+
+    /**
+     * Whether clipboard data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_CLIPBOARD,
 
     /**
      * Whether the specified screen recording path should automatically be
@@ -515,6 +526,11 @@ guac_telnet_settings* guac_telnet_parse_args(guac_user* user,
     settings->recording_include_keys =
         guac_user_parse_args_boolean(user, GUAC_TELNET_CLIENT_ARGS, argv,
                 IDX_RECORDING_INCLUDE_KEYS, false);
+
+    /* Parse clipboard inclusion flag */
+    settings->recording_include_clipboard =
+        guac_user_parse_args_boolean(user, GUAC_TELNET_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_CLIPBOARD, false);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/telnet/settings.h
+++ b/src/protocols/telnet/settings.h
@@ -249,6 +249,16 @@ typedef struct guac_telnet_settings {
     bool recording_include_keys;
 
     /**
+     * Whether clipboard data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    bool recording_include_clipboard;
+
+    /**
      * Whether existing files should be appended to when creating a new recording.
      * Disabled by default.
      */

--- a/src/protocols/telnet/telnet.c
+++ b/src/protocols/telnet/telnet.c
@@ -548,7 +548,8 @@ void* guac_telnet_client_thread(void* data) {
                 !settings->recording_exclude_mouse,
                 0, /* Touch events not supported */
                 settings->recording_include_keys,
-                settings->recording_write_existing);
+                settings->recording_write_existing,
+                settings->recording_include_clipboard);
     }
 
     /* Create terminal options with required parameters */

--- a/src/protocols/vnc/clipboard.c
+++ b/src/protocols/vnc/clipboard.c
@@ -103,7 +103,8 @@ int guac_vnc_clipboard_handler(guac_user* user, guac_stream* stream,
 
     /* Report clipboard within recording */
     if (vnc_client->recording != NULL)
-        guac_recording_report_clipboard(vnc_client->recording, stream, mimetype);
+        guac_recording_report_clipboard_begin(vnc_client->recording, stream,
+                mimetype);
 
     return 0;
 }
@@ -118,8 +119,6 @@ int guac_vnc_clipboard_blob_handler(guac_user* user, guac_stream* stream,
     guac_common_clipboard* clipboard = vnc_client->clipboard;
     if (clipboard == NULL)
         return 0;
-
-    guac_vnc_client* vnc_client = (guac_vnc_client*) user->client->data;
 
     /* Report clipboard blob within recording */
     if (vnc_client->recording != NULL)
@@ -140,6 +139,10 @@ int guac_vnc_clipboard_end_handler(guac_user* user, guac_stream* stream) {
     guac_common_clipboard* clipboard = vnc_client->clipboard;
     if (clipboard == NULL)
         return 0;
+
+    /* Report clipboard stream end within recording */
+    if (vnc_client->recording != NULL)
+        guac_recording_report_clipboard_end(vnc_client->recording, stream);
 
     guac_client* client = user->client;
     rfbClient* rfb_client = vnc_client->rfb_client;
@@ -185,10 +188,6 @@ int guac_vnc_clipboard_end_handler(guac_user* user, guac_stream* stream) {
     const char* input = clipboard->buffer;
     char* output = output_data;
     guac_iconv_write* writer = vnc_client->clipboard_writer;
-
-    /* Report clipboard stream end within recording */
-    if (vnc_client->recording != NULL)
-        guac_recording_report_clipboard_end(vnc_client->recording, stream);
 
     /* Convert clipboard contents */
     guac_iconv(GUAC_READ_UTF8, &input, clipboard->length,

--- a/src/protocols/vnc/clipboard.c
+++ b/src/protocols/vnc/clipboard.c
@@ -101,6 +101,10 @@ int guac_vnc_clipboard_handler(guac_user* user, guac_stream* stream,
     stream->blob_handler = guac_vnc_clipboard_blob_handler;
     stream->end_handler = guac_vnc_clipboard_end_handler;
 
+    /* Report clipboard within recording */
+    if (vnc_client->recording != NULL)
+        guac_recording_report_clipboard(vnc_client->recording, stream, mimetype);
+
     return 0;
 }
 
@@ -114,6 +118,12 @@ int guac_vnc_clipboard_blob_handler(guac_user* user, guac_stream* stream,
     guac_common_clipboard* clipboard = vnc_client->clipboard;
     if (clipboard == NULL)
         return 0;
+
+    guac_vnc_client* vnc_client = (guac_vnc_client*) user->client->data;
+
+    /* Report clipboard blob within recording */
+    if (vnc_client->recording != NULL)
+        guac_recording_report_clipboard_blob(vnc_client->recording, stream, data, length);
 
     /* Append new data */
     guac_common_clipboard_append(clipboard, (char*) data, length);
@@ -175,6 +185,10 @@ int guac_vnc_clipboard_end_handler(guac_user* user, guac_stream* stream) {
     const char* input = clipboard->buffer;
     char* output = output_data;
     guac_iconv_write* writer = vnc_client->clipboard_writer;
+
+    /* Report clipboard stream end within recording */
+    if (vnc_client->recording != NULL)
+        guac_recording_report_clipboard_end(vnc_client->recording, stream);
 
     /* Convert clipboard contents */
     guac_iconv(GUAC_READ_UTF8, &input, clipboard->length,

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -89,6 +89,7 @@ const char* GUAC_VNC_CLIENT_ARGS[] = {
     "recording-exclude-output",
     "recording-exclude-mouse",
     "recording-include-keys",
+    "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
     "clipboard-buffer-size",
@@ -354,6 +355,16 @@ enum VNC_ARGS_IDX {
      * as passwords, credit card numbers, etc.
      */
     IDX_RECORDING_INCLUDE_KEYS,
+
+    /**
+     * Whether clipboard data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    IDX_RECORDING_INCLUDE_CLIPBOARD,
 
     /**
      * Whether the specified screen recording path should automatically be
@@ -677,6 +688,11 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
     settings->recording_include_keys =
         guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_RECORDING_INCLUDE_KEYS, false);
+
+    /* Parse clipboard inclusion flag */
+    settings->recording_include_clipboard =
+        guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_RECORDING_INCLUDE_CLIPBOARD, false);
 
     /* Parse path creation flag */
     settings->create_recording_path =

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -311,6 +311,16 @@ typedef struct guac_vnc_settings {
     bool recording_include_keys;
 
     /**
+     * Whether clipboard data should be included in the session recording.
+     * Clipboard data is NOT included by default within the recording,
+     * as doing so has privacy and security implications. Including clipboard data
+     * may be necessary in certain auditing contexts, but should only be done
+     * with caution. Clipboard data can easily contain sensitive information, such
+     * as passwords, credit card numbers, etc.
+     */
+    bool recording_include_clipboard;
+
+    /**
      * Whether existing files should be appended to when creating a new recording.
      * Disabled by default.
      */

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -692,7 +692,8 @@ void* guac_vnc_client_thread(void* data) {
                 !settings->recording_exclude_mouse,
                 0, /* Touch events not supported */
                 settings->recording_include_keys,
-                settings->recording_write_existing);
+                settings->recording_write_existing,
+                settings->recording_include_clipboard);
     }
 
     /* Create display */


### PR DESCRIPTION
Built off https://github.com/apache/guacamole-server/pull/530

Added additional changes to record when the clipboard is modified on the remote desktop itself.

Paired with https://github.com/apache/guacamole-client/pull/1137