### PR TITLE
GUACAMOLE-2313: Disambiguate handling of lock modifiers and Mac-specific keys.

### DIFF
--- a/src/protocols/rdp/keyboard.c
+++ b/src/protocols/rdp/keyboard.c
@@ -482,9 +482,11 @@ unsigned int guac_rdp_keyboard_get_modifier_flags(guac_rdp_keyboard* keyboard) {
             || guac_rdp_keyboard_is_pressed(keyboard, GUAC_RDP_KEYSYM_RSHIFT))
         modifier_flags |= GUAC_RDP_KEYMAP_MODIFIER_SHIFT;
 
-    /* Dedicated AltGr key */
+    /* Dedicated AltGr/Option keys */
     if (guac_rdp_keyboard_is_pressed(keyboard, GUAC_RDP_KEYSYM_RALT)
-            || guac_rdp_keyboard_is_pressed(keyboard, GUAC_RDP_KEYSYM_ALTGR))
+            || guac_rdp_keyboard_is_pressed(keyboard, GUAC_RDP_KEYSYM_ALTGR)
+            || guac_rdp_keyboard_is_pressed(keyboard, GUAC_RDP_KEYSYM_LOPTION)
+            || guac_rdp_keyboard_is_pressed(keyboard, GUAC_RDP_KEYSYM_ROPTION))
         modifier_flags |= GUAC_RDP_KEYMAP_MODIFIER_ALTGR;
 
     /* AltGr via Ctrl+Alt */
@@ -634,6 +636,8 @@ void guac_rdp_keyboard_update_modifiers(guac_rdp_keyboard* keyboard,
         guac_rdp_keyboard_update_keysym(keyboard, GUAC_RDP_KEYSYM_RALT, 0, GUAC_RDP_KEY_SOURCE_SYNTHETIC);
         guac_rdp_keyboard_update_keysym(keyboard, GUAC_RDP_KEYSYM_LCTRL, 0, GUAC_RDP_KEY_SOURCE_SYNTHETIC);
         guac_rdp_keyboard_update_keysym(keyboard, GUAC_RDP_KEYSYM_RCTRL, 0, GUAC_RDP_KEY_SOURCE_SYNTHETIC);
+        guac_rdp_keyboard_update_keysym(keyboard, GUAC_RDP_KEYSYM_LOPTION, 0, GUAC_RDP_KEY_SOURCE_SYNTHETIC);
+        guac_rdp_keyboard_update_keysym(keyboard, GUAC_RDP_KEYSYM_ROPTION, 0, GUAC_RDP_KEY_SOURCE_SYNTHETIC);
     }
 
 }

--- a/src/protocols/rdp/keymap.h
+++ b/src/protocols/rdp/keymap.h
@@ -73,6 +73,17 @@
 #define GUAC_RDP_KEYSYM_RALT 0xFFEA
 
 /**
+ * The X11 keysym used by Guacamole for Left Option.
+ */
+#define GUAC_RDP_KEYSYM_LOPTION 0xFFED
+
+/**
+ * The X11 keysym used by Guacamole for Right Option.
+ */
+#define GUAC_RDP_KEYSYM_ROPTION 0xFFEE
+
+
+/**
  * The X11 keysym for AltGr.
  */
 #define GUAC_RDP_KEYSYM_ALTGR 0xFE03

--- a/src/protocols/rdp/keymaps/base.keymap
+++ b/src/protocols/rdp/keymaps/base.keymap
@@ -84,9 +84,14 @@ map      0x1D ~ 0xffe3 # Control_L
 map +ext 0x1D ~ 0xffe4 # Control_R
 map      0x38 ~ 0xffe9 # Alt_L
 map +ext 0x38 ~ 0xffea # Alt_R
