### PR TITLE
GUACAMOLE-2259: Set initial height/width on last_frame to 0

### DIFF
--- a/src/libguac/display-layer-list.c
+++ b/src/libguac/display-layer-list.c
@@ -181,13 +181,10 @@ static void XFW_guac_display_layer_buffer_resize(guac_display_layer_state* frame
 static void PFW_LFW_guac_display_layer_state_init(guac_display_layer_state* last_frame,
         guac_display_layer_state* pending_frame) {
 
-    last_frame->width = pending_frame->width = GUAC_DISPLAY_RESIZE_FACTOR;
-    last_frame->height = pending_frame->height = GUAC_DISPLAY_RESIZE_FACTOR;
+    pending_frame->width = GUAC_DISPLAY_RESIZE_FACTOR;
+    pending_frame->height = GUAC_DISPLAY_RESIZE_FACTOR;
     last_frame->opacity = pending_frame->opacity = 0xFF;
     last_frame->parent = pending_frame->parent = GUAC_DEFAULT_LAYER;
-
-    XFW_guac_display_layer_buffer_resize(last_frame,
-            last_frame->width, last_frame->height);
 
     XFW_guac_display_layer_buffer_resize(pending_frame,
             pending_frame->width, pending_frame->height);


### PR DESCRIPTION
This ensures the check for layer size changes will send the proper ```size``` instruction even if the layer happens to be GUAC_DISPLAY_RESIZE_FACTOR x GUAC_DISPLAY_RESIZE_FACTOR (currently 64x64)

```
/* Commit any change in layer size */
if (current->pending_frame.width != current->last_frame.width
        || current->pending_frame.height != current->last_frame.height) {

```

Having the last_frame buffer initially NULL also more clearly conveys that no frame has been sent yet, and once a frame has been sent, the buffer reallocates on sizes changes and will function normally. 