### PR TITLE
Update terminal.c

### DIFF
--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -1805,6 +1805,8 @@ static int __guac_terminal_send_modified_function(guac_terminal* term, int keysy
 
 static int __guac_terminal_send_key(guac_terminal* term, int keysym, int pressed) {
 
+    char data;
+
     /* Ignore user input if terminal is not started */
     if (!term->started) {
         guac_client_log(term->client, GUAC_LOG_DEBUG, "Ignoring user input "
@@ -1827,7 +1829,7 @@ static int __guac_terminal_send_key(guac_terminal* term, int keysym, int pressed
     else if (keysym == GUAC_TERMINAL_KEY_ALT_L || keysym == GUAC_TERMINAL_KEY_ALT_R)
         term->mod_alt = pressed;
     else if (keysym == GUAC_TERMINAL_KEY_SHIFT_L || keysym == GUAC_TERMINAL_KEY_SHIFT_R)
-
+        term->mod_shift = pressed;
     /*
      * Super (Windows/Command) and Hyper are treated as Meta since terminals don't
      * have separate modifier bits for them.
@@ -1920,8 +1922,6 @@ static int __guac_terminal_send_key(guac_terminal* term, int keysym, int pressed
 
         /* Translate Ctrl+letter to control code */
         if (term->mod_ctrl) {
-
-            char data;
 
             /* Keysyms for '@' through '_' are all conveniently in C0 order */
             if (keysym >= '@' && keysym <= '_')


### PR DESCRIPTION
terminal.c: In function '__guac_terminal_send_key': terminal.c:1924:18: error: variable 'data' set but not used [-Werror=unused-but-set-variable]
 1924 |             char data;
      |                  ^~~~
terminal.c:1967:51: error: 'data' undeclared (first use in this function)
 1967 |             return guac_terminal_send_data(term, &data, 1);
      |                                                   ^~~~
terminal.c:1967:51: note: each undeclared identifier is reported only once for each function it appears in
terminal.c:1829:13: error: suggest explicit braces to avoid ambiguous 'else' [-Werror=dangling-else]
 1829 |     else if (keysym == GUAC_TERMINAL_KEY_SHIFT_L || keysym == GUAC_TERMINAL_KEY_SHIFT_R)
      |             ^
terminal.c: At top level:
terminal.c:2193:5: error: expected identifier or '(' before 'return'
 2193 |     return 0;
      |     ^~~~~~
terminal.c:2195:1: error: expected identifier or '(' before '}' token
 2195 | }
      | ^
terminal.c: In function '__guac_terminal_send_key':
terminal.c:2191:5: error: control reaches end of non-void function [-Werror=return-type]
 2191 |     }
      |     ^