### PR TITLE
GUACAMOLE-2182: Automatically include config.h in every relevant .c file.

### DIFF
--- a/src/common-ssh/Makefile.am
+++ b/src/common-ssh/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 noinst_LTLIBRARIES = libguac_common_ssh.la

--- a/src/common-ssh/buffer.c
+++ b/src/common-ssh/buffer.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include <openssl/bn.h>
 #include <openssl/ossl_typ.h>
 

--- a/src/common-ssh/key.c
+++ b/src/common-ssh/key.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "common-ssh/buffer.h"
 #include "common-ssh/key.h"
 

--- a/src/common-ssh/tests/Makefile.am
+++ b/src/common-ssh/tests/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign 
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 #

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign 
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 noinst_LTLIBRARIES = libguac_common.la

--- a/src/common/blank_cursor.c
+++ b/src/common/blank_cursor.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include <cairo/cairo.h>
 #include <guacamole/client.h>
 #include <guacamole/layer.h>

--- a/src/common/clipboard.c
+++ b/src/common/clipboard.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "common/clipboard.h"
 
 #include <guacamole/client.h>

--- a/src/common/dot_cursor.c
+++ b/src/common/dot_cursor.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include <cairo/cairo.h>
 #include <guacamole/client.h>
 #include <guacamole/layer.h>

--- a/src/common/ibar_cursor.c
+++ b/src/common/ibar_cursor.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include <cairo/cairo.h>
 #include <guacamole/client.h>
 #include <guacamole/layer.h>

--- a/src/common/iconv.c
+++ b/src/common/iconv.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "common/iconv.h"
 
 #include <guacamole/unicode.h>

--- a/src/common/io.c
+++ b/src/common/io.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "common/io.h"
 
 #include <guacamole/error.h>

--- a/src/common/json.c
+++ b/src/common/json.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "common/json.h"
 
 #include <assert.h>

--- a/src/common/list.c
+++ b/src/common/list.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "common/list.h"
 
 #include <guacamole/mem.h>

--- a/src/common/pointer_cursor.c
+++ b/src/common/pointer_cursor.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include <cairo/cairo.h>
 #include <guacamole/client.h>
 #include <guacamole/layer.h>

