### PR TITLE
GUACAMOLE-2118: Correct non-deterministic hanging behavior encountered in guac_display.

### DIFF
--- a/src/libguac/display-flush.c
+++ b/src/libguac/display-flush.c
@@ -304,6 +304,7 @@ void guac_display_end_mouse_frame(guac_display* display) {
 void guac_display_end_multiple_frames(guac_display* display, int frames) {
 
     guac_display_plan* plan = NULL;
+    guac_display_layer* removed_layers = NULL;
 
     guac_rwlock_acquire_write_lock(&display->pending_frame.lock);
     display->pending_frame.frames += frames;
@@ -380,6 +381,16 @@ void guac_display_end_multiple_frames(guac_display* display, int frames) {
 
     guac_rwlock_release_lock(&display->last_frame.lock);
 
+    /* The last frame layer list has now been rebuilt from the pending frame
+     * layer list, so any layers removed since the previous flush are no longer
+     * part of either frame. Detach them for destruction below.
+     *
+     * IMPORTANT: These layers MUST NOT be freed until after the frame is fully
+     * flushed. The display plan may reference a removed layer's buffer as the
+     * source of a copy operation, and that plan has not yet been applied. */
+    removed_layers = display->pending_frame_removed_layers;
+    display->pending_frame_removed_layers = NULL;
+
     /* Awaken worker threads to perform the rest of the tasks required for the
      * frame (if any such tasks remain) */
     if (plan != NULL) {
@@ -402,5 +413,9 @@ void guac_display_end_multiple_frames(guac_display* display, int frames) {
 
 finished_with_pending_frame_lock:
     guac_rwlock_release_lock(&display->pending_frame.lock);
+
+    /* Free any layers detached above. NOTE: This is intentionally done outside
+     * the pending frame lock to avoid contending with drawing operations. */
+    guac_display_free_removed_layers(display, removed_layers);
 
 }

--- a/src/libguac/display-flush.c
+++ b/src/libguac/display-flush.c
@@ -115,15 +115,20 @@ static int PFW_LFW_guac_display_frame_complete(guac_display* display) {
     int retval = 0;
 
     display->last_frame.layers = display->pending_frame.layers;
-    guac_display_layer* current = display->pending_frame.layers;
-    while (current != NULL) {
+    for (guac_display_layer* current = display->pending_frame.layers;
+            current != NULL; current = current->pending_frame.next) {
 
-        /* Skip processing any layers whose buffers have been replaced with
-         * NULL (this is intentionally allowed to ensure references to external
-         * buffers can be safely removed if necessary, even before guac_display
-         * is freed) */
+        /* Duplicate layers from pending frame to last frame */
+        current->last_frame.prev = current->pending_frame.prev;
+        current->last_frame.next = current->pending_frame.next;
+
+        /* Skip non-existential updates for any layer whose buffer has been
+         * replaced with NULL (this is intentionally allowed to ensure references
+         * to external buffers can be safely removed if necessary, even before
+         * guac_display is freed) */
         if (current->pending_frame.buffer == NULL) {
             GUAC_ASSERT(current->pending_frame.buffer_is_external);
+            current->last_frame.dirty = (guac_rect) { 0 };
             continue;
         }
 
@@ -250,11 +255,6 @@ static int PFW_LFW_guac_display_frame_complete(guac_display* display) {
         /* Commit any change in lossless setting (no need to synchronize this
          * to the client - it affects only how last_frame is interpreted) */
         current->last_frame.lossless = current->pending_frame.lossless;
-
-        /* Duplicate layers from pending frame to last frame */
-        current->last_frame.prev = current->pending_frame.prev;
-        current->last_frame.next = current->pending_frame.next;
-        current = current->pending_frame.next;
 
     }
 

--- a/src/libguac/display-layer-list.c
+++ b/src/libguac/display-layer-list.c
@@ -23,6 +23,7 @@
 #include "guacamole/display.h"
 #include "guacamole/layer.h"
 #include "guacamole/mem.h"
+#include "guacamole/protocol.h"
 #include "guacamole/rwlock.h"
 
 #include <cairo/cairo.h>
@@ -308,64 +309,77 @@ void guac_display_remove_layer(guac_display_layer* display_layer) {
     if (display_layer->pending_frame.next != NULL)
         display_layer->pending_frame.next->pending_frame.prev = display_layer->pending_frame.prev;
 
+    /* Clear the now-stale list pointers so that an erroneous second removal of
+     * the same layer trips the assertion above rather than corrupting the
+     * list */
+    display_layer->pending_frame.prev = NULL;
+    display_layer->pending_frame.next = NULL;
+
+    /* The layer is deliberately NOT unlinked from the last_frame list here, as
+     * full removal and release of memory is deferred until after frame flush */
+    display_layer->next_removed = display->pending_frame_removed_layers;
+    display->pending_frame_removed_layers = display_layer;
+
     guac_rwlock_release_lock(&display->pending_frame.lock);
 
-    /*
-     * Remove layer from last frame
-     */
+}
 
-    guac_rwlock_acquire_write_lock(&display->last_frame.lock);
-
-    /* Update previous element, if it exists */
-    if (display_layer->last_frame.prev != NULL)
-        display_layer->last_frame.prev->last_frame.next = display_layer->last_frame.next;
-
-    /* If there is no previous element, then this element is the list head if
-     * the list has any elements at all. Update the list head accordingly. */
-    else if (display->last_frame.layers != NULL) {
-        GUAC_ASSERT(display->last_frame.layers == display_layer);
-        display->last_frame.layers = display_layer->last_frame.next;
-    }
-
-    /* Update next element, if it exists */
-    if (display_layer->last_frame.next != NULL)
-        display_layer->last_frame.next->last_frame.prev = display_layer->last_frame.prev;
-
-    guac_rwlock_release_lock(&display->last_frame.lock);
-
-    /*
-     * Layer has now been removed from both pending and last frame lists and
-     * can be safely freed
-     */
+void guac_display_free_removed_layers(guac_display* display,
+        guac_display_layer* removed_layers) {
 
     guac_client* client = display->client;
-    guac_client_free_buffer(client, display_layer->last_frame_buffer);
 
-    /* Release any Cairo resources */
-    guac_display_layer_cairo_context* cairo_context = &(display_layer->pending_frame_cairo_context);
-    if (cairo_context->surface != NULL) {
+    guac_display_layer* current = removed_layers;
+    while (current != NULL) {
 
-        cairo_surface_destroy(cairo_context->surface);
-        cairo_context->surface = NULL;
+        guac_display_layer* next_removed = current->next_removed;
+        const guac_layer* layer = current->layer;
 
-        cairo_destroy(cairo_context->cairo);
-        cairo_context->cairo = NULL;
+        guac_client_free_buffer(client, current->last_frame_buffer);
+
+        /* Release any Cairo resources */
+        guac_display_layer_cairo_context* cairo_context = &(current->pending_frame_cairo_context);
+        if (cairo_context->surface != NULL) {
+
+            cairo_surface_destroy(cairo_context->surface);
+            cairo_context->surface = NULL;
+
+            cairo_destroy(cairo_context->cairo);
+            cairo_context->cairo = NULL;
+
+        }
+
+        /* Free memory for underlying image surface and change tracking cells.
+         * Note that we do NOT free the associated memory for the pending frame
+         * if it was replaced with an external buffer. */
+
+        if (!current->pending_frame.buffer_is_external)
+            guac_mem_free(current->pending_frame.buffer);
+
+        guac_mem_free(current->last_frame.buffer);
+        guac_mem_free(current->pending_frame_cells);
+
+        pthread_mutex_destroy(&current->path_lock);
+
+        if (layer->index != 0) {
+
+            /* Free the corresponding layer/buffer on the remote side */
+            guac_protocol_send_dispose(client->socket, layer);
+
+            /* As long as this isn't the display layer, it's safe to cast away
+             * the constness and free the underlying layer/buffer. Only the
+             * default layer (layer #0) is truly const. */
+            if (layer->index > 0)
+                guac_client_free_layer(client, (guac_layer*) layer);
+            else
+                guac_client_free_buffer(client, (guac_layer*) layer);
+
+        }
+
+        guac_mem_free(current);
+        current = next_removed;
 
     }
-
-    /* Free memory for underlying image surface and change tracking cells. Note
-     * that we do NOT free the associated memory for the pending frame if it
-     * was replaced with an external buffer. */
-
-    if (!display_layer->pending_frame.buffer_is_external)
-        guac_mem_free(display_layer->pending_frame.buffer);
-
-    guac_mem_free(display_layer->last_frame.buffer);
-    guac_mem_free(display_layer->pending_frame_cells);
-
-    pthread_mutex_destroy(&display_layer->path_lock);
-
-    guac_mem_free(display_layer);
 
 }
 

--- a/src/libguac/display-layer-list.c
+++ b/src/libguac/display-layer-list.c
@@ -315,6 +315,10 @@ void guac_display_remove_layer(guac_display_layer* display_layer) {
     display_layer->pending_frame.prev = NULL;
     display_layer->pending_frame.next = NULL;
 
+    /* Automatically detach any external buffer */
+    if (display_layer->pending_frame.buffer_is_external)
+        display_layer->pending_frame.buffer = NULL;
+
     /* The layer is deliberately NOT unlinked from the last_frame list here, as
      * full removal and release of memory is deferred until after frame flush */
     display_layer->next_removed = display->pending_frame_removed_layers;

--- a/src/libguac/display-layer.c
+++ b/src/libguac/display-layer.c
@@ -217,6 +217,26 @@ void guac_display_layer_close_raw(guac_display_layer* layer, guac_display_layer_
 
     guac_display* display = layer->display;
 
+    /* Release any Cairo resources that were created around the external buffer,
+     * in case the details of the buffer have now changed */
+    if (context->buffer != layer->pending_frame.buffer) {
+        guac_display_layer_cairo_context* cairo_context = &(layer->pending_frame_cairo_context);
+        if (cairo_context->surface != NULL) {
+
+            /* NOTE: We do NOT flush any outstanding changes to the Cairo
+             * surface here, as the underlying buffer may already have been
+             * freed by the caller, and flushing the surface might write to
+             * that buffer */
+
+            cairo_surface_destroy(cairo_context->surface);
+            cairo_context->surface = NULL;
+
+            cairo_destroy(cairo_context->cairo);
+            cairo_context->cairo = NULL;
+
+        }
+    }
+
     /* Replace buffer if requested with an external buffer. This intentionally
      * falls through to the following buffer_is_external check to update the
      * buffer details. */
@@ -239,21 +259,13 @@ void guac_display_layer_close_raw(guac_display_layer* layer, guac_display_layer_
         if (height > GUAC_DISPLAY_MAX_HEIGHT)
             height = GUAC_DISPLAY_MAX_HEIGHT;
 
-        /* Release any Cairo surface that was created around the external
-         * buffer, in case the details of the buffer have now changed */
-        guac_display_layer_cairo_context* cairo_context = &(layer->pending_frame_cairo_context);
-        if (cairo_context->surface != NULL) {
-            cairo_surface_destroy(cairo_context->surface);
-            cairo_context->surface = NULL;
-        }
-
         layer->pending_frame.buffer = context->buffer;
         layer->pending_frame.buffer_width = width;
         layer->pending_frame.buffer_height = height;
         layer->pending_frame.buffer_stride = context->stride;
 
-        layer->pending_frame.width = layer->pending_frame.buffer_width;
-        layer->pending_frame.height = layer->pending_frame.buffer_height;
+        /* Update layer size and resize cell tracking array */
+        PFW_guac_display_layer_resize(layer, width, height);
 
     }
 

--- a/src/libguac/display-priv.h
+++ b/src/libguac/display-priv.h
@@ -609,6 +609,17 @@ struct guac_display_layer {
      */
     size_t pending_frame_cells_height;
 
+    /**
+     * The next layer within the list of layers that have been removed from
+     * the pending frame and are awaiting destruction, or NULL if this is the
+     * last such layer. This value is meaningful only for layers that have been
+     * removed from the pending frame layer list.
+     *
+     * IMPORTANT: The display-level pending_frame.lock MUST be acquired before
+     * modifying or reading this member.
+     */
+    guac_display_layer* next_removed;
+
 };
 
 typedef struct guac_display_state {
@@ -646,12 +657,13 @@ typedef struct guac_display_state {
      *  - NEXT: layer->pending_frame.next
      *  - PREV: layer->pending_frame.prev
      *
-     * Existing layers are deleted only at the time a frame is flushed when a
-     * layer in the last frame layer list is found to no longer exist in the
-     * pending frame layer list. The same goes for the addition of new layers:
-     * they are added only during flush when a layer that was not present in
-     * the last frame layer list is found to be present in the pending frame
-     * layer list.
+     * Layers are added to and removed from only the pending frame layer list.
+     * The last frame layer list is rebuilt from the pending frame layer list
+     * each time a frame is flushed, so an added or removed layer takes effect
+     * on the last frame only at that point. A removed layer is freed only
+     * after a flush has dropped it from the last frame layer list (see the
+     * pending_frame_removed_layers member of guac_display and
+     * guac_display_free_removed_layers()).
      */
     guac_display_layer* layers;
 
@@ -737,6 +749,16 @@ struct guac_display {
      * modifying or reading this member.
      */
     int pending_frame_dirty_excluding_mouse;
+
+    /**
+     * The head of the list of layers that have been removed from the pending
+     * frame but cannot be freed until the frame is flushed. This list is
+     * iterated via the next_removed member of guac_display_layer.
+     *
+     * IMPORTANT: The display-level pending_frame.lock MUST be acquired before
+     * modifying or reading this member.
+     */
+    guac_display_layer* pending_frame_removed_layers;
 
     /* ---------------- WELL-KNOWN LAYERS / BUFFERS ---------------- */
 
@@ -830,13 +852,32 @@ struct guac_display {
 guac_display_layer* guac_display_add_layer(guac_display* display, guac_layer* layer, int opaque);
 
 /**
- * Removes the given layer from all linked lists containing that layer and
- * frees all associated memory.
+ * Removes the given layer from the pending frame layer list. The layer is not
+ * immediately freed, but is instead scheduled to be freed via the
+ * pending_frame_removed_layers list of the display. It will finally be freed
+ * and removed from the last frame list when the frame is flushed.
  *
  * @param display_layer
  *     The layer to remove.
  */
 void guac_display_remove_layer(guac_display_layer* display_layer);
+
+/**
+ * Frees the list of layers that are awaiting removal from a previous call to
+ * guac_display_remove_layer(). This function is safe to call only after all
+ * removed layers are not part of any outstanding frame, including any
+ * operations that may not yet have been flushed by the worker threads.
+ *
+ * @param display
+ *     The display that the layers were removed from.
+ *
+ * @param removed_layers
+ *     The head of the list of removed layers to free, linked via the
+ *     next_removed member of guac_display_layer, or NULL if there are no such
+ *     layers.
+ */
+void guac_display_free_removed_layers(guac_display* display,
+        guac_display_layer* removed_layers);
 
 /**
  * Resizes the given layer to the given dimensions, including any underlying

--- a/src/libguac/display.c
+++ b/src/libguac/display.c
@@ -122,8 +122,8 @@ guac_display* guac_display_alloc(guac_client* client) {
     display->last_frame.timestamp = display->pending_frame.timestamp = guac_timestamp_current();
 
     /* It's safe to discard const of the default layer here, as
-     * guac_display_free_layer() function is specifically written to consider
-     * the default layer as const */
+     * guac_display_free_removed_layers() is specifically written to consider the
+     * default layer as const */
     display->default_layer = guac_display_add_layer(display, (guac_layer*) GUAC_DEFAULT_LAYER, 1);
     display->cursor_buffer = guac_display_alloc_buffer(display, 0);
 
@@ -218,15 +218,15 @@ void guac_display_free(guac_display* display) {
     guac_flag_destroy(&display->render_state);
     guac_fifo_destroy(&display->ops);
 
-    /* Free all layers within the pending_frame list (NOTE: This will also free
-     * those layers from the last_frame list) */
+    /* Remove any layers remaining in the pending frame (by definition, all other
+     * layers must already have been marked for removal) */
     while (display->pending_frame.layers != NULL)
         guac_display_free_layer(display->pending_frame.layers);
 
-    /* Free any remaining layers that were present only on the last_frame list
-     * and not on the pending_frame list */
-    while (display->last_frame.layers != NULL)
-        guac_display_free_layer(display->last_frame.layers);
+    /* All layers are now part of the pending_frame_removed_layers list and can
+     * be freed */
+    guac_display_free_removed_layers(display, display->pending_frame_removed_layers);
+    display->pending_frame_removed_layers = NULL;
 
     guac_rwlock_destroy(&display->last_frame.lock);
     guac_rwlock_destroy(&display->pending_frame.lock);
@@ -376,25 +376,5 @@ guac_display_layer* guac_display_alloc_buffer(guac_display* display, int opaque)
 }
 
 void guac_display_free_layer(guac_display_layer* display_layer) {
-
-    guac_display* display = display_layer->display;
-    const guac_layer* layer = display_layer->layer;
-
     guac_display_remove_layer(display_layer);
-
-    if (layer->index != 0) {
-
-        guac_client* client = display->client;
-        guac_protocol_send_dispose(client->socket, layer);
-
-        /* As long as this isn't the display layer, it's safe to cast away the
-         * constness and free the underlying layer/buffer. Only the default
-         * layer (layer #0) is truly const. */
-        if (layer->index > 0)
-            guac_client_free_layer(client, (guac_layer*) layer);
-        else
-            guac_client_free_buffer(client, (guac_layer*) layer);
-
-    }
-
 }

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -680,12 +680,6 @@ static int guac_rdp_handle_connection(guac_client* client) {
     guac_display_render_thread_destroy(rdp_client->render_thread);
     rdp_client->render_thread = NULL;
 
-    /* Remove reference to FreeRDP's GDI buffer so that it can be safely freed
-     * prior to freeing the guac_display */
-    guac_display_layer_raw_context* context = guac_display_layer_open_raw(default_layer);
-    context->buffer = NULL;
-    guac_display_layer_close_raw(default_layer, context);
-
     /* Ensure all background rendering processes are stopped before freeing
      * underlying memory */
     guac_display_stop(rdp_client->display);


### PR DESCRIPTION
This change corrects a set of issues that could produce the behavior described on GUACAMOLE-2118, mainly:

* `guac_display_frame_complete()` could loop infinitely when dealing with external buffers.
* Layers that were freed could still be referenced by unflushed ops. If that happens, the flushed frame could contain garbage.