### PR TITLE
GUACAMOLE-2223: Add require-recording flag

### DIFF
--- a/src/libguac/guacamole/recording.h
+++ b/src/libguac/guacamole/recording.h
@@ -115,6 +115,19 @@ typedef struct guac_recording {
      */
     int include_clipboard;
 
+    /**
+     * The client associated with this recording. Used to abort the connection
+     * if a write to the recording fails and require_recording is set.
+     */
+    guac_client* client;
+
+    /**
+     * Whether the connection should be aborted if writing to the recording
+     * fails. If non-zero, any write error on the recording socket will
+     * trigger a connection abort.
+     */
+    int require_recording;
+
 } guac_recording;
 
 /**
@@ -179,6 +192,11 @@ typedef struct guac_recording {
  *     caution. Clipboard can easily contain sensitive information, such as
  *     passwords, credit card numbers, etc.
  *
+ * @param require_recording
+ *     Non-zero if the connection should be aborted when a write to the
+ *     recording file fails, zero otherwise. If zero, write errors will be
+ *     silently ignored and the connection will continue.
+ *
  * @return
  *     A new guac_recording structure representing the in-progress
  *     recording if the recording file has been successfully created and a
@@ -187,7 +205,8 @@ typedef struct guac_recording {
 guac_recording* guac_recording_create(guac_client* client,
         const char* path, const char* name, int create_path,
         int include_output, int include_mouse, int include_touch,
-        int include_keys, int allow_write_existing, int include_clipboard);
+        int include_keys, int allow_write_existing, int include_clipboard,
+        int require_recording);
 
 /**
  * Frees the resources associated with the given in-progress recording. Note

--- a/src/libguac/recording.c
+++ b/src/libguac/recording.c
@@ -39,10 +39,134 @@
 #include <string.h>
 #include <unistd.h>
 
+/**
+ * Data specific to the write-required socket wrapper, which aborts the
+ * associated client connection if any write to the underlying socket fails.
+ */
+typedef struct guac_socket_require_write_data {
+
+    /**
+     * The wrapped socket to which all write operations are delegated.
+     */
+    guac_socket* wrapped;
+
+    /**
+     * The client to abort if a write fails.
+     */
+    guac_client* client;
+
+} guac_socket_require_write_data;
+
+/**
+ * Write handler for the require-write socket wrapper. Delegates the write to
+ * the wrapped socket, aborting the client connection on failure.
+ */
+static ssize_t __guac_socket_require_write_handler(guac_socket* socket,
+        const void* buf, size_t count) {
+
+    guac_socket_require_write_data* data =
+            (guac_socket_require_write_data*) socket->data;
+
+    if (guac_socket_write(data->wrapped, buf, count)) {
+        guac_client_abort(data->client,
+                GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+                "Write to recording failed. Aborting connection.");
+        return -1;
+    }
+
+    return count;
+
+}
+
+/**
+ * Flush handler for the require-write socket wrapper. Delegates the flush to
+ * the wrapped socket, aborting the client connection on failure.
+ */
+static ssize_t __guac_socket_require_flush_handler(guac_socket* socket) {
+
+    guac_socket_require_write_data* data =
+            (guac_socket_require_write_data*) socket->data;
+
+    if (guac_socket_flush(data->wrapped)) {
+        guac_client_abort(data->client,
+                GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+                "Flush of recording failed. Aborting connection.");
+        return -1;
+    }
+
+    return 0;
+
+}
+
+/**
+ * Lock handler for the require-write socket wrapper.
+ */
+static void __guac_socket_require_lock_handler(guac_socket* socket) {
+    guac_socket_require_write_data* data =
+            (guac_socket_require_write_data*) socket->data;
+    guac_socket_instruction_begin(data->wrapped);
+}
+
+/**
+ * Unlock handler for the require-write socket wrapper.
+ */
+static void __guac_socket_require_unlock_handler(guac_socket* socket) {
+    guac_socket_require_write_data* data =
+            (guac_socket_require_write_data*) socket->data;
+    guac_socket_instruction_end(data->wrapped);
+}
+
+/**
+ * Free handler for the require-write socket wrapper. Frees the wrapped socket
+ * and the wrapper data.
+ */
+static int __guac_socket_require_free_handler(guac_socket* socket) {
+    guac_socket_require_write_data* data =
+            (guac_socket_require_write_data*) socket->data;
+    guac_socket_free(data->wrapped);
+    guac_mem_free(data);
+    return 0;
+}
+
+/**
+ * Creates a socket wrapper that aborts the given client's connection if any
+ * write to the underlying socket fails.
+ *
+ * @param socket
+ *     The socket to wrap.
+ *
+ * @param client
+ *     The client to abort on write failure.
+ *
+ * @return
+ *     A new guac_socket that delegates to the given socket but aborts the
+ *     client on any write or flush error.
+ */
+static guac_socket* guac_socket_require_write(guac_socket* wrapped,
+        guac_client* client) {
+
+    guac_socket_require_write_data* data =
+            guac_mem_alloc(sizeof(guac_socket_require_write_data));
+    data->wrapped = wrapped;
+    data->client = client;
+
+    guac_socket* socket = guac_socket_alloc();
+    socket->data = data;
+    socket->write_handler = __guac_socket_require_write_handler;
+    socket->flush_handler = __guac_socket_require_flush_handler;
+    socket->lock_handler = __guac_socket_require_lock_handler;
+    socket->unlock_handler = __guac_socket_require_unlock_handler;
+    socket->free_handler = __guac_socket_require_free_handler;
+
+    return socket;
+
+}
+
 guac_recording* guac_recording_create(guac_client* client,
         const char* path, const char* name, int create_path,
         int include_output, int include_mouse, int include_touch,
-        int include_keys, int allow_write_existing, int include_clipboard) {
+        int include_keys, int allow_write_existing, int include_clipboard,
+        int require_recording) {
 
     char filename[GUAC_COMMON_RECORDING_MAX_NAME_LENGTH];
 
@@ -77,6 +201,14 @@ guac_recording* guac_recording_create(guac_client* client,
     recording->include_touch = include_touch;
     recording->include_keys = include_keys;
     recording->include_clipboard = include_clipboard;
+    recording->client = client;
+    recording->require_recording = require_recording;
+
+    /* If recording is required, wrap the recording socket so that any write
+     * failure will automatically abort the client connection */
+    if (require_recording)
+        recording->socket = guac_socket_require_write(
+                recording->socket, client);
 
     if (include_clipboard)
         recording->clipboard_stream = guac_client_alloc_stream(client);

--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -239,7 +239,8 @@ void* guac_kubernetes_client_thread(void* data) {
                 0, /* Touch events not supported */
                 settings->recording_include_keys,
                 settings->recording_write_existing,
-                settings->recording_include_clipboard);
+                settings->recording_include_clipboard,
+                settings->require_recording);
 
         /* If recording is required but failed, abort the connection */
         if (kubernetes_client->recording == NULL && settings->require_recording) {

--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -240,6 +240,14 @@ void* guac_kubernetes_client_thread(void* data) {
                 settings->recording_include_keys,
                 settings->recording_write_existing,
                 settings->recording_include_clipboard);
+
+        /* If recording is required but failed, abort the connection */
+        if (kubernetes_client->recording == NULL && settings->require_recording) {
+            guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+                    "Session recording is required but could not be created. "
+                    "Aborting connection.");
+            return NULL;
+        }
     }
 
     /* Create terminal options with required parameters */