--- a/src/common/rect.c
+++ b/src/common/rect.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "common/rect.h"
 
 void guac_common_rect_init(guac_common_rect* rect, int x, int y, int width, int height) {

--- a/src/common/string.c
+++ b/src/common/string.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "common/string.h"
 
 #include <guacamole/mem.h>

--- a/src/common/surface.c
+++ b/src/common/surface.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "common/rect.h"
 #include "common/surface.h"
 

--- a/src/common/tests/Makefile.am
+++ b/src/common/tests/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign 
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 #

--- a/src/guacd/Makefile.am
+++ b/src/guacd/Makefile.am
@@ -25,6 +25,8 @@
 
 AUTOMAKE_OPTIONS = foreign 
 
+AM_CPPFLAGS = -include config.h
+
 sbin_PROGRAMS = guacd
 
 man_MANS =           \

--- a/src/guacd/conf-args.c
+++ b/src/guacd/conf-args.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "conf.h"
 #include "conf-args.h"
 #include "conf-parse.h"

--- a/src/guacd/conf-file.c
+++ b/src/guacd/conf-file.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "conf.h"
 #include "conf-file.h"
 #include "conf-parse.h"

--- a/src/guacd/conf-parse.c
+++ b/src/guacd/conf-parse.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "conf.h"
 #include "conf-parse.h"
 

--- a/src/guacd/connection.c
+++ b/src/guacd/connection.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "connection.h"
 #include "log.h"
 #include "move-fd.h"

--- a/src/guacd/daemon.c
+++ b/src/guacd/daemon.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "conf.h"
 #include "conf-args.h"
 #include "conf-file.h"

--- a/src/guacd/log.c
+++ b/src/guacd/log.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "log.h"
 
 #include <guacamole/client.h>

--- a/src/guacd/move-fd.c
+++ b/src/guacd/move-fd.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "move-fd.h"
 
 /* Required for CMSG_* macros on BSD */

--- a/src/guacd/proc-map.c
+++ b/src/guacd/proc-map.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "common/list.h"
 #include "proc.h"
 #include "proc-map.h"

--- a/src/guacd/proc.c
+++ b/src/guacd/proc.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "log.h"
 #include "move-fd.h"
 #include "proc.h"

--- a/src/guacenc/Makefile.am
+++ b/src/guacenc/Makefile.am
@@ -25,6 +25,8 @@
 
 AUTOMAKE_OPTIONS = foreign 
 
+AM_CPPFLAGS = -include config.h
+
 bin_PROGRAMS = guacenc
 
 man_MANS =        \

--- a/src/guacenc/buffer.c
+++ b/src/guacenc/buffer.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "buffer.h"
 
 #include <cairo/cairo.h>

--- a/src/guacenc/cursor.c
+++ b/src/guacenc/cursor.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "buffer.h"
 #include "cursor.h"
 

--- a/src/guacenc/display-buffers.c
+++ b/src/guacenc/display-buffers.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "buffer.h"
 #include "layer.h"

--- a/src/guacenc/display-flatten.c
+++ b/src/guacenc/display-flatten.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "layer.h"
 #include "log.h"

--- a/src/guacenc/display-image-streams.c
+++ b/src/guacenc/display-image-streams.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "image-stream.h"
 #include "log.h"

--- a/src/guacenc/display-layers.c
+++ b/src/guacenc/display-layers.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "layer.h"
 #include "log.h"

--- a/src/guacenc/display-sync.c
+++ b/src/guacenc/display-sync.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "layer.h"
 #include "log.h"

--- a/src/guacenc/display.c
+++ b/src/guacenc/display.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "cursor.h"
 #include "display.h"
 #include "video.h"

--- a/src/guacenc/encode.c
+++ b/src/guacenc/encode.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "instructions.h"
 #include "log.h"

--- a/src/guacenc/ffmpeg-compat.c
+++ b/src/guacenc/ffmpeg-compat.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "ffmpeg-compat.h"
 #include "log.h"
 #include "video.h"

--- a/src/guacenc/guacenc.c
+++ b/src/guacenc/guacenc.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "encode.h"
 #include "guacenc.h"
 #include "log.h"

--- a/src/guacenc/image-stream.c
+++ b/src/guacenc/image-stream.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "image-stream.h"
 #include "jpeg.h"

--- a/src/guacenc/instruction-blob.c
+++ b/src/guacenc/instruction-blob.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "log.h"
 

--- a/src/guacenc/instruction-cfill.c
+++ b/src/guacenc/instruction-cfill.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "log.h"
 

--- a/src/guacenc/instruction-copy.c
+++ b/src/guacenc/instruction-copy.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "log.h"
 

--- a/src/guacenc/instruction-cursor.c
+++ b/src/guacenc/instruction-cursor.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "buffer.h"
 #include "cursor.h"
 #include "display.h"

--- a/src/guacenc/instruction-dispose.c
+++ b/src/guacenc/instruction-dispose.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "log.h"
 

--- a/src/guacenc/instruction-end.c
+++ b/src/guacenc/instruction-end.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "image-stream.h"
 #include "log.h"

--- a/src/guacenc/instruction-img.c
+++ b/src/guacenc/instruction-img.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "log.h"
 

--- a/src/guacenc/instruction-mouse.c
+++ b/src/guacenc/instruction-mouse.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "cursor.h"
 #include "display.h"
 #include "log.h"

--- a/src/guacenc/instruction-move.c
+++ b/src/guacenc/instruction-move.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "log.h"
 

--- a/src/guacenc/instruction-rect.c
+++ b/src/guacenc/instruction-rect.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "buffer.h"
 #include "display.h"
 #include "log.h"

--- a/src/guacenc/instruction-shade.c
+++ b/src/guacenc/instruction-shade.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "log.h"
 

--- a/src/guacenc/instruction-size.c
+++ b/src/guacenc/instruction-size.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "log.h"
 

--- a/src/guacenc/instruction-sync.c
+++ b/src/guacenc/instruction-sync.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "log.h"
 #include "parse.h"

--- a/src/guacenc/instruction-transfer.c
+++ b/src/guacenc/instruction-transfer.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "log.h"
 

--- a/src/guacenc/instructions.c
+++ b/src/guacenc/instructions.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display.h"
 #include "instructions.h"
 #include "log.h"

--- a/src/guacenc/jpeg.c
+++ b/src/guacenc/jpeg.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "jpeg.h"
 #include "log.h"
 

--- a/src/guacenc/layer.c
+++ b/src/guacenc/layer.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "buffer.h"
 #include "layer.h"
 

--- a/src/guacenc/log.c
+++ b/src/guacenc/log.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "guacenc.h"
 #include "log.h"
 

--- a/src/guacenc/parse.c
+++ b/src/guacenc/parse.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include <guacamole/timestamp.h>
 
 #include <errno.h>

--- a/src/guacenc/png.c
+++ b/src/guacenc/png.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "log.h"
 #include "png.h"
 

--- a/src/guacenc/video.c
+++ b/src/guacenc/video.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "buffer.h"
 #include "ffmpeg-compat.h"
 #include "log.h"

--- a/src/guacenc/webp.c
+++ b/src/guacenc/webp.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "log.h"
 #include "webp.h"
 

--- a/src/guaclog/Makefile.am
+++ b/src/guaclog/Makefile.am
@@ -25,6 +25,8 @@
 
 AUTOMAKE_OPTIONS = foreign 
 
+AM_CPPFLAGS = -include config.h
+
 bin_PROGRAMS = guaclog
 
 man_MANS =        \

--- a/src/guaclog/guaclog.c
+++ b/src/guaclog/guaclog.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guaclog.h"
 #include "interpret.h"
 #include "log.h"

--- a/src/guaclog/instruction-key.c
+++ b/src/guaclog/instruction-key.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "log.h"
 #include "state.h"
 

--- a/src/guaclog/instructions.c
+++ b/src/guaclog/instructions.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "state.h"
 #include "instructions.h"
 #include "log.h"

--- a/src/guaclog/interpret.c
+++ b/src/guaclog/interpret.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "instructions.h"
 #include "log.h"
 #include "state.h"

--- a/src/guaclog/keydef.c
+++ b/src/guaclog/keydef.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "keydef.h"
 #include "log.h"
 

--- a/src/guaclog/log.c
+++ b/src/guaclog/log.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "guaclog.h"
 #include "log.h"
 

--- a/src/guaclog/state.c
+++ b/src/guaclog/state.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "keydef.h"
 #include "log.h"
 #include "state.h"

--- a/src/libguac/Makefile.am
+++ b/src/libguac/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign 
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES = libguac.la

--- a/src/libguac/argv.c
+++ b/src/libguac/argv.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 #include "guacamole/argv.h"
 #include "guacamole/client.h"

--- a/src/libguac/audio.c
+++ b/src/libguac/audio.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 #include "guacamole/audio.h"
 #include "guacamole/client.h"

--- a/src/libguac/client.c
+++ b/src/libguac/client.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "encode-jpeg.h"
 #include "encode-png.h"
 #include "encode-webp.h"

--- a/src/libguac/display-render-thread.c
+++ b/src/libguac/display-render-thread.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display-priv.h"
 #include "guacamole/client.h"
 #include "guacamole/display.h"

--- a/src/libguac/display.c
+++ b/src/libguac/display.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "display-plan.h"
 #include "display-priv.h"
 #include "guacamole/client.h"

--- a/src/libguac/encode-jpeg.c
+++ b/src/libguac/encode-jpeg.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "encode-jpeg.h"
 #include "guacamole/mem.h"
 #include "guacamole/error.h"

--- a/src/libguac/encode-png.c
+++ b/src/libguac/encode-png.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "encode-png.h"
 #include "guacamole/mem.h"
 #include "guacamole/error.h"

--- a/src/libguac/encode-webp.c
+++ b/src/libguac/encode-webp.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "encode-webp.h"
 #include "guacamole/error.h"
 #include "guacamole/protocol.h"

--- a/src/libguac/error.c
+++ b/src/libguac/error.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 #include "guacamole/error.h"
 

--- a/src/libguac/fips.c
+++ b/src/libguac/fips.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "guacamole/fips.h"
 
 /* If OpenSSL is available, include header for version numbers */

--- a/src/libguac/hash.c
+++ b/src/libguac/hash.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include <cairo/cairo.h>
 
 #include <stdint.h>

--- a/src/libguac/id.c
+++ b/src/libguac/id.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 #include "guacamole/error.h"
 #include "id.h"

--- a/src/libguac/palette.c
+++ b/src/libguac/palette.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 #include "palette.h"
 

--- a/src/libguac/parser.c
+++ b/src/libguac/parser.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 #include "guacamole/error.h"
 #include "guacamole/parser.h"

--- a/src/libguac/pool.c
+++ b/src/libguac/pool.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/assert.h"
 #include "guacamole/mem.h"
 #include "guacamole/pool.h"

--- a/src/libguac/proctitle.c
+++ b/src/libguac/proctitle.c
@@ -16,8 +16,6 @@
  * limitations under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/proctitle.h"
 
 #include <guacamole/mem.h>

--- a/src/libguac/protocol.c
+++ b/src/libguac/protocol.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/error.h"
 #include "guacamole/layer.h"
 #include "guacamole/object.h"

--- a/src/libguac/raw_encoder.c
+++ b/src/libguac/raw_encoder.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 #include "guacamole/audio.h"
 #include "guacamole/client.h"

--- a/src/libguac/socket-broadcast.c
+++ b/src/libguac/socket-broadcast.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 #include "guacamole/client.h"
 #include "guacamole/error.h"

--- a/src/libguac/socket-fd.c
+++ b/src/libguac/socket-fd.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "wait-fd.h"
 
 #include "guacamole/mem.h"

--- a/src/libguac/socket-nest.c
+++ b/src/libguac/socket-nest.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 #include "guacamole/protocol.h"
 #include "guacamole/socket.h"

--- a/src/libguac/socket-ssl.c
+++ b/src/libguac/socket-ssl.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 #include "guacamole/error.h"
 #include "guacamole/socket-ssl.h"

--- a/src/libguac/socket-tee.c
+++ b/src/libguac/socket-tee.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 #include "guacamole/socket.h"
 

--- a/src/libguac/socket.c
+++ b/src/libguac/socket.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "guacamole/mem.h"
 #include "guacamole/error.h"
 #include "guacamole/proctitle.h"

--- a/src/libguac/string.c
+++ b/src/libguac/string.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 
 #include <stddef.h>

--- a/src/libguac/tcp.c
+++ b/src/libguac/tcp.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "guacamole/error.h"
 #include "guacamole/tcp.h"
 

--- a/src/libguac/tests/Makefile.am
+++ b/src/libguac/tests/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign 
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 #

--- a/src/libguac/timestamp.c
+++ b/src/libguac/timestamp.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/error.h"
 #include "guacamole/timestamp.h"
 

--- a/src/libguac/unicode.c
+++ b/src/libguac/unicode.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/unicode.h"
 
 #include <stddef.h>

--- a/src/libguac/user-handlers.c
+++ b/src/libguac/user-handlers.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 #include "guacamole/client.h"
 #include "guacamole/object.h"

--- a/src/libguac/user-handshake.c
+++ b/src/libguac/user-handshake.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/mem.h"
 #include "guacamole/client.h"
 #include "guacamole/error.h"

--- a/src/libguac/user.c
+++ b/src/libguac/user.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "encode-jpeg.h"
 #include "encode-png.h"
 #include "encode-webp.h"

--- a/src/libguac/wait-fd.c
+++ b/src/libguac/wait-fd.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "guacamole/error.h"
 #include <errno.h>
 

--- a/src/libguac/wol.c
+++ b/src/libguac/wol.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "guacamole/error.h"
 #include "guacamole/tcp.h"
 #include "guacamole/timestamp.h"

--- a/src/protocols/kubernetes/Makefile.am
+++ b/src/protocols/kubernetes/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES = libguac-client-kubernetes.la

--- a/src/protocols/kubernetes/argv.c
+++ b/src/protocols/kubernetes/argv.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "argv.h"
 #include "kubernetes.h"
 #include "terminal/terminal.h"

--- a/src/protocols/kubernetes/kubernetes.c
+++ b/src/protocols/kubernetes/kubernetes.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "argv.h"
 #include "client.h"
 #include "io.h"

--- a/src/protocols/kubernetes/tests/Makefile.am
+++ b/src/protocols/kubernetes/tests/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 #

--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES = libguac-client-rdp.la

--- a/src/protocols/rdp/argv.c
+++ b/src/protocols/rdp/argv.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "argv.h"
 #include "rdp.h"
 #include "settings.h"

--- a/src/protocols/rdp/channels/cliprdr.c
+++ b/src/protocols/rdp/channels/cliprdr.c
@@ -21,7 +21,6 @@
 #include "client.h"
 #include "common/clipboard.h"
 #include "common/iconv.h"
-#include "config.h"
 #include "plugins/channels.h"
 #include "rdp.h"
 

--- a/src/protocols/rdp/channels/disp.c
+++ b/src/protocols/rdp/channels/disp.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "channels/disp.h"
 #include "plugins/channels.h"
 #include "fs.h"

--- a/src/protocols/rdp/channels/rail.c
+++ b/src/protocols/rdp/channels/rail.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "channels/rail.h"
 #include "plugins/channels.h"
 #include "rdp.h"

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -23,7 +23,6 @@
 #include "channels/disp.h"
 #include "channels/pipe-svc.h"
 #include "channels/rail.h"
-#include "config.h"
 #include "fs.h"
 #include "log.h"
 #include "rdp.h"

--- a/src/protocols/rdp/color.c
+++ b/src/protocols/rdp/color.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "settings.h"
 
 #include <freerdp/codec/color.h>

--- a/src/protocols/rdp/input-queue.c
+++ b/src/protocols/rdp/input-queue.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "channels/disp.h"
 #include "channels/rdpei.h"
 #include "input.h"

--- a/src/protocols/rdp/input.c
+++ b/src/protocols/rdp/input.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "channels/disp.h"
 #include "channels/rdpei.h"
 #include "input.h"

--- a/src/protocols/rdp/keyboard.c
+++ b/src/protocols/rdp/keyboard.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "decompose.h"
 #include "keyboard.h"
 #include "keymap.h"

--- a/src/protocols/rdp/plugins/guac-common-svc/guac-common-svc.c
+++ b/src/protocols/rdp/plugins/guac-common-svc/guac-common-svc.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "channels/common-svc.h"
 
 #include <freerdp/svc.h>

--- a/src/protocols/rdp/plugins/guacai/guacai.c
+++ b/src/protocols/rdp/plugins/guacai/guacai.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "channels/audio-input/audio-buffer.h"
 #include "plugins/guacai/guacai.h"
 #include "plugins/guacai/guacai-messages.h"

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "argv.h"
 #include "beep.h"
 #include "channels/audio-input/audio-buffer.h"
@@ -33,7 +31,6 @@
 #include "channels/rdpsnd/rdpsnd.h"
 #include "client.h"
 #include "color.h"
-#include "config.h"
 #include "error.h"
 #include "fs.h"
 #include "gdi.h"

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -20,7 +20,6 @@
 #include "argv.h"
 #include "common/defaults.h"
 #include "common/string.h"
-#include "config.h"
 #include "rdp.h"
 #include "resolution.h"
 #include "settings.h"

--- a/src/protocols/rdp/sftp.c
+++ b/src/protocols/rdp/sftp.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "common-ssh/sftp.h"
 #include "rdp.h"
 #include "sftp.h"

--- a/src/protocols/rdp/tests/Makefile.am
+++ b/src/protocols/rdp/tests/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign 
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 #

--- a/src/protocols/rdp/user.c
+++ b/src/protocols/rdp/user.c
@@ -20,7 +20,6 @@
 #include "channels/audio-input/audio-input.h"
 #include "channels/cliprdr.h"
 #include "channels/pipe-svc.h"
-#include "config.h"
 #include "input.h"
 #include "rdp.h"
 #include "settings.h"

--- a/src/protocols/ssh/Makefile.am
+++ b/src/protocols/ssh/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES = libguac-client-ssh.la

--- a/src/protocols/ssh/argv.c
+++ b/src/protocols/ssh/argv.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "argv.h"
 #include "ssh.h"
 #include "terminal/terminal.h"

--- a/src/protocols/ssh/client.c
+++ b/src/protocols/ssh/client.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "argv.h"
 #include "client.h"
 #include "common-ssh/sftp.h"

--- a/src/protocols/ssh/clipboard.c
+++ b/src/protocols/ssh/clipboard.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "clipboard.h"
 #include "ssh.h"
 #include "terminal/terminal.h"

--- a/src/protocols/ssh/input.c
+++ b/src/protocols/ssh/input.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "ssh.h"
 #include "terminal/terminal.h"
 

--- a/src/protocols/ssh/pipe.c
+++ b/src/protocols/ssh/pipe.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "pipe.h"
 #include "ssh.h"
 #include "terminal/terminal.h"

--- a/src/protocols/ssh/settings.c
+++ b/src/protocols/ssh/settings.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "argv.h"
 #include "client.h"
 #include "common/defaults.h"

--- a/src/protocols/ssh/sftp.c
+++ b/src/protocols/ssh/sftp.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "common-ssh/sftp.h"
 #include "sftp.h"
 #include "ssh.h"

--- a/src/protocols/ssh/ssh.c
+++ b/src/protocols/ssh/ssh.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "argv.h"
 #include "common-ssh/sftp.h"
 #include "common-ssh/ssh.h"

--- a/src/protocols/ssh/ssh_agent.c
+++ b/src/protocols/ssh/ssh_agent.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "client.h"
 #include "ssh_agent.h"
 #include "ssh_buffer.h"

--- a/src/protocols/ssh/ttymode.c
+++ b/src/protocols/ssh/ttymode.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "ttymode.h"
 
 #include <stdarg.h>

--- a/src/protocols/ssh/user.c
+++ b/src/protocols/ssh/user.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "argv.h"
 #include "clipboard.h"
 #include "input.h"

--- a/src/protocols/telnet/Makefile.am
+++ b/src/protocols/telnet/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES = libguac-client-telnet.la

--- a/src/protocols/telnet/argv.c
+++ b/src/protocols/telnet/argv.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "argv.h"
 #include "telnet.h"
 #include "terminal/terminal.h"

--- a/src/protocols/telnet/client.c
+++ b/src/protocols/telnet/client.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "argv.h"
 #include "client.h"
 #include "settings.h"

--- a/src/protocols/telnet/clipboard.c
+++ b/src/protocols/telnet/clipboard.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "clipboard.h"
 #include "telnet.h"
 #include "terminal/terminal.h"

--- a/src/protocols/telnet/input.c
+++ b/src/protocols/telnet/input.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "input.h"
 #include "terminal/terminal.h"
 #include "telnet.h"

--- a/src/protocols/telnet/pipe.c
+++ b/src/protocols/telnet/pipe.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "pipe.h"
 #include "telnet.h"
 #include "terminal/terminal.h"

--- a/src/protocols/telnet/settings.c
+++ b/src/protocols/telnet/settings.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "argv.h"
 #include "common/defaults.h"
 #include "settings.h"

--- a/src/protocols/telnet/telnet.c
+++ b/src/protocols/telnet/telnet.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "argv.h"
 #include "telnet.h"
 #include "terminal/terminal.h"

--- a/src/protocols/telnet/user.c
+++ b/src/protocols/telnet/user.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "argv.h"
 #include "clipboard.h"
 #include "input.h"

--- a/src/protocols/vnc/Makefile.am
+++ b/src/protocols/vnc/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES = libguac-client-vnc.la

--- a/src/protocols/vnc/argv.c
+++ b/src/protocols/vnc/argv.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "argv.h"
 #include "vnc.h"
 

--- a/src/protocols/vnc/auth.c
+++ b/src/protocols/vnc/auth.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "argv.h"
 #include "auth.h"
 #include "vnc.h"

--- a/src/protocols/vnc/client.c
+++ b/src/protocols/vnc/client.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "client.h"
 #include "user.h"
 #include "vnc.h"

--- a/src/protocols/vnc/clipboard.c
+++ b/src/protocols/vnc/clipboard.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
 #include "client.h"
 #include "clipboard.h"
 #include "common/clipboard.h"

--- a/src/protocols/vnc/cursor.c
+++ b/src/protocols/vnc/cursor.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "client.h"
 #include "vnc.h"
 

--- a/src/protocols/vnc/display.c
+++ b/src/protocols/vnc/display.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "client.h"
 #include "display.h"
 #include "common/iconv.h"

--- a/src/protocols/vnc/input.c
+++ b/src/protocols/vnc/input.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "display.h"
 #include "vnc.h"
 

--- a/src/protocols/vnc/log.c
+++ b/src/protocols/vnc/log.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "client.h"
 #include "common/iconv.h"
 

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "argv.h"
 #include "client.h"
 #include "common/defaults.h"

--- a/src/protocols/vnc/sftp.c
+++ b/src/protocols/vnc/sftp.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "common-ssh/sftp.h"
 #include "sftp.h"
 #include "vnc.h"

--- a/src/protocols/vnc/user.c
+++ b/src/protocols/vnc/user.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "clipboard.h"
 #include "input.h"
 #include "user.h"

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "auth.h"
 #include "client.h"
 #include "clipboard.h"

--- a/src/pulse/Makefile.am
+++ b/src/pulse/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign 
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 noinst_LTLIBRARIES = libguac_pulse.la

--- a/src/pulse/pulse.c
+++ b/src/pulse/pulse.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "pulse/pulse.h"
 
 #include <guacamole/audio.h>

--- a/src/terminal/Makefile.am
+++ b/src/terminal/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES = libguac-terminal.la

--- a/src/terminal/display.c
+++ b/src/terminal/display.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "common/surface.h"
 #include "terminal/common.h"
 #include "terminal/display.h"

--- a/src/terminal/terminal-handlers.c
+++ b/src/terminal/terminal-handlers.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "terminal/char-mappings.h"
 #include "terminal/palette.h"
 #include "terminal/terminal.h"

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "config.h"
-
 #include "common/clipboard.h"
 #include "common/cursor.h"
 #include "common/iconv.h"

--- a/src/terminal/tests/Makefile.am
+++ b/src/terminal/tests/Makefile.am
@@ -24,6 +24,8 @@
 #
 
 AUTOMAKE_OPTIONS = foreign 
+
+AM_CPPFLAGS = -include config.h
 ACLOCAL_AMFLAGS = -I m4
 
 #


### PR DESCRIPTION
This avoids future issues with `config.h` ordering by automatically including it for all built .c files (and removing any manual includes of the same).