### PR TITLE
GUACAMOLE-2118: Signal end of user input to connection processes.

### DIFF
--- a/src/guacd/connection.c
+++ b/src/guacd/connection.c
@@ -129,6 +129,16 @@ static void* guacd_connection_write_thread(void* data) {
             break;
     }
 
+    /* Signal end of input to the connection process. Without this, a user
+     * which vanishes without sending "disconnect" leaves that process blocked
+     * awaiting input indefinitely, as nothing further will inform it that its
+     * last user has left. */
+    if (shutdown(params->fd, SHUT_WR))
+        guacd_log(GUAC_LOG_ERROR, "Unable to signal end of user input to "
+                "connection process: %s. That process may remain running but "
+                "inactive, retaining the memory of its connection until guacd "
+                "is restarted.", strerror(errno));
+
     return NULL;
 
 }


### PR DESCRIPTION
Once no further data can be read from a user, the thread forwarding that user's input simply returns, leaving its end of the socketpair shared with the connection process open. A user which vanishes without sending "disconnect" therefore leaves that process blocked awaiting input indefinitely: nothing further informs it that its last user has left, so it never stops itself and never exits.

The thread reading from that process cannot detect this either, as it remains blocked on a socket which an idle process will never write to again, and so never reaches the point at which it would close its end.

Shut down the write side of the socketpair when no further user input is possible, such that the connection process observes end of input.