### PR TITLE
GUACAMOLE-2002: Warn on clipboard truncation instead of silently dropping data

### DIFF
--- a/src/protocols/rdp/channels/cliprdr.c
+++ b/src/protocols/rdp/channels/cliprdr.c
@@ -403,8 +403,19 @@ static UINT guac_rdp_cliprdr_format_data_request(CliprdrClientContext* cliprdr,
      * requested */
     BYTE* start = (BYTE*) output;
     guac_iconv_read* local_reader = settings->normalize_clipboard ? GUAC_READ_UTF8_NORMALIZED : GUAC_READ_UTF8;
-    guac_iconv(local_reader, &input, clipboard->clipboard->length,
-            remote_writer, &output, output_buf_size);
+
+    /* A zero return indicates the output buffer filled before all input was
+     * consumed (truncation). Charset expansion (UTF-8 -> UTF-16, CRLF
+     * translation, or multi-byte characters such as emoji) can outgrow the
+     * configured clipboard buffer, so warn the operator rather than silently
+     * sending truncated data. */
+    if (!guac_iconv(local_reader, &input, clipboard->clipboard->length,
+            remote_writer, &output, output_buf_size)) {
+        guac_client_log(client, GUAC_LOG_WARNING, "CLIPRDR: Outbound clipboard "
+                "data was truncated to fit the %d-byte clipboard buffer. "
+                "Increase \"clipboard-buffer-size\" to transfer larger "
+                "clipboard content.", output_buf_size);
+    }
 
     CLIPRDR_FORMAT_DATA_RESPONSE data_response = {
         .requestedFormatData = (BYTE*) start,
@@ -513,11 +524,17 @@ static UINT guac_rdp_cliprdr_format_data_response(CliprdrClientContext* cliprdr,
     data_len = format_data_response->dataLen;
     #endif
 
-    /* Convert, store, and forward the clipboard data received from RDP
-     * server */
-    if (guac_iconv(remote_reader, &input, data_len,
-            GUAC_WRITE_UTF8, &output, output_buf_size)) {
-        int length = strnlen(received_data, output_buf_size);
+    /* Convert the clipboard data received from the RDP server. A zero return
+     * indicates the output buffer filled before all input was consumed
+     * (truncation) due to charset expansion. */
+    int converted = guac_iconv(remote_reader, &input, data_len,
+            GUAC_WRITE_UTF8, &output, output_buf_size);
+
+    /* Store and forward whatever was converted, even if truncated. Partial
+     * clipboard text is still useful, so we deliver it and warn the operator
+     * rather than dropping the paste entirely. */
+    int length = strnlen(received_data, output_buf_size);
+    if (length > 0) {
         guac_common_clipboard_reset(clipboard->clipboard, "text/plain");
         guac_common_clipboard_append(clipboard->clipboard, received_data, length);
         guac_common_clipboard_send(clipboard->clipboard, client);
@@ -528,6 +545,13 @@ static UINT guac_rdp_cliprdr_format_data_response(CliprdrClientContext* cliprdr,
                     clipboard->clipboard->mimetype,
                     clipboard->clipboard->buffer,
                     clipboard->clipboard->length);
+    }
+
+    if (!converted) {
+        guac_client_log(client, GUAC_LOG_WARNING, "CLIPRDR: Inbound clipboard "
+                "data was truncated to fit the %d-byte clipboard buffer. "
+                "Increase \"clipboard-buffer-size\" to receive larger "
+                "clipboard content.", output_buf_size);
     }
 
     guac_mem_free(received_data);

--- a/src/protocols/vnc/clipboard.c
+++ b/src/protocols/vnc/clipboard.c
@@ -191,9 +191,16 @@ int guac_vnc_clipboard_end_handler(guac_user* user, guac_stream* stream) {
     char* output = output_data;
     guac_iconv_write* writer = vnc_client->clipboard_writer;
 
-    /* Convert clipboard contents */
-    guac_iconv(GUAC_READ_UTF8, &input, clipboard->length,
-               writer, &output, output_buf_size);
+    /* Convert clipboard contents. A zero return indicates the output buffer
+     * filled before all input was consumed (truncation) due to charset
+     * expansion; warn rather than silently sending truncated data. */
+    if (!guac_iconv(GUAC_READ_UTF8, &input, clipboard->length,
+               writer, &output, output_buf_size)) {
+        guac_client_log(client, GUAC_LOG_WARNING, "VNC: Outbound clipboard "
+                "data was truncated to fit the %d-byte clipboard buffer. "
+                "Increase \"clipboard-buffer-size\" to transfer larger "
+                "clipboard content.", output_buf_size);
+    }
 
     SendClientCutText(rfb_client, output_data, output - output_data);
 
@@ -224,9 +231,16 @@ void guac_vnc_cut_text(rfbClient* client, const char* text, int textlen) {
     char* output = received_data;
     guac_iconv_read* reader = vnc_client->clipboard_reader;
 
-    /* Convert clipboard contents */
-    guac_iconv(reader, &input, textlen,
-               GUAC_WRITE_UTF8, &output, output_buf_size);
+    /* Convert clipboard contents. A zero return indicates the output buffer
+     * filled before all input was consumed (truncation) due to charset
+     * expansion; warn rather than silently delivering truncated data. */
+    if (!guac_iconv(reader, &input, textlen,
+               GUAC_WRITE_UTF8, &output, output_buf_size)) {
+        guac_client_log(gc, GUAC_LOG_WARNING, "VNC: Inbound clipboard data "
+                "was truncated to fit the %d-byte clipboard buffer. Increase "
+                "\"clipboard-buffer-size\" to receive larger clipboard "
+                "content.", output_buf_size);
+    }
 
     /* Send converted data */
     guac_common_clipboard_reset(vnc_client->clipboard, "text/plain");


### PR DESCRIPTION
Building on the configurable clipboard buffer work in GUACAMOLE-2002, this addresses a remaining silent-failure case: **charset expansion** during clipboard conversion can make the converted data outgrow the configured `clipboard-buffer-size`.

`clipboard->available` only bounds the *input*; it does not account for expansion such as UTF-8 ↔ UTF-16, CRLF translation, or multi-byte characters (e.g. emoji). `guac_iconv()` signals this by returning `0` (output buffer filled before all input was consumed), but the RDP (`cliprdr`) and VNC clipboard paths ignored that return value, so oversized clipboard transfers were **silently truncated or dropped** with no operator-visible signal.

## Changes

- **RDP `cliprdr.c`** (both the clipboard request and the `format_data_response` directions) and **VNC `clipboard.c`** (`end_handler` and `cut_text` directions) now check the `guac_iconv()` return value.
- On truncation we emit a `GUAC_LOG_WARNING` naming the byte limit and pointing the operator at the `clipboard-buffer-size` setting.
- For inbound data the converted (possibly partial) text is still **delivered/recorded** rather than dropped entirely — truncated clipboard text is still useful — and the warning is logged afterwards.
- This preserves `main`'s heap-allocated clipboard buffers (`guac_mem_alloc(clipboard->available)`) and the clipboard recording added in GUACAMOLE-1969.

## Relation to #659 and reviewer feedback

This follows up on #659 (now closed). In that thread @bbennett-ks and @eugen-keeper raised that simply over-allocating the buffer (e.g. `available * 4` to absorb worst-case expansion) is unsafe — with a 50 MiB `clipboard-buffer-size` that would mean pre-allocating up to **200 MiB** per clipboard transfer.

This PR deliberately chooses **detection + warning over pre-allocation**: the allocation stays bound to the operator-configured `clipboard-buffer-size`, and overflow is reported cleanly (with partial delivery where possible) instead of either silently dropping data or ballooning memory. cc @bbennett-ks @eugen-keeper

## Validation

- **Unit:** extended the `guac_iconv` CUnit suite with a truncation case (`test_iconv__truncation`) asserting a `0` return and no overflow for ASCII→UTF-16, CRLF, and emoji expansion.
- **Container/CI:** `test_guacamole_2002_clipboard.sh` and `test_cliprdr_hardening.sh` (static + functional checks), wired into our pipeline.
- **E2E against a real guacd build:** a 1 MiB clipboard transfer (the GUACAMOLE-2002 case) completes **without crash/disconnect** (session-clipboard suite: 21 passed); RDP + SSH sessions green.
- Honest status note: an XRDP large-buffer variant is still **deferred** due to a defective XRDP test target (not a guacd issue); further verification is ongoing. The PR can be treated as a draft until that completes if maintainers prefer.

Relates to / follows up on #659.
