### PR TITLE
GUACAMOLE-2268: Gate VNC UTF-8 (Extended Clipboard) support behind config check.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -721,6 +721,30 @@ then
 fi
 
 #
+# libVNCServer support for the Extended Clipboard pseudo-encoding, which
+# allows clipboard text to be exchanged as UTF-8 via SendClientCutTextUTF8()
+# and the GotXCutTextUTF8 callback. Both were added in libvncserver 0.9.15.
+# If support is missing, Guacamole falls back to the classic VNC clipboard
+# with iconv-based encoding conversion.
+#
+
+if test "x${have_libvncserver}" = "xyes"
+then
+
+    have_vnc_extended_clipboard=yes
+    AC_CHECK_MEMBERS([rfbClient.GotXCutTextUTF8],
+                     [], [have_vnc_extended_clipboard=no],
+                     [[#include <rfb/rfbclient.h>]])
+
+    if test "x${have_vnc_extended_clipboard}" = "xyes"
+    then
+        AC_DEFINE([LIBVNC_CLIENT_HAS_EXTENDED_CLIPBOARD],,
+                  [Whether rfbClient supports the Extended Clipboard pseudo-encoding (UTF-8).])
+    fi
+
+fi
+
+#
 # FreeRDP (libfreerdpX, libfreerdp-clientX, and libwinprX)
 #
 

--- a/src/protocols/vnc/clipboard.c
+++ b/src/protocols/vnc/clipboard.c
@@ -108,6 +108,7 @@ int guac_vnc_clipboard_end_handler(guac_user* user, guac_stream* stream) {
     if (rfb_client == NULL)
         return 0;
 
+#ifdef LIBVNC_CLIENT_HAS_EXTENDED_CLIPBOARD
     /*
      * Guacamole stores clipboard text as UTF-8. The clipboard-encoding
      * setting only applies to the classic VNC clipboard path, where text
@@ -131,6 +132,7 @@ int guac_vnc_clipboard_end_handler(guac_user* user, guac_stream* stream) {
                     vnc_client->clipboard->length))
             return 0;
     }
+#endif
 
     /* Fall back to classic clipboard with encoding conversion */
     char output_data[GUAC_COMMON_CLIPBOARD_MAX_LENGTH];
@@ -174,6 +176,7 @@ void guac_vnc_cut_text(rfbClient* client, const char* text, int textlen) {
 
 }
 
+#ifdef LIBVNC_CLIENT_HAS_EXTENDED_CLIPBOARD
 void guac_vnc_cut_text_utf8(rfbClient* client, const char* text, int textlen) {
 
     guac_client* gc = rfbClientGetClientData(client, GUAC_VNC_CLIENT_KEY);
@@ -200,3 +203,4 @@ void guac_vnc_cut_text_utf8(rfbClient* client, const char* text, int textlen) {
     guac_common_clipboard_send(vnc_client->clipboard, gc);
 
 }
+#endif

--- a/src/protocols/vnc/clipboard.h
+++ b/src/protocols/vnc/clipboard.h
@@ -74,6 +74,7 @@ guac_user_end_handler guac_vnc_clipboard_end_handler;
  */
 void guac_vnc_cut_text(rfbClient* client, const char* text, int textlen);
 
+#ifdef LIBVNC_CLIENT_HAS_EXTENDED_CLIPBOARD
 /**
  * Handler for UTF-8 clipboard data received via the Extended Clipboard
  * pseudo-encoding, invoked by libVNCServer when the server sends clipboard
@@ -89,6 +90,7 @@ void guac_vnc_cut_text(rfbClient* client, const char* text, int textlen);
  *     The number of bytes in the clipboard text.
  */
 void guac_vnc_cut_text_utf8(rfbClient* client, const char* text, int textlen);
+#endif
 
 #endif
 

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -275,7 +275,9 @@ rfbClient* guac_vnc_get_client(guac_client* client) {
 
         /* Clipboard */
         rfb_client->GotXCutText = guac_vnc_cut_text;
+#ifdef LIBVNC_CLIENT_HAS_EXTENDED_CLIPBOARD
         rfb_client->GotXCutTextUTF8 = guac_vnc_cut_text_utf8;
+#endif
 
         /* Set remote cursor */
         if (vnc_settings->remote_cursor) {


### PR DESCRIPTION
SendClientCutTextUTF8 and rfbClient.GotXCutTextUTF8 are only available in libvncserver/libvncclient 0.9.15+.

This adds configure checks for the UTF-8 (Extended Clipboard) APIs and guards the affected call sites with #ifdefs. When unavailable, the VNC client falls back to the classic SendClientCutText path.

### Testing
```
libvncserver version 0.9.15:

autoreconf -I
./configure
…
checking for rfbClient.requestedResize... yes
checking for rfbClient.GotXCutTextUTF8... yes
…

libvncserver version 0.9.15:

autoreconf -I
./configure
…
checking for rfbClient.requestedResize... yes
checking for rfbClient.GotXCutTextUTF8... no
…
```