--- a/src/protocols/kubernetes/settings.c
+++ b/src/protocols/kubernetes/settings.c
@@ -55,6 +55,7 @@ const char* GUAC_KUBERNETES_CLIENT_ARGS[] = {
     "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
+    "require-recording",
     "read-only",
     "backspace",
     "scrollback",
@@ -237,6 +238,12 @@ enum KUBERNETES_ARGS_IDX {
      * Disabled by default.
      */
     IDX_RECORDING_WRITE_EXISTING,
+
+    /**
+     * Whether recording is required. If set to "true", the connection will
+     * be closed if the recording cannot be created for any reason.
+     */
+    IDX_REQUIRE_RECORDING,
 
     /**
      * "true" if this connection should be read-only (user input should be
@@ -442,6 +449,11 @@ guac_kubernetes_settings* guac_kubernetes_parse_args(guac_user* user,
     settings->recording_write_existing =
         guac_user_parse_args_boolean(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
                 IDX_RECORDING_WRITE_EXISTING, false);
+
+    /* Parse require recording flag */
+    settings->require_recording =
+        guac_user_parse_args_boolean(user, GUAC_KUBERNETES_CLIENT_ARGS, argv,
+                IDX_REQUIRE_RECORDING, false);
 
     /* Parse backspace key code */
     settings->backspace =

--- a/src/protocols/kubernetes/settings.h
+++ b/src/protocols/kubernetes/settings.h
@@ -262,6 +262,13 @@ typedef struct guac_kubernetes_settings {
     bool recording_write_existing;
 
     /**
+     * Whether the connection should be closed when a recording cannot be
+     * created. Disabled by default, meaning the connection will proceed even
+     * if recording fails.
+     */
+    bool require_recording;
+
+    /**
      * The ASCII code, as an integer, that the Kubernetes client will use when
      * the backspace key is pressed. By default, this is 127, ASCII delete, if
      * not specified in the client settings.

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -940,6 +940,14 @@ void* guac_rdp_client_thread(void* data) {
                 settings->recording_include_keys,
                 settings->recording_write_existing,
                 settings->recording_include_clipboard);
+
+        /* If recording is required but failed, abort the connection */
+        if (rdp_client->recording == NULL && settings->require_recording) {
+            guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+                    "Session recording is required but could not be created. "
+                    "Aborting connection.");
+            return NULL;
+        }
     }
 
     /* Continue handling connections until error or client disconnect */

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -939,7 +939,8 @@ void* guac_rdp_client_thread(void* data) {
                 !settings->recording_exclude_touch,
                 settings->recording_include_keys,
                 settings->recording_write_existing,
-                settings->recording_include_clipboard);
+                settings->recording_include_clipboard,
+                settings->require_recording);
 
         /* If recording is required but failed, abort the connection */
         if (rdp_client->recording == NULL && settings->require_recording) {

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -128,6 +128,7 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
     "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
+    "require-recording",
     "resize-method",
     "enable-audio-input",
     "enable-touch",
@@ -603,6 +604,12 @@ enum RDP_ARGS_IDX {
      * Disabled by default.
      */
     IDX_RECORDING_WRITE_EXISTING,
+
+    /**
+     * Whether recording is required. If set to "true", the connection will
+     * be closed if the recording cannot be created for any reason.
+     */
+    IDX_REQUIRE_RECORDING,
 
     /**
      * The method to use to apply screen size changes requested by the user.
@@ -1231,6 +1238,11 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     settings->recording_write_existing =
         guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
                 IDX_RECORDING_WRITE_EXISTING, 0);
+
+    /* Parse require recording flag */
+    settings->require_recording =
+        guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_REQUIRE_RECORDING, 0);
 
     /* No resize method */
     if (strcmp(argv[IDX_RESIZE_METHOD], "") == 0) {

--- a/src/protocols/rdp/settings.h
+++ b/src/protocols/rdp/settings.h
@@ -605,6 +605,13 @@ typedef struct guac_rdp_settings {
      */
     int recording_write_existing;
 
+    /**
+     * Non-zero if the connection should be closed when a recording cannot be
+     * created. Zero by default, meaning the connection will proceed even if
+     * recording fails.
+     */
+    int require_recording;
+
     /** 
      * The method to apply when the user's display changes size.
      */

--- a/src/protocols/rdp/settings.h
+++ b/src/protocols/rdp/settings.h
@@ -606,11 +606,11 @@ typedef struct guac_rdp_settings {
     int recording_write_existing;
 
     /**
-     * Non-zero if the connection should be closed when a recording cannot be
-     * created. Zero by default, meaning the connection will proceed even if
-     * recording fails.
+     * Whether the connection should be closed when a recording cannot be
+     * created. Disabled by default, meaning the connection will proceed even
+     * if recording fails.
      */
-    int require_recording;
+    bool require_recording;
 
     /** 
      * The method to apply when the user's display changes size.

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -70,6 +70,7 @@ const char* GUAC_SSH_CLIENT_ARGS[] = {
     "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
+    "require-recording",
     "read-only",
     "server-alive-interval",
     "backspace",
@@ -276,6 +277,12 @@ enum SSH_ARGS_IDX {
      * Disabled by default.
      */
     IDX_RECORDING_WRITE_EXISTING,
+
+    /**
+     * Whether recording is required. If set to "true", the connection will
+     * be closed if the recording cannot be created for any reason.
+     */
+    IDX_REQUIRE_RECORDING,
 
     /**
      * "true" if this connection should be read-only (user input should be
@@ -561,6 +568,11 @@ guac_ssh_settings* guac_ssh_parse_args(guac_user* user,
     settings->recording_write_existing =
         guac_user_parse_args_boolean(user, GUAC_SSH_CLIENT_ARGS, argv,
                 IDX_RECORDING_WRITE_EXISTING, false);
+
+    /* Parse require recording flag */
+    settings->require_recording =
+        guac_user_parse_args_boolean(user, GUAC_SSH_CLIENT_ARGS, argv,
+                IDX_REQUIRE_RECORDING, false);
 
     /* Parse server alive interval */
     settings->server_alive_interval =

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -289,6 +289,13 @@ typedef struct guac_ssh_settings {
     bool recording_write_existing;
 
     /**
+     * Non-zero if the connection should be closed when a recording cannot be
+     * created. Zero by default, meaning the connection will proceed even if
+     * recording fails.
+     */
+    bool require_recording;
+
+    /**
      * The number of seconds between sending server alive messages.
      */
     int server_alive_interval;

--- a/src/protocols/ssh/settings.h
+++ b/src/protocols/ssh/settings.h
@@ -289,9 +289,9 @@ typedef struct guac_ssh_settings {
     bool recording_write_existing;
 
     /**
-     * Non-zero if the connection should be closed when a recording cannot be
-     * created. Zero by default, meaning the connection will proceed even if
-     * recording fails.
+     * Whether the connection should be closed when a recording cannot be
+     * created. Disabled by default, meaning the connection will proceed even
+     * if recording fails.
      */
     bool require_recording;
 

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -294,6 +294,14 @@ void* ssh_client_thread(void* data) {
                 settings->recording_include_keys,
                 settings->recording_write_existing,
                 settings->recording_include_clipboard);
+
+        /* If recording is required but failed, abort the connection */
+        if (ssh_client->recording == NULL && settings->require_recording) {
+            guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+                    "Session recording is required but could not be created. "
+                    "Aborting connection.");
+            return NULL;
+        }
     }
 
     /* Create terminal options with required parameters */

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -293,7 +293,8 @@ void* ssh_client_thread(void* data) {
                 0, /* Touch events not supported */
                 settings->recording_include_keys,
                 settings->recording_write_existing,
-                settings->recording_include_clipboard);
+                settings->recording_include_clipboard,
+                settings->require_recording);
 
         /* If recording is required but failed, abort the connection */
         if (ssh_client->recording == NULL && settings->require_recording) {

--- a/src/protocols/telnet/settings.c
+++ b/src/protocols/telnet/settings.c
@@ -61,6 +61,7 @@ const char* GUAC_TELNET_CLIENT_ARGS[] = {
     "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
+    "require-recording",
     "read-only",
     "backspace",
     "func-keys-and-keypad",
@@ -222,6 +223,12 @@ enum TELNET_ARGS_IDX {
      * Disabled by default.
      */
     IDX_RECORDING_WRITE_EXISTING,
+
+    /**
+     * Whether recording is required. If set to "true", the connection will
+     * be closed if the recording cannot be created for any reason.
+     */
+    IDX_REQUIRE_RECORDING,
 
     /**
      * "true" if this connection should be read-only (user input should be
@@ -541,6 +548,11 @@ guac_telnet_settings* guac_telnet_parse_args(guac_user* user,
     settings->recording_write_existing =
         guac_user_parse_args_boolean(user, GUAC_TELNET_CLIENT_ARGS, argv,
                 IDX_RECORDING_WRITE_EXISTING, false);
+
+    /* Parse require recording flag */
+    settings->require_recording =
+        guac_user_parse_args_boolean(user, GUAC_TELNET_CLIENT_ARGS, argv,
+                IDX_REQUIRE_RECORDING, false);
 
     /* Parse backspace key code */
     settings->backspace =

--- a/src/protocols/telnet/settings.h
+++ b/src/protocols/telnet/settings.h
@@ -265,6 +265,13 @@ typedef struct guac_telnet_settings {
     bool recording_write_existing;
 
     /**
+     * Non-zero if the connection should be closed when a recording cannot be
+     * created. Zero by default, meaning the connection will proceed even if
+     * recording fails.
+     */
+    bool require_recording;
+
+    /**
      * The ASCII code, as an integer, that the telnet client will use when the
      * backspace key is pressed.  By default, this is 127, ASCII delete, if
      * not specified in the client settings.

--- a/src/protocols/telnet/settings.h
+++ b/src/protocols/telnet/settings.h
@@ -265,9 +265,9 @@ typedef struct guac_telnet_settings {
     bool recording_write_existing;
 
     /**
-     * Non-zero if the connection should be closed when a recording cannot be
-     * created. Zero by default, meaning the connection will proceed even if
-     * recording fails.
+     * Whether the connection should be closed when a recording cannot be
+     * created. Disabled by default, meaning the connection will proceed even
+     * if recording fails.
      */
     bool require_recording;
 

--- a/src/protocols/telnet/telnet.c
+++ b/src/protocols/telnet/telnet.c
@@ -550,6 +550,14 @@ void* guac_telnet_client_thread(void* data) {
                 settings->recording_include_keys,
                 settings->recording_write_existing,
                 settings->recording_include_clipboard);
+
+        /* If recording is required but failed, abort the connection */
+        if (telnet_client->recording == NULL && settings->require_recording) {
+            guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+                    "Session recording is required but could not be created. "
+                    "Aborting connection.");
+            return NULL;
+        }
     }
 
     /* Create terminal options with required parameters */

--- a/src/protocols/telnet/telnet.c
+++ b/src/protocols/telnet/telnet.c
@@ -549,7 +549,8 @@ void* guac_telnet_client_thread(void* data) {
                 0, /* Touch events not supported */
                 settings->recording_include_keys,
                 settings->recording_write_existing,
-                settings->recording_include_clipboard);
+                settings->recording_include_clipboard,
+                settings->require_recording);
 
         /* If recording is required but failed, abort the connection */
         if (telnet_client->recording == NULL && settings->require_recording) {

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -92,6 +92,7 @@ const char* GUAC_VNC_CLIENT_ARGS[] = {
     "recording-include-clipboard",
     "create-recording-path",
     "recording-write-existing",
+    "require-recording",
     "clipboard-buffer-size",
     "disable-copy",
     "disable-paste",
@@ -377,6 +378,12 @@ enum VNC_ARGS_IDX {
      * Disabled by default.
      */
     IDX_RECORDING_WRITE_EXISTING,
+
+    /**
+     * Whether recording is required. If set to "true", the connection will
+     * be closed if the recording cannot be created for any reason.
+     */
+    IDX_REQUIRE_RECORDING,
 
     /**
      * The maximum number of bytes to allow within the clipboard.
@@ -703,6 +710,11 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
     settings->recording_write_existing =
         guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_RECORDING_WRITE_EXISTING, false);
+
+    /* Parse require recording flag */
+    settings->require_recording =
+        guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_REQUIRE_RECORDING, false);
 
     /* Parse clipboard copy disable flag */
     settings->disable_copy =

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -325,6 +325,13 @@ typedef struct guac_vnc_settings {
      * Disabled by default.
      */
     bool recording_write_existing;
+
+    /**
+     * Non-zero if the connection should be closed when a recording cannot be
+     * created. Zero by default, meaning the connection will proceed even if
+     * recording fails.
+     */
+    bool require_recording;
     
     /**
      * Whether or not to send the magic Wake-on-LAN (WoL) packet prior to

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -327,9 +327,9 @@ typedef struct guac_vnc_settings {
     bool recording_write_existing;
 
     /**
-     * Non-zero if the connection should be closed when a recording cannot be
-     * created. Zero by default, meaning the connection will proceed even if
-     * recording fails.
+     * Whether the connection should be closed when a recording cannot be
+     * created. Disabled by default, meaning the connection will proceed even
+     * if recording fails.
      */
     bool require_recording;
     

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -696,6 +696,14 @@ void* guac_vnc_client_thread(void* data) {
                 settings->recording_include_keys,
                 settings->recording_write_existing,
                 settings->recording_include_clipboard);
+
+        /* If recording is required but failed, abort the connection */
+        if (vnc_client->recording == NULL && settings->require_recording) {
+            guac_client_abort(client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
+                    "Session recording is required but could not be created. "
+                    "Aborting connection.");
+            return NULL;
+        }
     }
 
     /* Create display */

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -695,7 +695,8 @@ void* guac_vnc_client_thread(void* data) {
                 0, /* Touch events not supported */
                 settings->recording_include_keys,
                 settings->recording_write_existing,
-                settings->recording_include_clipboard);
+                settings->recording_include_clipboard,
+                settings->require_recording);
 
         /* If recording is required but failed, abort the connection */
         if (vnc_client->recording == NULL && settings->require_recording) {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/GUACAMOLE-2223

Naming convention for recording files may not always be unique leading to suffix exhaustion or file creation could fail due to various reasons. This pr adds a new `require-recording` flag to enforce recording file creation when a connection attempt is made. 

Current behavior: 
Connection is allowed even if it can't be recorded due to recording file creation failure. 

Expected behavior: 
When the session can't be recorded, reject the attempt for compliance. 