### PR TITLE
GUACAMOLE-2265: Fix worker process leak after client disconnect.

### DIFF
--- a/src/guacd/proc.c
+++ b/src/guacd/proc.c
@@ -34,6 +34,7 @@
 #include <guacamole/user.h>
 
 #include <errno.h>
+#include <poll.h>
 #include <pthread.h>
 #include <signal.h>
 #include <stdlib.h>
@@ -138,7 +139,17 @@ static void guacd_proc_add_user(guacd_proc* proc, int fd, int owner) {
 
     /* Start user thread */
     pthread_t user_thread;
-    pthread_create(&user_thread, NULL, guacd_user_thread, params);
+    int err = pthread_create(&user_thread, NULL, guacd_user_thread, params);
+    if (err) {
+        guacd_log(GUAC_LOG_ERROR,
+                "Unable to create user thread (error %d: %s). "
+                "Closing connection and stopping worker to prevent leak.",
+                err, strerror(err));
+        close(fd);
+        guac_mem_free(params);
+        guacd_proc_stop(proc);
+        return;
+    }
     pthread_detach(user_thread);
 
 }
@@ -365,11 +376,109 @@ static void guacd_exec_proc(guacd_proc* proc, const char* protocol) {
     sigaction(SIGINT, &signal_stop_action, NULL);
     sigaction(SIGTERM, &signal_stop_action, NULL);
 
+    /* Track whether we have ever had a user, so we can detect the case
+     * where all users have disconnected and no new ones will arrive.
+     * Also track idle time so we can forcibly exit after an absolute max. */
+    int had_user = 0;
+    int idle_cycles = 0;
+    int no_user_cycles = 0;
+
     /* Add each received file descriptor as a new user */
     int received_fd;
-    while ((received_fd = guacd_recv_fd(proc->fd_socket)) != -1) {
+    for (;;) {
+
+        /* Use poll() with a timeout instead of blocking indefinitely in
+         * recvmsg(). This allows the worker to self-terminate if the client
+         * has stopped and no user thread triggered guacd_proc_stop(). */
+        struct pollfd pfd = {
+            .fd = proc->fd_socket,
+            .events = POLLIN
+        };
+
+        int poll_result = poll(&pfd, 1, GUACD_PROC_IDLE_TIMEOUT_MS);
+
+        if (poll_result < 0) {
+            if (errno == EINTR)
+                continue;
+            break;
+        }
+
+        if (poll_result == 0) {
+            idle_cycles++;
+
+            /* If we had a user and client explicitly stopped, exit */
+            if (had_user && client->state != GUAC_CLIENT_RUNNING) {
+                guacd_log(GUAC_LOG_INFO,
+                        "Worker idle timeout: client no longer running "
+                        "(state=%d), exiting.", client->state);
+                break;
+            }
+
+            /* If no users remain, allow a grace period for reconnects
+             * (browser refresh, tab re-open) before giving up */
+            if (had_user && client->connected_users == 0) {
+                no_user_cycles++;
+                if (no_user_cycles * GUACD_PROC_IDLE_TIMEOUT_MS
+                        >= GUACD_PROC_RECONNECT_GRACE_MS) {
+                    guacd_log(GUAC_LOG_INFO,
+                            "Worker idle timeout: no connected users "
+                            "for %ds, exiting.",
+                            GUACD_PROC_RECONNECT_GRACE_MS / 1000);
+                    break;
+                }
+            }
+            else {
+                no_user_cycles = 0;
+
+                /* While users are still connected, the session is healthy
+                 * even though no new user file descriptors arrive on
+                 * fd_socket: ongoing session traffic of an already-connected
+                 * session runs in separate user threads on other sockets.
+                 * Reset the absolute idle counter so it measures true idle
+                 * time since the last disconnect, not time since the last new
+                 * FD. Without this, the safety net below would accumulate
+                 * idle_cycles on a healthy single-user session and force-exit
+                 * the active connection after GUACD_PROC_MAX_IDLE_MS. */
+                if (client->connected_users > 0)
+                    idle_cycles = 0;
+            }
+
+            /* Absolute safety net: if we've been idle for too long after
+             * having a user AND no users remain connected, force exit
+             * regardless of client state. This catches cases where the client
+             * free handler is blocked (e.g. guac_argv_await in FreeRDP
+             * authenticate callback) after a real disconnect.
+             *
+             * The connected_users == 0 guard is required: a healthy active
+             * session receives no new user FDs and would otherwise accumulate
+             * idle_cycles and be force-killed even though it is fully alive.
+             * idle_cycles is now reset above while users are connected, but
+             * the explicit connected_users check is kept as a second line of
+             * defence. */
+            if (had_user
+                    && client->connected_users == 0
+                    && idle_cycles * GUACD_PROC_IDLE_TIMEOUT_MS
+                        >= GUACD_PROC_MAX_IDLE_MS) {
+                guacd_log(GUAC_LOG_WARNING,
+                        "Worker exceeded maximum idle time (%ds) with no "
+                        "connected users. Force exiting.",
+                        GUACD_PROC_MAX_IDLE_MS / 1000);
+                break;
+            }
+
+            continue;
+        }
+
+        if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL))
+            break;
+
+        received_fd = guacd_recv_fd(proc->fd_socket);
+        if (received_fd == -1)
+            break;
 
         guacd_proc_add_user(proc, received_fd, owner);
+        had_user = 1;
+        idle_cycles = 0;
 
         /* Future file descriptors are not owners */
         owner = 0;

--- a/src/guacd/proc.h
+++ b/src/guacd/proc.h
@@ -47,6 +47,30 @@
 #define GUACD_CLIENT_FREE_TIMEOUT 5
 
 /**
+ * The number of milliseconds the worker process will wait in poll()
+ * before checking whether the client is still alive. If no new user FDs
+ * arrive within this interval, the worker checks client state and user
+ * count to decide whether to continue waiting or exit.
+ */
+#define GUACD_PROC_IDLE_TIMEOUT_MS 5000
+
+/**
+ * Grace period (in milliseconds) after the last user disconnects before
+ * the worker process exits. This allows a brief window during which a
+ * reconnecting user (browser refresh, tab re-open) can rejoin without
+ * losing the underlying remote desktop session.
+ */
+#define GUACD_PROC_RECONNECT_GRACE_MS 60000
+
+/**
+ * Absolute maximum idle time (in milliseconds) after which a worker
+ * that once had a user will forcibly exit, regardless of client state. This
+ * catches edge cases where the normal exit path is blocked (e.g. FreeRDP's
+ * authenticate callback stuck in guac_argv_await).
+ */
+#define GUACD_PROC_MAX_IDLE_MS 120000
+
+/**
  * Process information of the internal remote desktop client.
  */
 typedef struct guacd_proc {


### PR DESCRIPTION
## Summary

Worker processes may remain alive indefinitely after all users have
disconnected, particularly under resource pressure (e.g. cgroup pids-limit).
Over days/weeks this leads to steady PID accumulation until no new connections
can be created.

### Root causes

**1. `pthread_create()` failure ignored in `guacd_proc_add_user()`**

When thread creation fails with EAGAIN (common under cgroup pids-limit), the
user thread never runs, so `guacd_proc_stop()` is never called and the worker
blocks in `recvmsg()` forever.

**2. Worker main loop blocks indefinitely in `recvmsg()`**

The loop in `guacd_exec_proc()` calls `guacd_recv_fd()` with no timeout or
health check. If `guacd_proc_stop()` is not triggered for any reason, the
worker hangs at 0% CPU consuming a PID slot indefinitely.

**3. RDP fail path does not clean up resources**

`guac_rdp_handle_connection()` does not free the display, FreeRDP instance,
keyboard, or SVC list on the fail path, leaking resources on every failed
connection attempt.

### Fix

- Handle `pthread_create()` failure by closing the FD, freeing params, and
  calling `guacd_proc_stop()`
- Replace the bare `recvmsg()` loop with a `poll()`-based loop that checks
  client state every 5 seconds (`GUACD_PROC_IDLE_TIMEOUT_MS`). Workers exit
  when the client has stopped or all users have disconnected. An absolute
  safety timeout (`GUACD_PROC_MAX_IDLE_MS` = 30s) handles edge cases where
  the normal exit path is blocked
- Add resource cleanup to the `fail` label in
  `guac_rdp_handle_connection()`

### JIRA

[GUACAMOLE-2265](https://issues.apache.org/jira/browse/GUACAMOLE-2265)

### Related

- [GUACAMOLE-2118](https://issues.apache.org/jira/browse/GUACAMOLE-2118) -
  Sporadic hanging connections after upgrade
- [GUACAMOLE-2143](https://issues.apache.org/jira/browse/GUACAMOLE-2143) -
  Improve process management to prevent zombie process accumulation

## Test plan

- [ ] Run guacd under cgroup with `pids.max=50`, create 60 concurrent
      connections, verify workers exit after disconnect
- [ ] Kill the user's browser mid-session, verify worker exits within 30s
- [ ] Trigger RDP connection failures (unreachable host), verify no resource
      leak via `/proc/[pid]/fd` count
- [ ] Stress test: 100 rapid connect/disconnect cycles, verify process count
      returns to baseline
- [ ] Verify normal operation is unaffected (long-running sessions, reconnect)