### PR TITLE
GUACAMOLE-2182: Fix segfaults caused by missing `config.h` includes.

### DIFF
--- a/src/protocols/rdp/channels/disp.c
+++ b/src/protocols/rdp/channels/disp.c
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include "config.h"
+
 #include "channels/disp.h"
 #include "plugins/channels.h"
 #include "fs.h"

--- a/src/protocols/rdp/input.c
+++ b/src/protocols/rdp/input.c
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include "config.h"
+
 #include "channels/disp.h"
 #include "channels/rdpei.h"
 #include "input.h"


### PR DESCRIPTION
Correction of two segfaults caused by GUACAMOLE-2182:
```bash
[root@localhost guacamole-server]# git bisect bad
309971b2113b0e7692eeb25e3f0cd6c233d25670 is the first bad commit
commit 309971b2113b0e7692eeb25e3f0cd6c233d25670 (HEAD)
Author: Virtually Nick <vnick@apache.org>
Date:   Thu Dec 11 06:28:27 2025 -0500

    GUACAMOLE-2182: Remove config.h includes from header files.
```

First segfault that I encounter during each RDP connection:
```
Mar 26 15:59:36 localhost kernel: guacd[537380]: segfault at 18 ip 000079bf75251d86 sp 000079bf52fcda60 error 6 in libguac-client-rdp.so.0.0.0[79bf7524c000+2a000] likely on CPU 0 (core 0, socket 0)
Mar 26 15:59:36 localhost kernel: Code: 00 00 00 7f 07 c7 45 d0 c8 00 00 00 8b 45 d4 99 c1 ea 1f 01 d0 83 e0 01 29 d0 83 f8 01 75 04 83 6d d4 01 48 8b 45 e8 8b 55 d4 <89> 50 18 48 8b 45 e8 8b 55 d0 89 50 1c 48 8b 55 d8 48 8b 4d e0 48
Mar 26 15:59:36 localhost kernel: guacd: guacd: potentially unexpected fatal signal 11.
Mar 26 15:59:36 localhost kernel: CPU: 0 PID: 537380 Comm: guacd Not tainted 6.6.87.2-microsoft-standard-WSL2 #1
Mar 26 15:59:36 localhost kernel: RIP: 0033:0x79bf75251d86
Mar 26 15:59:36 localhost kernel: Code: 00 00 00 7f 07 c7 45 d0 c8 00 00 00 8b 45 d4 99 c1 ea 1f 01 d0 83 e0 01 29 d0 83 f8 01 75 04 83 6d d4 01 48 8b 45 e8 8b 55 d4 <89> 50 18 48 8b 45 e8 8b 55 d0 89 50 1c 48 8b 55 d8 48 8b 4d e0 48
Mar 26 15:59:36 localhost kernel: RSP: 002b:000079bf52fcda60 EFLAGS: 00010297
Mar 26 15:59:36 localhost kernel: RAX: 0000000000000000 RBX: 00000000000003ee RCX: 0000000000000000
Mar 26 15:59:36 localhost kernel: RDX: 0000000000000780 RSI: 0000000000002000 RDI: 000079bf52fcda80
Mar 26 15:59:36 localhost kernel: RBP: 000079bf52fcda90 R08: 00000000000003ee R09: 0000000000000000
Mar 26 15:59:36 localhost kernel: R10: 000079bf77000318 R11: 000079bf77019624 R12: 000079bf6801a530
Mar 26 15:59:36 localhost kernel: R13: 000079bf68008390 R14: 000079bf52fcdb40 R15: 0000000000000001
Mar 26 15:59:36 localhost kernel: FS:  000079bf52fce640 GS:  0000000000000000
```
GDB:
```
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Core was generated by `/usr/local/sbin/guacd -f`.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000079bf75251d86 in guac_rdp_disp_set_size (disp=0x0, settings=0x266d1b20, rdp_inst=0x79bf68008100, width=1920, height=1006) at channels/disp.c:181
[Current thread is 1 (Thread 0x79bf52fce640 (LWP 536868))]
(gdb) bt full
#0  0x000079bf75251d86 in guac_rdp_disp_set_size (disp=0x0, settings=0x266d1b20, rdp_inst=0x79bf68008100, width=1920, height=1006) at channels/disp.c:181
        resize = {left = 0, top = 0, right = 1920, bottom = 1006}
#1  0x000079bf75251bab in guac_rdp_disp_channel_connected (context=0x79bf68008390, args=0x79bf52fcdb40) at channels/disp.c:89
        client = 0x79bf7000ba30
        rdp_client = 0x79bf74890010
        guac_disp = 0x0
        disp = 0x0
#2  0x000079bf74f69ea6 in PubSub_OnEvent () from /lib64/libwinpr2.so.2
No symbol table info available.
#3  0x000079bf750fea9f in freerdp_drdynvc_on_channel_connected () from /lib64/libfreerdp2.so.2
No symbol table info available.
#4  0x000079bf7502e78b in drdynvc_virtual_channel_client_thread () from /lib64/libfreerdp-client2.so.2
No symbol table info available.
#5  0x000079bf74f7ea93 in thread_launcher () from /lib64/libwinpr2.so.2
No symbol table info available.
#6  0x000079bf76489d32 in start_thread () from /lib64/libc.so.6
No symbol table info available.
#7  0x000079bf7650edc0 in clone3 () from /lib64/libc.so.6
No symbol table info available.
```
Fixed with `#include "config.h"` in `rdp/channels/disp.c`.

