### PR TITLE
GUACAMOLE-2123: Fix remote app render issues.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1081,6 +1081,54 @@ then
 fi
 if test "x${have_freerdp}" = "xyes"
 then
+    AC_MSG_CHECKING([whether FreeRDP supports RDPGFX surface area updates])
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+        #include <freerdp/client/rdpgfx.h>
+        #include <freerdp/codec/color.h>
+        #include <freerdp/codec/region.h>
+        #include <freerdp/gdi/gdi.h>
+        #include <freerdp/gdi/gfx.h>
+
+        int main() {
+            RdpgfxClientContext* context = 0;
+            rdpGdi* gdi = 0;
+            gdiGfxSurface* surface = 0;
+
+            (void) context->GetSurfaceData(context, 0);
+            (void) gdi_graphics_pipeline_init_ex(gdi, context, 0, 0, 0);
+            (void) surface->windowId;
+            (void) surface->mappedWidth;
+            (void) surface->mappedHeight;
+            (void) surface->outputTargetWidth;
+            (void) surface->outputTargetHeight;
+
+            return 0;
+        }
+    ]])],
+    [AC_MSG_RESULT([yes])]
+    [AC_DEFINE([HAVE_RDPGFX_SURFACE_AREA_UPDATE],,
+               [Defined if FreeRDP supports RDPGFX surface area update callbacks])],
+    [AC_MSG_RESULT([no])])
+fi
+if test "x${have_freerdp}" = "xyes"
+then
+    AC_MSG_CHECKING([whether FreeRDP supports RDPGFX window surface updates])
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+        #include <freerdp/client/rdpgfx.h>
+
+        int main() {
+            RdpgfxClientContext* context = 0;
+            context->UpdateWindowFromSurface = 0;
+            return 0;
+        }
+    ]])],
+    [AC_MSG_RESULT([yes])]
+    [AC_DEFINE([HAVE_RDPGFX_WINDOW_SURFACE_UPDATE],,
+               [Defined if FreeRDP supports RDPGFX updates for window-mapped surfaces])],
+    [AC_MSG_RESULT([no])])
+fi
+if test "x${have_freerdp}" = "xyes"
+then
     # Check whether FreeRDP 3.x requires const for GetPluginData
     AC_MSG_CHECKING([whether GetPluginData requires const for the returned args])
     AC_COMPILE_IFELSE([AC_LANG_SOURCE([[

--- a/src/protocols/rdp/channels/rail.c
+++ b/src/protocols/rdp/channels/rail.c
@@ -19,10 +19,20 @@
 
 #include "config.h"
 
+#include "color.h"
 #include "channels/rail.h"
 #include "plugins/channels.h"
 #include "rdp.h"
 #include "settings.h"
+
+#ifdef HAVE_RDPGFX_SURFACE_AREA_UPDATE
+#include <freerdp/codec/color.h>
+#include <freerdp/codec/region.h>
+#include <freerdp/gdi/gdi.h>
+#include <freerdp/gdi/gfx.h>
+#include <guacamole/display.h>
+#include <guacamole/rect.h>
+#endif
 
 #include <freerdp/client/rail.h>
 #include <freerdp/event.h>
@@ -36,6 +46,185 @@
 
 #include <stddef.h>
 #include <string.h>
+
+/*
+ * RemoteApp (RAIL) with the RDPGFX pipeline.
+ *
+ * When both RAIL and GFX are active, the RDP server delivers per-window
+ * graphical updates as RDPGFX surfaces tagged with a non-zero windowId
+ * (gdiGfxSurface->windowId). The default GDI graphics pipeline only knows how
+ * to paint into a single primary desktop buffer, so without intervention these
+ * window-mapped surfaces are silently dropped on the floor.
+ *
+ * This module tracks each RAIL window with its own guac_display_layer,
+ * positioned by the RAIL window-order stream and painted from the corresponding
+ * RDPGFX surface via either:
+ *
+ *   - UpdateWindowFromSurface (preferred; called once per surface per frame
+ *     with the surface's accumulated invalid region), or
+ *
+ *   - UpdateSurfaceArea (fallback for older FreeRDP without the window
+ *     callback; called with rect lists for any surface update).
+ *
+ * We never install both at once on the same surface: when the window callback
+ * is available, UpdateSurfaceArea is either not installed at all or no-ops on
+ * window-mapped surfaces.
+ */
+
+struct guac_rdp_rail_window {
+
+    /**
+     * The server-side ID of the RAIL window.
+     */
+    UINT64 window_id;
+
+    /**
+     * The Guacamole layer that renders the contents of this window.
+     */
+    guac_display_layer* layer;
+
+    /**
+     * The position of this window within the remote desktop.
+     */
+    int x;
+    int y;
+
+    /**
+     * Whether this window should be visible (per RAIL show state).
+     */
+    int visible;
+
+    /**
+     * Whether this window has received at least one graphical update from an
+     * RDPGFX surface.
+     */
+    int has_surface;
+
+    /**
+     * Whether a RAIL WindowCreate/Update order has been observed for this
+     * window. Layers created speculatively from a surface update (before any
+     * RAIL order arrives) are held off-screen until this is set.
+     */
+    int has_rail_order;
+
+    /**
+     * The current dimensions of the Guacamole layer.
+     */
+    int layer_width;
+    int layer_height;
+
+    /**
+     * The next RAIL window in the list.
+     */
+    guac_rdp_rail_window* next;
+
+};
+
+/**
+ * Returns whether RAIL window surfaces should be rendered through Guacamole
+ * layers for the given RDP client.
+ */
+static int guac_rdp_rail_uses_gfx(guac_rdp_client* rdp_client) {
+    return rdp_client->settings->remote_app != NULL
+        && rdp_client->settings->enable_gfx;
+}
+
+/**
+ * Returns the RAIL window having the given ID, or NULL if no such window is
+ * being tracked. The rail_windows_lock must be held.
+ */
+static guac_rdp_rail_window* guac_rdp_rail_get_window(
+        guac_rdp_client* rdp_client, UINT64 window_id) {
+
+    guac_rdp_rail_window* current = rdp_client->rail_windows;
+
+    while (current != NULL) {
+        if (current->window_id == window_id)
+            return current;
+        current = current->next;
+    }
+
+    return NULL;
+
+}
+
+/**
+ * Returns the RAIL window having the given ID, creating it if necessary.
+ * The rail_windows_lock must be held.
+ */
+static guac_rdp_rail_window* guac_rdp_rail_get_or_create_window(
+        guac_client* client, UINT64 window_id) {
+
+    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
+
+    guac_rdp_rail_window* rail_window =
+        guac_rdp_rail_get_window(rdp_client, window_id);
+
+    if (rail_window != NULL)
+        return rail_window;
+
+    rail_window = guac_mem_zalloc(sizeof(guac_rdp_rail_window));
+    if (rail_window == NULL) {
+        guac_client_log(client, GUAC_LOG_WARNING, "RAIL window 0x%08x could "
+                "not be tracked. Window contents may not render.",
+                (unsigned int) window_id);
+        return NULL;
+    }
+
+    rail_window->layer = guac_display_alloc_layer(rdp_client->display, 0);
+    if (rail_window->layer == NULL) {
+        guac_client_log(client, GUAC_LOG_WARNING, "RAIL window 0x%08x could "
+                "not be tracked. Window contents may not render.",
+                (unsigned int) window_id);
+        guac_mem_free(rail_window);
+        return NULL;
+    }
+
+    rail_window->window_id = window_id;
+    rail_window->visible = 1;
+
+    /* Keep the layer hidden until we have both a RAIL order (so we know where
+     * to put it) and at least one surface paint (so we have something to
+     * show). */
+    guac_display_layer_set_opacity(rail_window->layer, 0);
+
+    rail_window->next = rdp_client->rail_windows;
+    rdp_client->rail_windows = rail_window;
+
+    return rail_window;
+
+}
+
+/**
+ * Updates the visibility of the Guacamole layer backing the given RAIL window.
+ * The rail_windows_lock must be held.
+ */
+static void guac_rdp_rail_update_window_opacity(
+        guac_rdp_rail_window* rail_window) {
+
+    int opacity = (rail_window->visible
+            && rail_window->has_surface
+            && rail_window->has_rail_order) ? 0xFF : 0;
+    guac_display_layer_set_opacity(rail_window->layer, opacity);
+
+}
+
+/**
+ * Removes the given RAIL window from the list and frees its resources. The
+ * rail_windows_lock must be held.
+ */
+static void guac_rdp_rail_free_window(guac_rdp_client* rdp_client,
+        guac_rdp_rail_window* previous, guac_rdp_rail_window* rail_window) {
+
+    if (previous != NULL)
+        previous->next = rail_window->next;
+    else
+        rdp_client->rail_windows = rail_window->next;
+
+    guac_display_free_layer(rail_window->layer);
+    guac_mem_free(rail_window);
+
+}
 
 /**
  * Completes initialization of the RemoteApp session, responding to the server
@@ -259,6 +448,45 @@ static BOOL guac_rdp_rail_window_update(rdpContext* context,
 
     UINT32 fieldFlags = orderInfo->fieldFlags;
 
+    /* Track window location and visibility for RDPGFX RemoteApp rendering. */
+    if (guac_rdp_rail_uses_gfx(rdp_client)) {
+
+        pthread_mutex_lock(&(rdp_client->rail_windows_lock));
+
+        guac_rdp_rail_window* rail_window =
+            guac_rdp_rail_get_or_create_window(client, orderInfo->windowId);
+
+        if (rail_window != NULL) {
+
+            int needs_opacity_update = !rail_window->has_rail_order;
+            rail_window->has_rail_order = 1;
+
+            if (fieldFlags & WINDOW_ORDER_FIELD_WND_OFFSET) {
+                rail_window->x = windowState->windowOffsetX;
+                rail_window->y = windowState->windowOffsetY;
+                guac_display_layer_move(rail_window->layer,
+                        rail_window->x, rail_window->y);
+                rdp_client->gdi_modified = 1;
+            }
+
+            if (fieldFlags & WINDOW_ORDER_FIELD_SHOW) {
+                rail_window->visible =
+                    windowState->showState != GUAC_RDP_RAIL_WINDOW_STATE_HIDDEN
+                    && windowState->showState != GUAC_RDP_RAIL_WINDOW_STATE_MINIMIZED;
+                needs_opacity_update = 1;
+            }
+
+            if (needs_opacity_update) {
+                guac_rdp_rail_update_window_opacity(rail_window);
+                rdp_client->gdi_modified = 1;
+            }
+
+        }
+
+        pthread_mutex_unlock(&(rdp_client->rail_windows_lock));
+
+    }
+
     /* If the flag for window visibilty is set, check visibility. */
     if (fieldFlags & WINDOW_ORDER_FIELD_SHOW) {
         guac_client_log(client, GUAC_LOG_TRACE, "RAIL window visibility change: %d", windowState->showState);
@@ -276,6 +504,258 @@ static BOOL guac_rdp_rail_window_update(rdpContext* context,
     }
 
     return TRUE;
+
+}
+
+/**
+ * Handler for the RAIL WindowDelete order. Removes any tracked RAIL window
+ * with the given ID.
+ */
+static BOOL guac_rdp_rail_window_delete(rdpContext* context,
+        RAIL_CONST WINDOW_ORDER_INFO* orderInfo) {
+
+    guac_client* client = ((rdp_freerdp_context*) context)->client;
+    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
+
+    if (!guac_rdp_rail_uses_gfx(rdp_client))
+        return TRUE;
+
+    pthread_mutex_lock(&(rdp_client->rail_windows_lock));
+
+    guac_rdp_rail_window* previous = NULL;
+    guac_rdp_rail_window* current = rdp_client->rail_windows;
+
+    while (current != NULL) {
+        if (current->window_id == orderInfo->windowId) {
+            guac_rdp_rail_free_window(rdp_client, previous, current);
+            rdp_client->gdi_modified = 1;
+            break;
+        }
+        previous = current;
+        current = current->next;
+    }
+
+    pthread_mutex_unlock(&(rdp_client->rail_windows_lock));
+
+    return TRUE;
+
+}
+
+#ifdef HAVE_RDPGFX_SURFACE_AREA_UPDATE
+/**
+ * Copies updated regions from the given RDPGFX surface to the Guacamole layer
+ * associated with that surface's RAIL window. The rail_windows_lock must NOT
+ * be held on entry; this function takes it internally.
+ *
+ * The invalidRegion of the surface is left untouched. FreeRDP's GDI pipeline
+ * owns that region and may consume or clear it independently; touching it
+ * from these callbacks led to misplaced updates in early versions of this
+ * code (menus appearing in the wrong location, etc.) because regions were
+ * being double-consumed.
+ */
+static UINT guac_rdp_rail_paint_surface(guac_client* client,
+        gdiGfxSurface* surface, UINT32 rect_count, const RECTANGLE_16* rects) {
+
+    if (surface == NULL || surface->windowId == 0
+            || rects == NULL || rect_count == 0)
+        return CHANNEL_RC_OK;
+
+    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
+
+    pthread_mutex_lock(&(rdp_client->rail_windows_lock));
+
+    guac_rdp_rail_window* rail_window =
+        guac_rdp_rail_get_or_create_window(client, surface->windowId);
+
+    if (rail_window == NULL) {
+        pthread_mutex_unlock(&(rdp_client->rail_windows_lock));
+        return CHANNEL_RC_OK;
+    }
+
+    /* Per FreeRDP's gdi/gfx.c and xf_gfx.c, mappedWidth/Height and
+     * outputTargetWidth/Height are initialized to the same value at surface
+     * creation, and only diverge when an explicit MapSurfaceToScaledWindow
+     * order rescales the surface. We honor any divergence but optimize for
+     * the common 1:1 case with a plain copy. */
+    int source_width = surface->mappedWidth;
+    int source_height = surface->mappedHeight;
+    int target_width = surface->outputTargetWidth;
+    int target_height = surface->outputTargetHeight;
+
+    if (target_width <= 0) target_width = source_width;
+    if (target_height <= 0) target_height = source_height;
+
+    if (source_width <= 0 || source_height <= 0
+            || target_width <= 0 || target_height <= 0) {
+        rail_window->has_surface = 0;
+        guac_rdp_rail_update_window_opacity(rail_window);
+        pthread_mutex_unlock(&(rdp_client->rail_windows_lock));
+        return CHANNEL_RC_OK;
+    }
+
+    int scaled = (source_width != target_width
+            || source_height != target_height);
+
+    if (rail_window->layer_width != target_width
+            || rail_window->layer_height != target_height) {
+        guac_display_layer_resize(rail_window->layer,
+                target_width, target_height);
+        rail_window->layer_width = target_width;
+        rail_window->layer_height = target_height;
+    }
+
+    guac_display_layer_raw_context* layer_context =
+        guac_display_layer_open_raw(rail_window->layer);
+
+    guac_rect source_bounds;
+    guac_rect_init(&source_bounds, 0, 0, source_width, source_height);
+
+    for (UINT32 i = 0; i < rect_count; i++) {
+
+        const RECTANGLE_16* rect = &rects[i];
+        guac_rect src_rect;
+        guac_rect_init(&src_rect, rect->left, rect->top,
+                rect->right - rect->left, rect->bottom - rect->top);
+
+        guac_rect_constrain(&src_rect, &source_bounds);
+        if (guac_rect_is_empty(&src_rect))
+            continue;
+
+        guac_rect dst_rect;
+        if (scaled) {
+            dst_rect.left =
+                ((UINT64) src_rect.left * target_width) / source_width;
+            dst_rect.top =
+                ((UINT64) src_rect.top * target_height) / source_height;
+            dst_rect.right =
+                (((UINT64) src_rect.right * target_width)
+                    + source_width - 1) / source_width;
+            dst_rect.bottom =
+                (((UINT64) src_rect.bottom * target_height)
+                    + source_height - 1) / source_height;
+        }
+        else {
+            dst_rect = src_rect;
+        }
+
+        guac_rect_constrain(&dst_rect, &layer_context->bounds);
+        if (guac_rect_is_empty(&dst_rect))
+            continue;
+
+        BOOL success;
+        if (!scaled)
+            success = freerdp_image_copy(
+                    GUAC_DISPLAY_LAYER_RAW_BUFFER(layer_context, dst_rect),
+                    guac_rdp_get_native_pixel_format(TRUE),
+                    layer_context->stride,
+                    0, 0,
+                    guac_rect_width(&dst_rect),
+                    guac_rect_height(&dst_rect),
+                    surface->data, surface->format, surface->scanline,
+                    src_rect.left, src_rect.top,
+                    NULL, FREERDP_FLIP_NONE);
+        else
+            success = freerdp_image_scale(
+                    GUAC_DISPLAY_LAYER_RAW_BUFFER(layer_context, dst_rect),
+                    guac_rdp_get_native_pixel_format(TRUE),
+                    layer_context->stride,
+                    0, 0,
+                    guac_rect_width(&dst_rect),
+                    guac_rect_height(&dst_rect),
+                    surface->data, surface->format, surface->scanline,
+                    src_rect.left, src_rect.top,
+                    guac_rect_width(&src_rect),
+                    guac_rect_height(&src_rect));
+
+        if (!success) {
+            guac_display_layer_close_raw(rail_window->layer, layer_context);
+            pthread_mutex_unlock(&(rdp_client->rail_windows_lock));
+            return ERROR_INTERNAL_ERROR;
+        }
+
+        guac_rect_extend(&layer_context->dirty, &dst_rect);
+
+    }
+
+    guac_display_layer_close_raw(rail_window->layer, layer_context);
+
+    rail_window->has_surface = 1;
+    guac_rdp_rail_update_window_opacity(rail_window);
+    rdp_client->gdi_modified = 1;
+
+    pthread_mutex_unlock(&(rdp_client->rail_windows_lock));
+
+    return CHANNEL_RC_OK;
+
+}
+
+UINT guac_rdp_rail_update_surface_area(RdpgfxClientContext* context,
+        UINT16 surface_id, UINT32 rect_count, const RECTANGLE_16* rects) {
+
+    rdpGdi* gdi = (rdpGdi*) context->custom;
+    if (gdi == NULL || gdi->context == NULL || gdi->suppressOutput)
+        return CHANNEL_RC_OK;
+
+    if (context->GetSurfaceData == NULL)
+        return CHANNEL_RC_OK;
+
+    gdiGfxSurface* surface =
+        (gdiGfxSurface*) context->GetSurfaceData(context, surface_id);
+
+    /* Only window-mapped surfaces are routed through us; non-RAIL surfaces
+     * are handled by FreeRDP's default GDI pipeline. We return early without
+     * touching invalidRegion so the default path can consume it normally on
+     * the next UpdateSurfaces tick. */
+    if (surface == NULL || surface->windowId == 0)
+        return CHANNEL_RC_OK;
+
+    guac_client* client = ((rdp_freerdp_context*) gdi->context)->client;
+    return guac_rdp_rail_paint_surface(client, surface, rect_count, rects);
+
+}
+
+#ifdef HAVE_RDPGFX_WINDOW_SURFACE_UPDATE
+UINT guac_rdp_rail_update_window_from_surface(RdpgfxClientContext* context,
+        gdiGfxSurface* surface) {
+
+    rdpGdi* gdi = (rdpGdi*) context->custom;
+    if (gdi == NULL || gdi->context == NULL || gdi->suppressOutput)
+        return CHANNEL_RC_OK;
+
+    if (surface == NULL || surface->windowId == 0)
+        return CHANNEL_RC_OK;
+
+    guac_client* client = ((rdp_freerdp_context*) gdi->context)->client;
+
+    /* Snapshot the rect list before painting. region16_rects() returns a
+     * pointer into the region's internal storage, which is only valid until
+     * the region is next modified. FreeRDP's GDI pipeline clears
+     * invalidRegion after this callback returns. */
+    UINT32 rect_count = 0;
+    const RECTANGLE_16* rects =
+        region16_rects(&surface->invalidRegion, &rect_count);
+
+    return guac_rdp_rail_paint_surface(client, surface, rect_count, rects);
+
+}
+#endif
+#endif
+
+void guac_rdp_rail_free_windows(guac_rdp_client* rdp_client) {
+
+    pthread_mutex_lock(&(rdp_client->rail_windows_lock));
+
+    guac_rdp_rail_window* current = rdp_client->rail_windows;
+    rdp_client->rail_windows = NULL;
+
+    while (current != NULL) {
+        guac_rdp_rail_window* next = current->next;
+        guac_display_free_layer(current->layer);
+        guac_mem_free(current);
+        current = next;
+    }
+
+    pthread_mutex_unlock(&(rdp_client->rail_windows_lock));
 
 }
 
@@ -318,7 +798,9 @@ static void guac_rdp_rail_channel_connected(rdpContext* context,
     rail->ServerExecuteResult = guac_rdp_rail_execute_result;
     rail->ServerHandshake = guac_rdp_rail_handshake;
     rail->ServerHandshakeEx = guac_rdp_rail_handshake_ex;
+    context->update->window->WindowCreate = guac_rdp_rail_window_update;
     context->update->window->WindowUpdate = guac_rdp_rail_window_update;
+    context->update->window->WindowDelete = guac_rdp_rail_window_delete;
 
     guac_client_log(client, GUAC_LOG_DEBUG, "RAIL (RemoteApp) channel "
             "connected.");

--- a/src/protocols/rdp/channels/rail.h
+++ b/src/protocols/rdp/channels/rail.h
@@ -23,6 +23,13 @@
 #include <freerdp/freerdp.h>
 #include <freerdp/window.h>
 
+struct guac_rdp_client;
+
+#ifdef HAVE_RDPGFX_SURFACE_AREA_UPDATE
+#include <freerdp/client/rdpgfx.h>
+#include <freerdp/gdi/gfx.h>
+#endif
+
 #ifdef FREERDP_RAIL_CALLBACKS_REQUIRE_CONST
 /**
  * FreeRDP 2.0.0-rc4 and newer requires the final arguments for RAIL
@@ -59,6 +66,36 @@
  *     The rdpContext associated with the FreeRDP side of the RDP connection.
  */
 void guac_rdp_rail_load_plugin(rdpContext* context);
+
+#ifdef HAVE_RDPGFX_SURFACE_AREA_UPDATE
+/**
+ * Updates the Guacamole display layer for a RAIL window from modified areas of
+ * the given RDPGFX surface. Non-RAIL (windowId == 0) surfaces are ignored and
+ * left for FreeRDP's default GDI pipeline.
+ *
+ * Used only as a fallback when UpdateWindowFromSurface is unavailable in the
+ * installed FreeRDP. The invalidRegion of the surface is NOT cleared.
+ */
+UINT guac_rdp_rail_update_surface_area(RdpgfxClientContext* context,
+        UINT16 surface_id, UINT32 rect_count, const RECTANGLE_16* rects);
+
+#ifdef HAVE_RDPGFX_WINDOW_SURFACE_UPDATE
+/**
+ * Updates the Guacamole display layer for a RAIL window from the given
+ * window-mapped RDPGFX surface. FreeRDP's GDI pipeline calls this once per
+ * surface per frame, with the surface's accumulated invalidRegion, and
+ * subsequently clears that region itself.
+ */
+UINT guac_rdp_rail_update_window_from_surface(RdpgfxClientContext* context,
+        gdiGfxSurface* surface);
+#endif
+#endif
+
+/**
+ * Frees all RAIL window state tracked for RemoteApp rendering. Safe to call
+ * even when no RAIL windows are tracked.
+ */
+void guac_rdp_rail_free_windows(struct guac_rdp_client* rdp_client);
 
 #endif
 

--- a/src/protocols/rdp/channels/rdpgfx.c
+++ b/src/protocols/rdp/channels/rdpgfx.c
@@ -17,7 +17,10 @@
  * under the License.
  */
 
+#include "config.h"
+
 #include "channels/rdpgfx.h"
+#include "channels/rail.h"
 #include "plugins/channels.h"
 #include "rdp.h"
 #include "settings.h"
@@ -58,16 +61,56 @@ static void guac_rdp_rdpgfx_channel_connected(rdpContext* context,
     if (strcmp(args->name, RDPGFX_DVC_CHANNEL_NAME) != 0)
         return;
 
-    /* Init GDI-backed support for the Graphics Pipeline */
     RdpgfxClientContext* rdpgfx = (RdpgfxClientContext*) args->pInterface;
     rdpGdi* gdi = context->gdi;
+    guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;
+    guac_rdp_settings* settings = rdp_client->settings;
+    BOOL gfx_initialized;
 
-    if (!gdi_graphics_pipeline_init(gdi, rdpgfx))
+    /*
+     * RAIL+GFX rendering selection:
+     *
+     *   Newest FreeRDP (HAVE_RDPGFX_WINDOW_SURFACE_UPDATE): use the default
+     *   gdi_graphics_pipeline_init and override UpdateWindowFromSurface. The
+     *   default GDI UpdateSurfaceArea will still run for non-window surfaces;
+     *   for window surfaces it harmlessly paints into a primary buffer that is
+     *   never displayed, and UpdateWindowFromSurface is the authoritative path
+     *   for RAIL rendering.
+     *
+     *   Older FreeRDP without UpdateWindowFromSurface but with the _ex init
+     *   (HAVE_RDPGFX_SURFACE_AREA_UPDATE only): wire up our UpdateSurfaceArea
+     *   via the _ex form. Our handler ignores non-window surfaces, letting the
+     *   default GDI pipeline handle them (note: the _ex form does NOT install
+     *   the default UpdateSurfaceArea, but the default UpdateSurfaces loop
+     *   still paints non-window surfaces to the primary GDI buffer on each
+     *   tick, which is what we want for the non-RAIL desktop case).
+     *
+     *   Anything older: fall back to the default init. RAIL+GFX will not
+     *   render correctly; users must disable GFX for RemoteApp.
+     */
+
+#if defined(HAVE_RDPGFX_SURFACE_AREA_UPDATE) \
+        && !defined(HAVE_RDPGFX_WINDOW_SURFACE_UPDATE)
+    gfx_initialized = (settings->remote_app != NULL)
+        ? gdi_graphics_pipeline_init_ex(gdi, rdpgfx, NULL, NULL,
+                guac_rdp_rail_update_surface_area)
+        : gdi_graphics_pipeline_init(gdi, rdpgfx);
+#else
+    gfx_initialized = gdi_graphics_pipeline_init(gdi, rdpgfx);
+#endif
+
+    if (!gfx_initialized) {
         guac_client_log(client, GUAC_LOG_WARNING, "Rendering backend for RDPGFX "
                 "channel could not be loaded. Graphics may not render at all!");
-    else
+    } else {
+#ifdef HAVE_RDPGFX_WINDOW_SURFACE_UPDATE
+        if (settings->remote_app != NULL)
+            rdpgfx->UpdateWindowFromSurface =
+                guac_rdp_rail_update_window_from_surface;
+#endif
         guac_client_log(client, GUAC_LOG_DEBUG, "RDPGFX channel will be used for "
                 "the RDP Graphics Pipeline Extension.");
+    }
 
 }
 
@@ -119,4 +162,3 @@ void guac_rdp_rdpgfx_load_plugin(rdpContext* context) {
     guac_freerdp_dynamic_channel_collection_add(context->settings, "rdpgfx", NULL);
 
 }
-

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -232,6 +232,7 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
     /* Init required locks */
     guac_rwlock_init(&(rdp_client->lock));
     pthread_mutex_init(&(rdp_client->message_lock), &(rdp_client->attributes));
+    pthread_mutex_init(&(rdp_client->rail_windows_lock), &(rdp_client->attributes));
 
     /* Set handlers */
     client->join_handler = guac_rdp_user_join_handler;
@@ -320,6 +321,7 @@ int guac_rdp_client_free_handler(guac_client* client) {
         guac_rdp_audio_buffer_free(rdp_client->audio_input);
 
     guac_rwlock_destroy(&(rdp_client->lock));
+    pthread_mutex_destroy(&(rdp_client->rail_windows_lock));
     pthread_mutex_destroy(&(rdp_client->message_lock));
 
     /* Free client data */

--- a/src/protocols/rdp/gdi.c
+++ b/src/protocols/rdp/gdi.c
@@ -128,14 +128,24 @@ BOOL guac_rdp_gdi_end_paint(rdpContext* context) {
      * checking and bailing out here if an external bug breaks that. */
     GUAC_ASSERT(w <= INT_MAX && h <= INT_MAX);
 
-    /* Mark modified region as dirty, but only within the bounds of the
-     * rendering surface */
-    guac_rect dst_rect;
-    guac_rect_init(&dst_rect, x, y, w, h);
-    guac_rect_constrain(&dst_rect, &current_context->bounds);
-    guac_rect_extend(&current_context->dirty, &dst_rect);
+    /*
+     *For RemoteApp connections the default layer is held
+     * permanently black (filled once in guac_rdp_handle_connection).
+     * Suppress dirty-region propagation so FreeRDP's ongoing painting of
+     * the server desktop into gdi->primary_buffer is never sent to the client.
+     */
+    if (rdp_client->settings->remote_app == NULL) {
 
-    rdp_client->gdi_modified = 1;
+        /* Mark modified region as dirty, but only within the bounds of the
+         * rendering surface */
+        guac_rect dst_rect;
+        guac_rect_init(&dst_rect, x, y, w, h);
+        guac_rect_constrain(&dst_rect, &current_context->bounds);
+        guac_rect_extend(&current_context->dirty, &dst_rect);
+
+        rdp_client->gdi_modified = 1;
+
+    }
 
 paint_complete:
 

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -536,6 +536,54 @@ static int guac_rdp_handle_connection(guac_client* client) {
     guac_display_layer* default_layer = guac_display_default_layer(rdp_client->display);
     guac_display_layer_resize(default_layer, rdp_client->settings->width, rdp_client->settings->height);
 
+    /*
+     * For RemoteApp connections, the default layer
+     * represents the (invisible) desktop behind the application windows.
+     * Fill it once with opaque black; guac_rdp_gdi_end_paint refuses to
+     * mark it dirty again for the rest of the session, so FreeRDP's
+     * ongoing painting of the server desktop into the shared GDI primary
+     * buffer never reaches the client.
+     *
+     * Without this, GFX-enabled RemoteApp sessions show the server's
+     * desktop behind the application
+     * windows because gdi->primary_buffer shares memory with the default
+     * layer and FreeRDP paints all windowId==0 surfaces into it.
+     */
+    if (rdp_client->settings->remote_app != NULL) {
+
+        guac_display_layer_raw_context* bg_ctx =
+                guac_display_layer_open_raw(default_layer);
+
+        if (bg_ctx != NULL) {
+
+            guac_rect full_bounds = bg_ctx->bounds;
+            int height = guac_rect_height(&full_bounds);
+            int width = guac_rect_width(&full_bounds);
+
+            unsigned char* row =
+                    GUAC_DISPLAY_LAYER_RAW_BUFFER(bg_ctx, full_bounds);
+
+            for (int y = 0; y < height; y++) {
+                unsigned char* pixel = row;
+                for (int x = 0; x < width; x++) {
+                    pixel[0] = 0x00;  /* B */
+                    pixel[1] = 0x00;  /* G */
+                    pixel[2] = 0x00;  /* R */
+                    pixel[3] = 0xFF;  /* A */
+                    pixel += 4;
+                }
+                row += bg_ctx->stride;
+            }
+
+            guac_rect_extend(&bg_ctx->dirty, &full_bounds);
+            guac_display_layer_close_raw(default_layer, bg_ctx);
+
+            rdp_client->gdi_modified = 1;
+
+        }
+
+    }
+
     /* Use lossless compression only if requested (otherwise, use default
      * heuristics) */
     guac_display_layer_set_lossless(default_layer, settings->lossless);
@@ -681,6 +729,9 @@ static int guac_rdp_handle_connection(guac_client* client) {
     /* Stop render loop */
     guac_display_render_thread_destroy(rdp_client->render_thread);
     rdp_client->render_thread = NULL;
+
+    /* Free any RAIL windows tracked for RemoteApp rendering */
+    guac_rdp_rail_free_windows(rdp_client);
 
     /* Remove reference to FreeRDP's GDI buffer so that it can be safely freed
      * prior to freeing the guac_display */

--- a/src/protocols/rdp/rdp.h
+++ b/src/protocols/rdp/rdp.h
@@ -72,6 +72,11 @@
 #define GUAC_RDP_INPUT_EVENT_QUEUE_SIZE 4096
 
 /**
+ * RDP-specific RAIL window data.
+ */
+typedef struct guac_rdp_rail_window guac_rdp_rail_window;
+
+/**
  * RDP-specific client data.
  */
 typedef struct guac_rdp_client {
@@ -246,6 +251,16 @@ typedef struct guac_rdp_client {
      * in use.
      */
     RailClientContext* rail_interface;
+
+    /**
+     * Lock which synchronizes access to the list of RAIL windows.
+     */
+    pthread_mutex_t rail_windows_lock;
+
+    /**
+     * The list of RAIL windows being tracked for RemoteApp rendering.
+     */
+    guac_rdp_rail_window* rail_windows;
 
 } guac_rdp_client;
 


### PR DESCRIPTION
Fixing remote app render issues with this patch, using per-window guac_display_layer for remote apps. Also introducing a fix for stale desktop background on RDPGFX.

Using per-window guac_display_layer for remote apps and also prevent dirty-region propagation to desktop background. Added support for UpdateSurfaceArea (FreeRDP 2.x) and UpdateWindowFromSurface (FreeRDP 3.x)

When Guacamole's RDP plugin is configured with both RemoteApp and the RDPGFX pipeline enabled, remote application windows fail to render. 
With GFX active, FreeRDP does not update RAIL window contents via BeginPaint/Endpaint, but via RDPGFX surfaces using windowId and callbacks.
For FreeRDP 3.x: UpdateWindowFromSurface is called per window-mapped surface with its accumulated invalid region.
For FreeRDP 2.x: UpdateSurfaceArea is called per surface with a rect list.

This patch has a dedicated guac_display_layer for each remote app and derives visibility via showState. Surface content painted with RDPGFX callbacks and scaled to correct size.
Layer is kept hidden until both window position is known and at least one surface paint request has arrived, avoiding flashes and race conditions.

Tested remote apps with FreeRDP 3.26.0 with the latest staging/1.6.1 branch, also built with 2.11.7.
