### PR TITLE
GUACAMOLE-2136: Correct constness of results per GCC warnings.

### DIFF
--- a/src/guaclog/keydef.c
+++ b/src/guaclog/keydef.c
@@ -144,7 +144,7 @@ static int guaclog_keydef_bsearch_compare(const void* key,
         const void* member) {
 
     int keysym = (int) ((intptr_t) key);
-    guaclog_keydef* current = (guaclog_keydef*) member;
+    const guaclog_keydef* current = (const guaclog_keydef*) member;
 
     /* Compare given keysym to keysym of current member */
     return keysym  - current->keysym;
@@ -163,7 +163,7 @@ static int guaclog_keydef_bsearch_compare(const void* key,
  *     A pointer to the static guaclog_keydef associated with the given keysym,
  *     or NULL if the key could not be found.
  */
-static guaclog_keydef* guaclog_get_known_key(int keysym) {
+static const guaclog_keydef* guaclog_get_known_key(int keysym) {
 
     /* Search through known keys for given keysym */
     return bsearch((void*) ((intptr_t) keysym),
@@ -280,7 +280,7 @@ static guaclog_keydef* guaclog_get_unicode_key(int keysym) {
  *     A newly-allocated guaclog_keydef structure copied from the given
  *     guaclog_keydef.
  */
-static guaclog_keydef* guaclog_copy_key(guaclog_keydef* keydef) {
+static guaclog_keydef* guaclog_copy_key(const guaclog_keydef* keydef) {
 
     guaclog_keydef* copy = guac_mem_alloc(sizeof(guaclog_keydef));
 
@@ -301,7 +301,7 @@ static guaclog_keydef* guaclog_copy_key(guaclog_keydef* keydef) {
 
 guaclog_keydef* guaclog_keydef_alloc(int keysym) {
 
-    guaclog_keydef* keydef;
+    const guaclog_keydef* keydef;
 
     /* Check list of known keys first */
     keydef = guaclog_get_known_key(keysym);

--- a/src/libguac/string.c
+++ b/src/libguac/string.c
@@ -118,25 +118,28 @@ char* guac_strnstr(const char *haystack, const char *needle, size_t len) {
 #ifdef HAVE_STRNSTR
     return strnstr(haystack, needle, len);
 #else
-    char* chr;
-    size_t nlen = strlen(needle), off = 0;
+    const char* chr;
+    size_t nlen = strlen(needle);
 
     /* Follow documented API: return haystack if needle is the empty string. */
     if (nlen == 0)
-        return (char *)haystack;
+        return (char*) haystack;
 
     /* Use memchr to find candidates. It might be optimized in asm. */
-    while (off < len && NULL != (chr = memchr(haystack + off, needle[0], len - off))) {
+    for (size_t off = 0; off < len
+            && NULL != (chr = memchr(haystack + off, needle[0], len - off)); off++) {
+
         /* chr is guaranteed to be in bounds of and >= haystack. */
         off = chr - haystack;
+
         /* If needle would go beyond provided len, it doesn't exist in haystack. */
         if (off + nlen > len)
             return NULL;
+
         /* Now that we know we have at least nlen bytes, compare them. */
         if (!memcmp(chr, needle, nlen))
-            return chr;
-        /* Make sure we make progress. */
-        off += 1;
+            return (char*) chr;
+
     }
 
     /* memchr ran out of candidates, needle wasn't found. */

--- a/src/terminal/named-colors.c
+++ b/src/terminal/named-colors.c
@@ -784,7 +784,7 @@ static int guac_terminal_named_color_search(const void* a, const void* b) {
 int guac_terminal_find_color(const char* name, guac_terminal_color* color) {
 
     /* Search for the color having the given name */
-    guac_terminal_named_color* found = bsearch(name,
+    const guac_terminal_named_color* found = bsearch(name,
             GUAC_TERMINAL_NAMED_COLORS, GUAC_TERMINAL_NAMED_COLORS_LENGTH,
             sizeof(guac_terminal_named_color),
             guac_terminal_named_color_search);


### PR DESCRIPTION
Recent GCC fails with warnings regarding constness based on known behavior of `memchr()`, `bsearch()`, etc. regardless of the declared non-const return type.