### PR TITLE
GUACAMOLE-2270: Fix ABBA deadlock between guac_display_dup and guac_display_end_multiple_frames

### DIFF
--- a/src/libguac/display.c
+++ b/src/libguac/display.c
@@ -256,8 +256,35 @@ void guac_display_dup(guac_display* display, guac_socket* socket) {
 
         const guac_layer* layer = current->layer;
 
-        guac_rect layer_bounds;
-        guac_display_layer_get_bounds(current, &layer_bounds);
+        /* Read bounds directly from last_frame state (which is protected
+         * by display->last_frame.lock — already held above). Do NOT call
+         * guac_display_layer_get_bounds() here: that helper acquires
+         * display->pending_frame.lock and reads layer->pending_frame
+         * dimensions. Both are wrong here:
+         *
+         *   1. We are syncing the LAST FRAME state to a newly joined
+         *      user, so layer->last_frame.width/height is the correct
+         *      data source (every other field read in this loop already
+         *      uses current->last_frame.*).
+         *
+         *   2. Acquiring pending_frame.lock from this code path creates
+         *      an ABBA lock-order deadlock with
+         *      guac_display_end_multiple_frames(), which acquires
+         *      pending_frame.lock first and then last_frame.lock. With
+         *      this function holding last_frame.lock and waiting for
+         *      pending_frame.lock, while end_multiple_frames holds
+         *      pending_frame.lock and waits for last_frame.lock, the
+         *      pipeline wedges. Symptoms: guacd's VNC client thread,
+         *      pending-user-promotion thread, and render loop all
+         *      blocked on the display rwlocks; viewers see a black
+         *      screen because no draws ever flow.
+         */
+        guac_rect layer_bounds = {
+            .left   = 0,
+            .top    = 0,
+            .right  = current->last_frame.width,
+            .bottom = current->last_frame.height
+        };
 
         int width = guac_rect_width(&layer_bounds);
         int height = guac_rect_height(&layer_bounds);


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/GUACAMOLE-2270

## TL;DR

Multi-user sessions started intermittently freezing with viewers stuck on a black screen. Root cause is an ABBA rwlock deadlock between `guac_display_dup()` (user-join path) and `guac_display_end_multiple_frames()` (render-loop frame flush). Once wedged, the entire display pipeline starves and no draws flow. One-line fix inside `guac_display_dup` removes the cross-lock acquire that creates the cycle.

## Summary

`guac_display_dup()` and `guac_display_end_multiple_frames()` acquire `display->last_frame.lock` and `display->pending_frame.lock` in opposite orders:

| Function | Lock order |
|---|---|
| `guac_display_dup()` | `last_frame` (R) -> `pending_frame` (R) |
| `guac_display_end_multiple_frames()` | `pending_frame` (W) -> `last_frame` (W) |

`guac_display_dup()` takes `last_frame.lock` as a reader near its top, then inside the per-layer iteration loop calls `guac_display_layer_get_bounds()`, which itself acquires `pending_frame.lock` as a reader. `guac_display_end_multiple_frames()` takes `pending_frame.lock` as a writer and, when it is not deferring the frame, then takes `last_frame.lock` as a writer.

When a new user is being promoted (the protocol's `join_pending_handler` calling `guac_display_dup`) at the same time the render loop is flushing a frame (`guac_display_end_multiple_frames`), the two threads can wedge:

- T1 holds `last_frame.lock` (R), blocks acquiring `pending_frame.lock` (R)
- T2 holds `pending_frame.lock` (W), blocks acquiring `last_frame.lock` (W)

Under glibc's default rwlock policy, additional readers queue behind a waiting writer, so once T2 has parked on `last_frame.lock` as a writer, T1's pending read acquire never makes progress, and T2 cannot acquire `last_frame.lock` until T1 releases it. Neither does. The race is intermittent and timing-dependent: it requires `join_pending_handler` firing while `end_multiple_frames` is past its `defer_frame` early-return and into the second lock acquire.

## GDB evidence

Backtrace from a wedged guacd 1.6.0 process (one connection, four users juggling a join + a leave concurrent with a frame flush):

```
Thread A: guac_client_pending_users_thread()
            -> guac_client_promote_pending_users()
               -> protocol join_pending_handler
                  -> guac_display_dup()
                     -> guac_display_layer_get_bounds()
                        -> guac_rwlock_acquire_read_lock(pending_frame.lock)
                           -> pthread_rwlock_rdlock                    [BLOCKED]

Thread B: guac_display_render_loop()
            -> guac_display_end_multiple_frames()
               -> guac_rwlock_acquire_write_lock(last_frame.lock)
                  -> pthread_rwlock_wrlock                             [BLOCKED]

Thread C: protocol-client (e.g. VNC) main loop
            -> guac_display_layer_open_raw()
               -> guac_rwlock_acquire_write_lock(pending_frame.lock)
                  -> pthread_rwlock_wrlock                             [BLOCKED]

Thread D: guac_user_handle_connection()
            -> guac_client_add_pending_user()
               -> guac_rwlock_acquire_write_lock(client users-rwlock)
                  -> pthread_rwlock_wrlock                             [BLOCKED]

Thread E: guac_user_handle_connection()
            -> guac_client_remove_user()
               -> guac_rwlock_acquire_write_lock(client users-rwlock)
                  -> pthread_rwlock_wrlock                             [BLOCKED]
```

A custom acquire/release trace inserted into `rwlock.c` confirmed lock identity by pointer: Thread A held the read lock on `last_frame.lock` and was queued on `pending_frame.lock`; Thread B held the write lock on `pending_frame.lock` and was queued on `last_frame.lock`. No third party held either lock; the wedge was purely between A and B.

## Impact

Once wedged, the entire display pipeline starves: the protocol-client thread (e.g. VNC) blocks on `pending_frame.lock` trying to mutate a layer (`guac_display_layer_open_raw`); per-user add/remove paths block on the client-level users-rwlock, because the affected protocol-client thread's progress is required to release these locks. Viewers see a black screen, and no draws flow for the duration of the connection.

## Secondary issue: wrong field source

Aside from the deadlock, `guac_display_layer_get_bounds()` reads `layer->pending_frame.width` and `.height`. That is the wrong field source for `guac_display_dup()`. The function is iterating `display->last_frame`'s linked list of layers and duplicating the last-flushed frame state to a newly joined user. Every other per-layer field the loop reads already comes from `current->last_frame.*` (buffer, buffer_stride, parent, x, y, z, opacity, touches). Reading the pending dimensions but the last-frame pixel buffer can produce a corrupt sync if a layer resize landed between frames.

## Fix

Read width/height inline from `current->last_frame`, which is protected by `display->last_frame.lock` (already held by the surrounding function). The inline read drops the cross-lock acquire entirely, eliminating the ABBA cycle, and corrects the per-layer state source so the loop is internally consistent.

## Reproducer

Connect concurrently with multiple users to a session that produces frames continuously (any protocol whose render loop is active, with `guac_display_render_loop` kept hot). Have users join and leave in a loop. Pre-fix, the deadlock manifests within seconds and the connection stops producing frames; post-fix the same workload runs cleanly across repeated join/leave cycles.