### PR TITLE
GUACAMOLE-2120: Ensure guac_terminal_options is zero-initialized.

### DIFF
--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -237,7 +237,7 @@ void* guac_terminal_thread(void* data) {
 guac_terminal_options* guac_terminal_options_create(
         int width, int height, int dpi) {
 
-    guac_terminal_options* options = guac_mem_alloc(sizeof(guac_terminal_options));
+    guac_terminal_options* options = guac_mem_zalloc(sizeof(guac_terminal_options));
 
     /* Set all required parameters */
     options->width = width;


### PR DESCRIPTION
The current use of `guac_mem_alloc` leaves the `guac_terminal_options` struct with uninitialized memory. This creates a fragile pattern where any future addition to the struct requires either manual initialization of the new field across all consumer functions, or explicit initialization within the allocation function itself.

If a developer adds a property but misses an initialization step, the field will contain indeterminate "garbage" data, leading to intermittent bugs, logic errors, or crashes that are difficult to debug. Switching to `guac_mem_zalloc` provides a fail-safe default of zero/NULL for all members, ensuring predictable behavior and preventing regressions as the API evolves.