### PR TITLE
GUACAMOLE-2271: VNC: implement FinishedFrameBufferUpdate callback to optimize frame flushing.

### DIFF
--- a/src/libguac/display-render-thread.c
+++ b/src/libguac/display-render-thread.c
@@ -48,8 +48,10 @@
 /**
  * The start routine for the display render thread, consisting of a single
  * render loop. The render loop will proceed until signalled to stop,
- * determining frame boundaries via a combination of heuristics and explicit
- * marking (if available).
+ * determining frame boundaries via explicit marking when available (e.g. VNC's
+ * FinishedFrameBufferUpdate, RDP's frame markers), falling back to heuristics
+ * based on the timing of display modifications when the protocol handler
+ * provides no explicit frame boundaries.
  *
  * @param data
  *     The guac_display_render_thread structure containing the render thread

--- a/src/protocols/vnc/display.c
+++ b/src/protocols/vnc/display.c
@@ -307,6 +307,22 @@ void guac_vnc_display_set_size(rfbClient* client, int requested_width, int reque
 }
 #endif // LIBVNC_HAS_RESIZE_SUPPORT
 
+void guac_vnc_finished_frame(rfbClient* client) {
+
+    guac_client* gc = rfbClientGetClientData(client, GUAC_VNC_CLIENT_KEY);
+    guac_vnc_client* vnc_client = (guac_vnc_client*) gc->data;
+
+    if (!vnc_client->finished_frame_logged) {
+        guac_client_log(gc, GUAC_LOG_DEBUG,
+                "Received first FinishedFrameBufferUpdate callback from VNC server.");
+        vnc_client->finished_frame_logged = 1;
+    }
+
+    /* All rectangles in this FramebufferUpdate have been processed. */
+    guac_display_render_thread_notify_frame(vnc_client->render_thread);
+
+}
+
 void guac_vnc_set_pixel_format(rfbClient* client, int color_depth) {
     client->format.trueColour = 1;
     switch(color_depth) {

--- a/src/protocols/vnc/display.h
+++ b/src/protocols/vnc/display.h
@@ -117,6 +117,17 @@ void* guac_vnc_display_set_owner_size(guac_user* owner, void* data);
 void guac_vnc_display_set_size(rfbClient* client, int requested_width, int requested_height);
 
 /**
+ * Callback invoked by libVNCServer when all rectangles within a single
+ * FramebufferUpdate message have been fully processed. Signals the render
+ * thread that an explicit frame boundary has been reached.
+ *
+ * @param client
+ *     The VNC client associated with the VNC session in which the update
+ *     was completed.
+ */
+void guac_vnc_finished_frame(rfbClient* client);
+
+/**
  * Sets the pixel format to request of the VNC server. The request will be made
  * during the connection handshake with the VNC server using the values
  * specified by this function. Note that the VNC server is not required to

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -139,6 +139,8 @@ rfbClient* guac_vnc_get_client(guac_client* client) {
 
     /* Framebuffer update handler */
     rfb_client->GotFrameBufferUpdate = guac_vnc_update;
+    /* Framebuffer finished frame handler */
+    rfb_client->FinishedFrameBufferUpdate = guac_vnc_finished_frame;
     vnc_client->rfb_GotCopyRect = rfb_client->GotCopyRect;
     rfb_client->GotCopyRect = guac_vnc_copyrect;
 

--- a/src/protocols/vnc/vnc.h
+++ b/src/protocols/vnc/vnc.h
@@ -96,6 +96,11 @@ typedef struct guac_vnc_client {
     int copy_rect_used;
 
     /**
+     * Whether the first FinishedFrameBufferUpdate callback has been logged.
+     */
+    int finished_frame_logged;
+
+    /**
      * Client settings, parsed from args.
      */
     guac_vnc_settings* settings;
@@ -212,4 +217,3 @@ void* guac_vnc_client_thread(void* data);
 extern char* GUAC_VNC_CLIENT_KEY;
 
 #endif
-


### PR DESCRIPTION
While reviewing unimplemented VNC callbacks, I noticed `FinishedFrameBufferUpdate` is not currently supported.

Supporting `FinishedFrameBufferUpdate` will allow Guacamole to batch rectangle updates and flush them once per VNC framebuffer update, improving performance and rendering smoothness.

Without this callback, the render thread relies on heuristics (gaps in `notify_modified()` call timing) to infer frame boundaries, which can lead to premature or delayed flushes.

FYI, other VNC callbacks not supported:
- `FinishedFrameBufferUpdate`: Invoked after all updates to a frame are applied
- `Bell`: Invoked when the server sends a bell (audio) event
- `HandleTextChat`: Invoked for RFB text chat messages
- `HandleKeyboardLedState`: Invoked when keyboard LED state (Num/Caps/Scroll Lock) changes
- `HandleCursorPos`: Invoked when the remote cursor position is updated
- `SoftCursorLockArea`: Invoked to lock a region for software cursor updates
- `SoftCursorUnlockScreen`: Invoked to unlock the screen after cursor updates
- `HandleXvpMsg`: Invoked for XVP extension messages (power control`: shutdown/reboot/reset)
- `GotFillRect`: Invoked for solid-fill rectangle updates (Tight/ZRLE optimization)
- `GotBitmap`: Invoked for raw bitmap sub-rectangle updates
- `GotJpeg`: Invoked for JPEG-encoded sub-rectangle updates
- `GetSASLMechanism`: Invoked to select a SASL authentication mechanism
- `GetUser`: Invoked to retrieve the SASL username

Support for the following is being added in GUACAMOLE-2268.
`GotXCutTextUTF8`: Invoked when UTF-8 clipboard text is received via the extended clipboard mechanism