-map +ext 0x5B ~ 0xffe7 # Meta_L
-map +ext 0x5C ~ 0xffe8 # Meta_R
-map +ext 0x5B ~ 0xffeb # Super_L
-map +ext 0x5C ~ 0xffec # Super_R
+map +ext 0x5B ~ 0xffe7 # Command_L
+map +ext 0x5C ~ 0xffe8 # Command_R
+map +ext 0x5B ~ 0xffeb # Super_L (Left "Windows" key)
+map +ext 0x5C ~ 0xffec # Super_R (Right "Windows" key)
 map +ext 0x5D ~ 0xff67 # Menu
+
+# NOTE: Option_L and Option_R are intentionally unmapped for the same reason
+# that AltGr is unmapped - mapping directly would mean mapping to Alt, which
+# may be interpreted by the RDP server as part of a keyboard shortcut instead
+# of normal typing (see base_altgr.keymap).
 

--- a/src/protocols/rdp/keymaps/base_altgr.keymap
+++ b/src/protocols/rdp/keymaps/base_altgr.keymap
@@ -22,4 +22,6 @@ name    "base_altgr"
 
 # Modifiers
 map +ext 0x38 ~ 0xfe03 # AltGr
+map +ext 0x38 ~ 0xffed # Option_L
+map +ext 0x38 ~ 0xffee # Option_R
 

--- a/src/protocols/vnc/input.c
+++ b/src/protocols/vnc/input.c
@@ -18,6 +18,7 @@
  */
 
 #include "display.h"
+#include "input.h"
 #include "vnc.h"
 
 #include <guacamole/display.h>
@@ -74,6 +75,47 @@ static int guac_vnc_translate_keysym(int keysym) {
 
 }
 
+/**
+ * Toggles the lock controlled by the given lock keysym within the VNC session
+ * by pressing and releasing that key. The key will be pressed/released only if
+ * the given lock flag is set within the reported lock key state.
+ *
+ * @param rfb_client
+ *     The VNC client to send key events through.
+ *
+ * @param led_state
+ *     The lock key state reported by the VNC server, as a bitmask of
+ *     rfbKeyboardMask* flags.
+ *
+ * @param led_mask
+ *     The single rfbKeyboardMask* flag to test.
+ *
+ * @param keysym
+ *     The keysym of the lock key that toggles the tested lock.
+ */
+static void guac_vnc_release_lock(rfbClient* rfb_client, int led_state,
+        int led_mask, int keysym) {
+    if (led_state & led_mask) {
+        SendKeyEvent(rfb_client, keysym, TRUE);
+        SendKeyEvent(rfb_client, keysym, FALSE);
+    }
+}
+
+void guac_vnc_keyboard_led_state(rfbClient* rfb_client, int state, int pad) {
+
+    guac_client* client = rfbClientGetClientData(rfb_client, GUAC_VNC_CLIENT_KEY);
+    guac_vnc_client* vnc_client = (guac_vnc_client*) client->data;
+
+    /* Clear lock states once we know which locks need to be cleared */
+    if (!vnc_client->lock_state_synced) {
+        guac_vnc_release_lock(rfb_client, state, rfbKeyboardMaskCapsLock,   0xFFE5 /* Caps_Lock */);
+        guac_vnc_release_lock(rfb_client, state, rfbKeyboardMaskNumLock,    0xFF7F /* Num_Lock */);
+        guac_vnc_release_lock(rfb_client, state, rfbKeyboardMaskScrollLock, 0xFF14 /* Scroll_Lock */);
+        vnc_client->lock_state_synced = 1;
+    }
+
+}
+
 int guac_vnc_user_key_handler(guac_user* user, int keysym, int pressed) {
 
     guac_vnc_client* vnc_client = (guac_vnc_client*) user->client->data;
@@ -85,8 +127,21 @@ int guac_vnc_user_key_handler(guac_user* user, int keysym, int pressed) {
                 keysym, pressed);
 
     /* Send VNC event only if finished connecting */
-    if (rfb_client != NULL)
+    if (rfb_client != NULL) {
+
+        /* Ensure the lock key state of the VNC session matches the
+         * all-released state assumed by connecting clients before any key
+         * events are forwarded */
+        if (!vnc_client->lock_state_synced) {
+            vnc_client->lock_state_synced = 1;
+            guac_client_log(user->client, GUAC_LOG_WARNING, "VNC server did "
+                "not report which lock keys are active. Client-side use of "
+                "Caps Lock, etc. may not match server-side lock state.");
+        }
+
         SendKeyEvent(rfb_client, guac_vnc_translate_keysym(keysym), pressed);
+
+    }
 
     return 0;
 }

