### PR TITLE
GUACAMOLE-2294: Address multiple minor resource leaks.

### DIFF
--- a/src/guacd/conf-file.c
+++ b/src/guacd/conf-file.c
@@ -197,24 +197,21 @@ guacd_config* guacd_conf_load() {
 
     /* Read configuration from file */
     int fd = open(GUACD_CONF_FILE, O_RDONLY);
-    if (fd > 0) {
-
-        int retval = guacd_conf_parse_file(conf, fd);
-        close(fd);
-
-        if (retval != 0) {
-            fprintf(stderr, "Unable to parse \"" GUACD_CONF_FILE "\".\n");
-            guac_mem_free(conf->bind_host);
-            guac_mem_free(conf->bind_port);
-            guac_mem_free(conf);
-            return NULL;
-        }
-
-    }
 
     /* Notify of errors preventing reading */
-    else if (errno != ENOENT) {
+    if (fd < 0 && errno != ENOENT) {
         fprintf(stderr, "Unable to open \"" GUACD_CONF_FILE "\": %s\n", strerror(errno));
+        guac_mem_free(conf->bind_host);
+        guac_mem_free(conf->bind_port);
+        guac_mem_free(conf);
+        return NULL;
+    }
+
+    int retval = guacd_conf_parse_file(conf, fd);
+    close(fd);
+
+    if (retval != 0) {
+        fprintf(stderr, "Unable to parse \"" GUACD_CONF_FILE "\".\n");
         guac_mem_free(conf->bind_host);
         guac_mem_free(conf->bind_port);
         guac_mem_free(conf);

--- a/src/guacd/conf-file.c
+++ b/src/guacd/conf-file.c
@@ -204,6 +204,8 @@ guacd_config* guacd_conf_load() {
 
         if (retval != 0) {
             fprintf(stderr, "Unable to parse \"" GUACD_CONF_FILE "\".\n");
+            guac_mem_free(conf->bind_host);
+            guac_mem_free(conf->bind_port);
             guac_mem_free(conf);
             return NULL;
         }
@@ -213,6 +215,8 @@ guacd_config* guacd_conf_load() {
     /* Notify of errors preventing reading */
     else if (errno != ENOENT) {
         fprintf(stderr, "Unable to open \"" GUACD_CONF_FILE "\": %s\n", strerror(errno));
+        guac_mem_free(conf->bind_host);
+        guac_mem_free(conf->bind_port);
         guac_mem_free(conf);
         return NULL;
     }

--- a/src/protocols/telnet/settings.c
+++ b/src/protocols/telnet/settings.c
@@ -371,9 +371,11 @@ guac_telnet_settings* guac_telnet_parse_args(guac_user* user,
 
     /* Read username regex only if username is specified */
     if (settings->username != NULL) {
-        settings->username_regex = guac_telnet_compile_regex(user,
-            guac_user_parse_args_string(user, GUAC_TELNET_CLIENT_ARGS, argv,
-                    IDX_USERNAME_REGEX, GUAC_TELNET_DEFAULT_USERNAME_REGEX));
+        char* username_regex = guac_user_parse_args_string(user,
+            GUAC_TELNET_CLIENT_ARGS, argv, IDX_USERNAME_REGEX,
+            GUAC_TELNET_DEFAULT_USERNAME_REGEX);
+        settings->username_regex = guac_telnet_compile_regex(user, username_regex);
+        guac_mem_free(username_regex);
     }
 
     /* Read password */
@@ -383,20 +385,24 @@ guac_telnet_settings* guac_telnet_parse_args(guac_user* user,
 
     /* Read password regex only if password is specified */
     if (settings->password != NULL) {
-        settings->password_regex = guac_telnet_compile_regex(user,
-            guac_user_parse_args_string(user, GUAC_TELNET_CLIENT_ARGS, argv,
-                    IDX_PASSWORD_REGEX, GUAC_TELNET_DEFAULT_PASSWORD_REGEX));
+        char* password_regex = guac_user_parse_args_string(user,
+            GUAC_TELNET_CLIENT_ARGS, argv, IDX_PASSWORD_REGEX,
+            GUAC_TELNET_DEFAULT_PASSWORD_REGEX);
+        settings->password_regex = guac_telnet_compile_regex(user, password_regex);
+        guac_mem_free(password_regex);
     }
 
     /* Read optional login success detection regex */
-    settings->login_success_regex = guac_telnet_compile_regex(user,
-            guac_user_parse_args_string(user, GUAC_TELNET_CLIENT_ARGS, argv,
-                    IDX_LOGIN_SUCCESS_REGEX, NULL));
+    char* login_success_regex = guac_user_parse_args_string(user,
+        GUAC_TELNET_CLIENT_ARGS, argv, IDX_LOGIN_SUCCESS_REGEX, NULL);
+    settings->login_success_regex = guac_telnet_compile_regex(user, login_success_regex);
+    guac_mem_free(login_success_regex);
 
     /* Read optional login failure detection regex */
-    settings->login_failure_regex = guac_telnet_compile_regex(user,
-            guac_user_parse_args_string(user, GUAC_TELNET_CLIENT_ARGS, argv,
-                    IDX_LOGIN_FAILURE_REGEX, NULL));
+    char* login_failure_regex = guac_user_parse_args_string(user,
+        GUAC_TELNET_CLIENT_ARGS, argv, IDX_LOGIN_FAILURE_REGEX, NULL);
+    settings->login_failure_regex = guac_telnet_compile_regex(user, login_failure_regex);
+    guac_mem_free(login_failure_regex);
 
     /* Both login success and login failure regexes must be provided if either
      * is present at all */

--- a/src/terminal/display.c
+++ b/src/terminal/display.c
@@ -269,6 +269,10 @@ guac_terminal_display* guac_terminal_display_alloc(guac_client* client,
     if (guac_terminal_display_set_font(display, font_name, font_size, dpi)) {
         guac_client_abort(display->client, GUAC_PROTOCOL_STATUS_SERVER_ERROR,
                 "Unable to set initial font \"%s\"", font_name);
+        guac_common_surface_free(display->display_surface);
+        guac_client_free_layer(client, display->display_layer);
+        guac_client_free_layer(client, display->select_layer);
+        guac_mem_free(display->default_palette);
         guac_mem_free(display);
         return NULL;
     }

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -557,6 +557,10 @@ guac_terminal* guac_terminal_create(guac_client* client,
     /* Fail if display init failed */
     if (term->display == NULL) {
         guac_client_log(client, GUAC_LOG_DEBUG, "Display initialization failed");
+        guac_terminal_buffer_free(term->alternate_buffer);
+        free((char *)(term->color_scheme));
+        guac_terminal_buffer_free(term->current_buffer);
+        free((char *)(term->font_name));
         guac_mem_free(term);
         return NULL;
     }


### PR DESCRIPTION
This addresses a few minor resource leaks identified by Coverity/Blackduck. Nothing major, just some cleanup.

It's worth noting that our macro for freeing memory, `PRIV_guac_mem_free`, doesn't seem to handle freeing `const *` members/pointers.