Second segfault on screen resize:
```
Mar 26 16:03:56 localhost kernel: guacd[540558]: segfault at 18 ip 00007e761bd43d86 sp 00007e7612ffcb40 error 6 in libguac-client-rdp.so.0.0.0[7e761bd3e000+2a000] likely on CPU 3 (core 1, socket 0)
Mar 26 16:03:56 localhost kernel: Code: 00 00 00 7f 07 c7 45 d0 c8 00 00 00 8b 45 d4 99 c1 ea 1f 01 d0 83 e0 01 29 d0 83 f8 01 75 04 83 6d d4 01 48 8b 45 e8 8b 55 d4 <89> 50 18 48 8b 45 e8 8b 55 d0 89 50 1c 48 8b 55 d8 48 8b 4d e0 48
Mar 26 16:03:56 localhost kernel: guacd: guacd: potentially unexpected fatal signal 11.
Mar 26 16:03:56 localhost kernel: CPU: 3 PID: 540558 Comm: guacd Not tainted 6.6.87.2-microsoft-standard-WSL2 #1
Mar 26 16:03:56 localhost kernel: RIP: 0033:0x7e761bd43d86
Mar 26 16:03:56 localhost kernel: Code: 00 00 00 7f 07 c7 45 d0 c8 00 00 00 8b 45 d4 99 c1 ea 1f 01 d0 83 e0 01 29 d0 83 f8 01 75 04 83 6d d4 01 48 8b 45 e8 8b 55 d4 <89> 50 18 48 8b 45 e8 8b 55 d0 89 50 1c 48 8b 55 d8 48 8b 4d e0 48
Mar 26 16:03:56 localhost kernel: RSP: 002b:00007e7612ffcb40 EFLAGS: 00010297
Mar 26 16:03:56 localhost kernel: RAX: 0000000000000000 RBX: 00007e761bd54b4f RCX: 0000000000000000
Mar 26 16:03:56 localhost kernel: RDX: 0000000000000356 RSI: 0000000000002000 RDI: 00007e7612ffcb60
Mar 26 16:03:56 localhost kernel: RBP: 00007e7612ffcb70 R08: 00000000000002b9 R09: 0000000000000000
Mar 26 16:03:56 localhost kernel: R10: 00007e761cf9eac0 R11: 00007e761cf9f3c0 R12: 00000000000002b9
Mar 26 16:03:56 localhost kernel: R13: 0000000000000000 R14: 00007e761ce89a60 R15: 0000000000000000
Mar 26 16:03:56 localhost kernel: FS:  00007e7612ffd640 GS:  0000000000000000
```
GDB:
```
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Core was generated by `/usr/local/sbin/guacd -f`.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007e761bd43d86 in guac_rdp_disp_set_size (disp=0x0, settings=0x23850b20, rdp_inst=0x7e760c008100, width=854, height=697) at channels/disp.c:183
183         disp->requested_width = width;
[Current thread is 1 (Thread 0x7e7612ffd640 (LWP 540044))]
(gdb) bt full
#0  0x00007e761bd43d86 in guac_rdp_disp_set_size (disp=0x0, settings=0x23850b20, rdp_inst=0x7e760c008100, width=854, height=697) at channels/disp.c:183
        resize = {left = 0, top = 0, right = 854, bottom = 697}
#1  0x00007e761bd54be4 in guac_rdp_user_size_handler (user=0x238500b0, width=854, height=697) at input.c:114
        client = 0x7e761400ba30
        rdp_client = 0x7e761b382010
        settings = 0x23850b20
        rdp_inst = 0x7e760c008100
#2  0x00007e761db111ac in __guac_handle_size (user=0x238500b0, argc=4, argv=0x2385fab0) at user-handlers.c:372
No locals.
#3  0x00007e761db11d1d in __guac_user_call_opcode_handler (map=0x7e761db1d120 <__guac_instruction_handler_map>, user=0x238500b0, opcode=0x23861238 "size", argc=4, argv=0x2385fab0)
    at user-handlers.c:769
        current = 0x7e761db1d180 <__guac_instruction_handler_map+96>
#4  0x00007e761db11ff9 in guac_user_input_thread (data=0x7e7618bfdbe0) at user-handshake.c:166
        params = 0x7e7618bfdbe0
        usec_timeout = 15000000
        user = 0x238500b0
        parser = 0x2385fa80
        client = 0x7e761400ba30
        socket = 0x23851840
#5  0x00007e761ce89d32 in start_thread () from /lib64/libc.so.6
No symbol table info available.
#6  0x00007e761cf0edc0 in clone3 () from /lib64/libc.so.6
No symbol table info available.
```
Fixed with `#include "config.h"` in `rdp/input.c`.