--- a/src/protocols/vnc/input.c
+++ b/src/protocols/vnc/input.c
@@ -45,6 +45,35 @@ int guac_vnc_user_mouse_handler(guac_user* user, int x, int y, int mask) {
     return 0;
 }
 
+/**
+ * Translates the keysyms that Guacamole uses to represent platform-specific
+ * keys into the keysyms that established VNC clients conventionally send for
+ * those keys.
+ *
+ * @param keysym
+ *     The keysym received from the Guacamole client.
+ *
+ * @return
+ *     The keysym that should be sent to the VNC server.
+ */
+static int guac_vnc_translate_keysym(int keysym) {
+
+    switch (keysym) {
+
+        /* Command is conventionally sent as Super by VNC clients */
+        case 0xFFE7: return 0xFFEB; /* Command_L (Meta_L) -> Super_L */
+        case 0xFFE8: return 0xFFEC; /* Command_R (Meta_R) -> Super_R */
+
+        /* Option is conventionally sent as Alt by VNC clients */
+        case 0xFFED: return 0xFFE9; /* Option_L (Hyper_L) -> Alt_L */
+        case 0xFFEE: return 0xFFEA; /* Option_R (Hyper_R) -> Alt_R */
+
+    }
+
+    return keysym;
+
+}
+
 int guac_vnc_user_key_handler(guac_user* user, int keysym, int pressed) {
 
     guac_vnc_client* vnc_client = (guac_vnc_client*) user->client->data;
@@ -57,7 +86,7 @@ int guac_vnc_user_key_handler(guac_user* user, int keysym, int pressed) {
 
     /* Send VNC event only if finished connecting */
     if (rfb_client != NULL)
-        SendKeyEvent(rfb_client, keysym, pressed);
+        SendKeyEvent(rfb_client, guac_vnc_translate_keysym(keysym), pressed);
 
     return 0;
 }

--- a/src/protocols/vnc/input.h
+++ b/src/protocols/vnc/input.h
@@ -21,6 +21,7 @@
 #define GUAC_VNC_INPUT_H
 
 #include <guacamole/user.h>
+#include <rfb/rfbclient.h>
 
 /**
  * Handler for Guacamole user mouse events.
@@ -31,6 +32,22 @@ guac_user_mouse_handler guac_vnc_user_mouse_handler;
  * Handler for Guacamole user key events.
  */
 guac_user_key_handler guac_vnc_user_key_handler;
+
+/**
+ * Handler for lock key state (KeyboardLedState) updates received from the VNC
+ * server. Where supported, this is used to help ensure the client can assume all
+ * locks are inactive at connection start.
+ *
+ * @param client
+ *     The VNC client associated with the update.
+ *
+ * @param state
+ *     The reported lock key state, as a bitmask of rfbKeyboardMask flags.
+ *
+ * @param pad
+ *     Unused (reserved by libvncclient for future use).
+ */
+void guac_vnc_keyboard_led_state(rfbClient* client, int state, int pad);
 
 /**
  * Handler for Guacamole user resize events.

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -23,6 +23,7 @@
 #include "common/clipboard.h"
 #include "cursor.h"
 #include "display.h"
+#include "input.h"
 #include "log.h"
 #include "settings.h"
 #include "vnc.h"
@@ -241,6 +242,9 @@ rfbClient* guac_vnc_get_client(guac_client* client) {
     rfb_client->FinishedFrameBufferUpdate = guac_vnc_finished_frame;
     vnc_client->rfb_GotCopyRect = rfb_client->GotCopyRect;
     rfb_client->GotCopyRect = guac_vnc_copyrect;
+
+    /* Lock key state (KeyboardLedState) update handler */
+    rfb_client->HandleKeyboardLedState = guac_vnc_keyboard_led_state;
 
 #ifdef ENABLE_VNC_TLS_LOCKING
     /* TLS Locking and Unlocking */

--- a/src/protocols/vnc/vnc.h
+++ b/src/protocols/vnc/vnc.h
@@ -101,6 +101,13 @@ typedef struct guac_vnc_client {
     int finished_frame_logged;
 
     /**
+     * Whether the initial lock key state of the VNC session has been received
+     * and synchronized with the all-released state that connecting Guacamole
+     * clients assume.
+     */
+    int lock_state_synced;
+
+    /**
      * Client settings, parsed from args.
      */
     guac_vnc_settings* settings;

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -121,17 +121,22 @@ typedef enum guac_terminal_keysym {
     GUAC_KEYSYM_SHIFT_R = 0xFFE2,           /* Right Shift modifier key.                   */
     GUAC_KEYSYM_CTRL_L = 0xFFE3,            /* Left Control modifier key.                  */
     GUAC_KEYSYM_CTRL_R = 0xFFE4,            /* Right Control modifier key.                 */
-    GUAC_KEYSYM_META_L = 0xFFE7,            /* Left Meta modifier key.                     */
-    GUAC_KEYSYM_META_R = 0xFFE8,            /* Right Meta modifier key.                    */
+    GUAC_KEYSYM_COMMAND_L = 0xFFE7,         /* Left Command key (Mac-specific).            */
+    GUAC_KEYSYM_COMMAND_R = 0xFFE8,         /* Right Command key (Mac-specific).           */
     GUAC_KEYSYM_ALT_L = 0xFFE9,             /* Left Alt modifier key.                      */
     GUAC_KEYSYM_ALT_R = 0xFFEA,             /* Right Alt modifier key.                     */
-    GUAC_KEYSYM_SUPER_L = 0xFFEB,           /* Left Super key, such as Windows/Command.    */
-    GUAC_KEYSYM_SUPER_R = 0xFFEC,           /* Right Super key, such as Windows/Command.   */
-    GUAC_KEYSYM_HYPER_L = 0xFFED,           /* Left Hyper modifier key.                    */
-    GUAC_KEYSYM_HYPER_R = 0xFFEE,           /* Right Hyper modifier key.                   */
+    GUAC_KEYSYM_SUPER_L = 0xFFEB,           /* Left Super key ("OS" or "Windows" key).     */
+    GUAC_KEYSYM_SUPER_R = 0xFFEC,           /* Right Super key ("OS" or "Windows" key).    */
+    GUAC_KEYSYM_OPTION_L = 0xFFED,          /* Left Option key (Mac-specific).             */
+    GUAC_KEYSYM_OPTION_R = 0xFFEE,          /* Right Option key (Mac-specific).            */
     GUAC_KEYSYM_MODE_SWITCH = 0xFF7E,       /* Keyboard group or layout switch key.        */
-    GUAC_KEYSYM_ISO_LEVEL3_SHIFT = 0xFE03,  /* ISO Level 3 shift key, often AltGr/Option.  */
+    GUAC_KEYSYM_ALTGR = 0xFE03,             /* ISO Level 3 shift key (AltGr)               */
     GUAC_KEYSYM_ISO_LEVEL5_SHIFT = 0xFE11,  /* ISO Level 5 shift key.                      */
+
+    /* Lock keys */
+    GUAC_KEYSYM_CAPS_LOCK = 0xFFE5,         /* Caps Lock key.                              */
+    GUAC_KEYSYM_NUM_LOCK = 0xFF7F,          /* Num Lock key.                               */
+    GUAC_KEYSYM_SCROLL_LOCK = 0xFF14,       /* Scroll Lock key.                            */
 
     /* Arrow/navigation direction keys */
     GUAC_KEYSYM_LEFT = 0xFF51,              /* Left arrow key.                             */
@@ -1634,6 +1639,35 @@ static int __guac_terminal_is_editing_keysym(int keysym) {
 }
 
 /**
+ * Returns whether the given keysym is a modifier.
+ *
+ * @param keysym
+ *     The X11 keysym to test.
+ *
+ * @return
+ *     Non-zero if the keysym is a modifier, zero otherwise.
+ */
+static int __guac_terminal_is_modifier_keysym(int keysym) {
+    return (keysym >= GUAC_KEYSYM_SHIFT_L && keysym <= GUAC_KEYSYM_OPTION_R)
+        || keysym == GUAC_KEYSYM_ALTGR;
+}
+
+/**
+ * Returns whether the given keysym is a lock key.
+ *
+ * @param keysym
+ *     The X11 keysym to test.
+ *
+ * @return
+ *     Non-zero if the keysym is a lock key, zero otherwise.
+ */
+static int __guac_terminal_is_lock_keysym(int keysym) {
+    return keysym == GUAC_KEYSYM_CAPS_LOCK
+        || keysym == GUAC_KEYSYM_NUM_LOCK
+        || keysym == GUAC_KEYSYM_SCROLL_LOCK;
+}
+
+/**
  * Returns the xterm-style modifier parameter for CSI key sequences, encoding
  * the current modifier state of the terminal. The value is 1 plus the bitmask
  * of active modifiers: Shift=1, Alt=2, Ctrl=4, Meta=8.
@@ -1810,19 +1844,18 @@ static int __guac_terminal_send_key(guac_terminal* term, int keysym, int pressed
     }
 
     /*
-     * Super (Windows/Command) and Hyper are treated as Meta since terminals don't
-     * have separate modifier bits for them.
+     * Super (the "Windows" key) and Command are treated as Meta since
+     * terminals don't have separate modifier bits for them.
      *
-     * MODE_SWITCH and the ISO level selectors are intentionally not treated as
-     * Alt. On international layouts these are often used to produce printable
-     * third-/fifth-level characters, and folding them into Alt would inject an
-     * unwanted ESC prefix into normal text input.
+     * Option and AltGr are intentionally not treated as terminal-visible
+     * modifiers. These keys are used purely to compose printable characters
+     * and treating them as a modifiers would add unwanted console code
+     * sequences into otherwise normal text, breaking input.
      */
     if (keysym == GUAC_KEYSYM_CTRL_L || keysym == GUAC_KEYSYM_CTRL_R)
         term->mod_ctrl = pressed;
-    else if (keysym == GUAC_KEYSYM_META_L || keysym == GUAC_KEYSYM_META_R
-            || keysym == GUAC_KEYSYM_SUPER_L || keysym == GUAC_KEYSYM_SUPER_R
-            || keysym == GUAC_KEYSYM_HYPER_L || keysym == GUAC_KEYSYM_HYPER_R)
+    else if (keysym == GUAC_KEYSYM_COMMAND_L || keysym == GUAC_KEYSYM_COMMAND_R
+            || keysym == GUAC_KEYSYM_SUPER_L || keysym == GUAC_KEYSYM_SUPER_R)
         term->mod_meta = pressed;
     else if (keysym == GUAC_KEYSYM_ALT_L || keysym == GUAC_KEYSYM_ALT_R)
         term->mod_alt = pressed;
@@ -1867,9 +1900,12 @@ static int __guac_terminal_send_key(guac_terminal* term, int keysym, int pressed
 
         }
 
-        /* Reset scroll */
-        if (term->scroll_offset != 0)
+        /* Reset scroll, unless the pressed key produces no output (ie: is purely
+         * a modifier or lock key) */
+        if (term->scroll_offset != 0 && !__guac_terminal_is_modifier_keysym(keysym)
+                && !__guac_terminal_is_lock_keysym(keysym)) {
             guac_terminal_scroll_display_down(term, term->scroll_offset);
+        }
 
         /*
          * Modified arrows, function keys, and cursor editing keys encode Alt


### PR DESCRIPTION
This change is the server half of the changes proposed by https://github.com/apache/guacamole-client/pull/1238, adding handling for the Command/Option keysyms and ensuring keypresses of modifiers and locks do not cause the terminal to suddenly scroll down.