### PR TITLE
GUACAMOLE-2316: Allow the number of display worker threads per connection to be limited.

### DIFF
--- a/src/guacd-docker/bin/entrypoint.sh
+++ b/src/guacd-docker/bin/entrypoint.sh
@@ -5,6 +5,11 @@ if [ -n "$GUACD_LOG_LEVEL" ]; then
     echo "WARNING: The GUACD_LOG_LEVEL environment variable has been deprecated in favor of the LOG_LEVEL environment variable. Please migrate your configuration when possible." >&2
 fi
 
+# Limit the number of worker threads created per connection, if requested
+if [ -n "$MAX_WORKER_THREADS" ]; then
+    set -- -w "$MAX_WORKER_THREADS" "$@"
+fi
+
 # Listen on 0.0.0.0:4822, logging messages at the info level. Allow log level
 # to be overridden with LOG_LEVEL, and other behavior to be overridden with
 # additional command-line options passed to Docker.

--- a/src/guacd/conf-args.c
+++ b/src/guacd/conf-args.c
@@ -25,6 +25,7 @@
 #include <guacamole/string.h>
 
 #include <getopt.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -33,7 +34,7 @@ int guacd_conf_parse_args(guacd_config* config, int argc, char** argv) {
 
     /* Parse arguments */
     int opt;
-    while ((opt = getopt(argc, argv, "l:b:p:L:C:K:fv")) != -1) {
+    while ((opt = getopt(argc, argv, "l:b:p:L:C:K:w:fv")) != -1) {
 
         /* -l: Bind port */
         if (opt == 'l') {
@@ -77,6 +78,23 @@ int guacd_conf_parse_args(guacd_config* config, int argc, char** argv) {
 
         }
 
+        /* -w: Maximum number of worker threads per connection */
+        else if (opt == 'w') {
+
+            /* Validate and parse worker thread limit */
+            char* end;
+            long max_threads = strtol(optarg, &end, 10);
+            if (*optarg == '\0' || *end != '\0'
+                    || max_threads < 0 || max_threads > INT_MAX) {
+                fprintf(stderr, "Invalid maximum number of worker threads. "
+                        "The value must be a non-negative integer.\n");
+                return 1;
+            }
+
+            config->max_worker_threads = (int) max_threads;
+
+        }
+
 #ifdef ENABLE_SSL
         /* -C SSL certificate */
         else if (opt == 'C') {
@@ -111,6 +129,7 @@ int guacd_conf_parse_args(guacd_config* config, int argc, char** argv) {
                     " [-C CERTIFICATE_FILE]"
                     " [-K PEM_FILE]"
 #endif
+                    " [-w MAX_WORKER_THREADS]"
                     " [-f]"
                     " [-v]\n", argv[0]);
 

--- a/src/guacd/conf-file.c
+++ b/src/guacd/conf-file.c
@@ -27,6 +27,7 @@
 #include <guacamole/string.h>
 
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -59,6 +60,25 @@ static int guacd_conf_callback(const char* section, const char* param, const cha
             guac_mem_free(config->bind_port);
             config->bind_port = guac_strdup(value);
             return 0;
+        }
+
+        /* Maximum number of worker threads per connection */
+        else if (strcmp(param, "max_worker_threads") == 0) {
+
+            char* end;
+            long max_threads = strtol(value, &end, 10);
+
+            /* Invalid worker thread limit */
+            if (*value == '\0' || *end != '\0'
+                    || max_threads < 0 || max_threads > INT_MAX) {
+                guacd_conf_parse_error = "Maximum number of worker threads must be a non-negative integer";
+                return 1;
+            }
+
+            /* Valid worker thread limit */
+            config->max_worker_threads = (int) max_threads;
+            return 0;
+
         }
 
     }
@@ -187,6 +207,7 @@ guacd_config* guacd_conf_load(void) {
     conf->foreground = 0;
     conf->print_version = 0;
     conf->max_log_level = GUAC_LOG_INFO;
+    conf->max_worker_threads = 0;
 
 #ifdef ENABLE_SSL
     conf->cert_file = NULL;

--- a/src/guacd/conf.h
+++ b/src/guacd/conf.h
@@ -81,6 +81,13 @@ typedef struct guacd_config {
      */
     guac_client_log_level max_log_level;
 
+    /**
+     * The maximum number of worker threads that should be created to encode
+     * graphical updates for each connection, or zero if the number of worker
+     * threads should be limited only by the number of available processors.
+     */
+    int max_worker_threads;
+
 } guacd_config;
 
 #endif

--- a/src/guacd/connection.c
+++ b/src/guacd/connection.c
@@ -260,7 +260,8 @@ static int guacd_add_user(guacd_proc* proc, guac_parser* parser, guac_socket* so
  *     Zero if the connection was successfully routed, non-zero if routing has
  *     failed.
  */
-static int guacd_route_connection(guacd_proc_map* map, guac_socket* socket) {
+static int guacd_route_connection(guacd_proc_map* map, guac_socket* socket,
+        int max_display_worker_threads) {
 
     guac_parser* parser = guac_parser_alloc();
 
@@ -323,7 +324,7 @@ static int guacd_route_connection(guacd_proc_map* map, guac_socket* socket) {
                 identifier);
 
         /* Create new process */
-        proc = guacd_create_proc(identifier);
+        proc = guacd_create_proc(identifier, max_display_worker_threads);
         new_process = 1;
 
     }
@@ -423,7 +424,7 @@ void* guacd_connection_thread(void* data) {
 #endif
 
     /* Route connection according to Guacamole, creating a new process if needed */
-    if (guacd_route_connection(map, socket))
+    if (guacd_route_connection(map, socket, params->max_display_worker_threads))
         guac_socket_free(socket);
 
     guac_mem_free(params);

--- a/src/guacd/connection.h
+++ b/src/guacd/connection.h
@@ -36,6 +36,14 @@ typedef struct guacd_connection_thread_params {
      */
     guacd_proc_map* map;
 
+    /**
+     * The maximum number of worker threads that should be created to encode
+     * graphical updates for each connection, as configured for guacd, or
+     * zero if the number of worker threads should be limited only by the
+     * number of available processors.
+     */
+    int max_display_worker_threads;
+
 #ifdef ENABLE_SSL
     /**
      * SSL context for encrypted connections to guacd. If SSL is not active,

--- a/src/guacd/daemon.c
+++ b/src/guacd/daemon.c
@@ -353,6 +353,14 @@ int main(int argc, char* argv[]) {
     /* Log start */
     guacd_log(GUAC_LOG_INFO, "Guacamole proxy daemon (guacd) version " VERSION " started");
 
+    /* Log any configured limit on the number of worker threads created per
+     * connection (the limit is applied to the client of each connection
+     * process as it is created) */
+    if (config->max_worker_threads > 0)
+        guacd_log(GUAC_LOG_INFO, "Graphical updates of each connection will "
+                "be encoded using no more than %i worker thread(s).",
+                config->max_worker_threads);
+
     /* Get addresses for binding */
     if ((retval = getaddrinfo(config->bind_host, config->bind_port,
                     &hints, &addresses))) {
@@ -575,6 +583,7 @@ int main(int argc, char* argv[]) {
         }
 
         params->map = map;
+        params->max_display_worker_threads = config->max_worker_threads;
         params->connected_socket_fd = connected_socket_fd;
 
 #ifdef ENABLE_SSL

--- a/src/guacd/man/guacd.8.in
+++ b/src/guacd/man/guacd.8.in
@@ -29,6 +29,7 @@ guacd \- Guacamole proxy daemon
 [\fB-L\fR \fILOG LEVEL\fR]
 [\fB-C\fR \fICERTIFICATE FILE\fR]
 [\fB-K\fR \fIKEY FILE\fR]
+[\fB-w\fR \fIMAX WORKER THREADS\fR]
 [\fB-f\fR]
 [\fB-v\fR]
 .
@@ -75,6 +76,15 @@ and
 .B error.
 The default value is
 .B info.
+.TP
+\fB\-w\fR \fIMAX WORKER THREADS\fR
+Limits the number of worker threads that
+.B guacd
+will create to encode the graphical updates of each connection. By default,
+one worker thread is created per available processor, which can needlessly
+exhaust system resources on machines with very many processors serving many
+concurrent connections. A value of 0 (the default) imposes no limit beyond
+the number of available processors.
 .TP
 \fB\-f\fR
 Causes

--- a/src/guacd/man/guacd.8.in
+++ b/src/guacd/man/guacd.8.in
@@ -81,10 +81,13 @@ The default value is
 Limits the number of worker threads that
 .B guacd
 will create to encode the graphical updates of each connection. By default,
-one worker thread is created per available processor, which can needlessly
-exhaust system resources on machines with very many processors serving many
-concurrent connections. A value of 0 (the default) imposes no limit beyond
-the number of available processors.
+one worker thread is created per available processor, ensuring encoding
+throughput can scale with demand. As each connection has its own worker
+threads, deployments serving many concurrent connections on machines with
+very many processors may wish to limit the total number of threads created,
+trading peak encoding throughput of each connection for reduced resource
+usage. A value of 0 (the default) imposes no limit beyond the number of
+available processors.
 .TP
 \fB\-f\fR
 Causes

--- a/src/guacd/man/guacd.conf.5.in
+++ b/src/guacd/man/guacd.conf.5.in
@@ -106,10 +106,13 @@ will bind to port 4822.
 Limits the number of worker threads that
 .B guacd
 will create to encode the graphical updates of each connection. By default,
-one worker thread is created per available processor, which can needlessly
-exhaust system resources on machines with very many processors serving many
-concurrent connections. A value of 0 (the default) imposes no limit beyond
-the number of available processors.
+one worker thread is created per available processor, ensuring encoding
+throughput can scale with demand. As each connection has its own worker
+threads, deployments serving many concurrent connections on machines with
+very many processors may wish to limit the total number of threads created,
+trading peak encoding throughput of each connection for reduced resource
+usage. A value of 0 (the default) imposes no limit beyond the number of
+available processors.
 .
 .SH DAEMON PARAMETERS
 .TP

--- a/src/guacd/man/guacd.conf.5.in
+++ b/src/guacd/man/guacd.conf.5.in
@@ -101,6 +101,15 @@ Requires
 to bind to a specific port when listening for connections. By default,
 .B guacd
 will bind to port 4822.
+.TP
+\fBmax_worker_threads\fR \fB=\fR \fICOUNT\fR
+Limits the number of worker threads that
+.B guacd
+will create to encode the graphical updates of each connection. By default,
+one worker thread is created per available processor, which can needlessly
+exhaust system resources on machines with very many processors serving many
+concurrent connections. A value of 0 (the default) imposes no limit beyond
+the number of available processors.
 .
 .SH DAEMON PARAMETERS
 .TP

--- a/src/guacd/proc.c
+++ b/src/guacd/proc.c
@@ -550,7 +550,8 @@ static void guacd_close_inherited_fds(int keep_fd) {
 
 }
 
-guacd_proc* guacd_create_proc(const char* protocol) {
+guacd_proc* guacd_create_proc(const char* protocol,
+        int max_display_worker_threads) {
 
     int sockets[2];
 
@@ -583,6 +584,10 @@ guacd_proc* guacd_create_proc(const char* protocol) {
 
     /* Init logging */
     proc->client->log_handler = guacd_client_log;
+
+    /* Apply any configured limit on the number of worker threads created to
+     * encode graphical updates for this connection */
+    proc->client->max_display_worker_threads = max_display_worker_threads;
 
     /* Fork */
     proc->pid = fork();

--- a/src/guacd/proc.h
+++ b/src/guacd/proc.h
@@ -87,12 +87,18 @@ typedef struct guacd_proc {
  * @param protocol
  *     The protocol for which this process is client being created.
  *
+ * @param max_display_worker_threads
+ *     The maximum number of worker threads that should be created to encode
+ *     graphical updates for this connection, or zero if the number of worker
+ *     threads should be limited only by the number of available processors.
+ *
  * @return
  *     A newly-allocated process structure pointing to the file descriptor of
  *     the background process specific to the specified protocol, or NULL of
  *     the process could not be created.
  */
-guacd_proc* guacd_create_proc(const char* protocol);
+guacd_proc* guacd_create_proc(const char* protocol,
+        int max_display_worker_threads);
 
 /**
  * Signals the given process to stop accepting new users and clean up. This

--- a/src/libguac/display.c
+++ b/src/libguac/display.c
@@ -148,6 +148,18 @@ guac_display* guac_display_alloc(guac_client* client) {
     }
 
     display->worker_thread_count = cpu_count * GUAC_DISPLAY_CPU_THREAD_FACTOR;
+
+    /* Limit the number of worker threads if the client is configured with a
+     * maximum. Each connection has its own guac_display (and therefore its
+     * own set of worker threads), and a single display will rarely produce
+     * enough parallelizable work to occupy a large number of processors. On
+     * machines with very many processors, creating one thread per processor
+     * for each of many concurrent connections can needlessly exhaust system
+     * resources. */
+    if (client->max_display_worker_threads > 0
+            && display->worker_thread_count > client->max_display_worker_threads)
+        display->worker_thread_count = client->max_display_worker_threads;
+
     display->worker_threads = guac_mem_alloc(display->worker_thread_count, sizeof(pthread_t));
     guac_client_log(client, GUAC_LOG_INFO, "Graphical updates will be encoded "
             "using %i worker thread(s).", display->worker_thread_count);

--- a/src/libguac/display.c
+++ b/src/libguac/display.c
@@ -151,11 +151,12 @@ guac_display* guac_display_alloc(guac_client* client) {
 
     /* Limit the number of worker threads if the client is configured with a
      * maximum. Each connection has its own guac_display (and therefore its
-     * own set of worker threads), and a single display will rarely produce
-     * enough parallelizable work to occupy a large number of processors. On
-     * machines with very many processors, creating one thread per processor
-     * for each of many concurrent connections can needlessly exhaust system
-     * resources. */
+     * own set of worker threads), so the total number of threads created
+     * scales with both the number of processors and the number of concurrent
+     * connections. Deployments that need to bound that total (hosts with
+     * very many processors, containers with strict process/thread limits,
+     * etc.) can use this limit to trade peak per-connection encoding
+     * throughput for a bounded thread count. */
     if (client->max_display_worker_threads > 0
             && display->worker_thread_count > client->max_display_worker_threads)
         display->worker_thread_count = client->max_display_worker_threads;

--- a/src/libguac/guacamole/client.h
+++ b/src/libguac/guacamole/client.h
@@ -311,6 +311,16 @@ struct guac_client {
      */
     void* __plugin_handle;
 
+    /**
+     * The maximum number of worker threads that should be created to encode
+     * graphical updates for any guac_display allocated for this client, or
+     * zero (the default) if the number of worker threads should be limited
+     * only by the number of available processors. Negative values are
+     * treated as zero. To have any effect, this value must be assigned
+     * before the guac_display is allocated with guac_display_alloc().
+     */
+    int max_display_worker_threads;
+
 };
 
 /**

--- a/src/libguac/tests/Makefile.am
+++ b/src/libguac/tests/Makefile.am
@@ -41,6 +41,7 @@ noinst_HEADERS =                     \
 test_libguac_SOURCES =               \
     client/buffer_pool.c             \
     client/layer_pool.c              \
+    display/max_worker_threads.c     \
     fifo/fifo.c                      \
     file/openat.c                    \
     flag/flag.c                      \

--- a/src/libguac/tests/display/max_worker_threads.c
+++ b/src/libguac/tests/display/max_worker_threads.c
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "display-priv.h"
+
+#include <CUnit/CUnit.h>
+#include <guacamole/client.h>
+#include <guacamole/display.h>
+
+/**
+ * Allocates a guac_display for a newly-allocated guac_client configured with
+ * the given limit on the number of display worker threads, returning the
+ * number of worker threads that were created for that display. The
+ * guac_display and guac_client are both freed before this function returns.
+ *
+ * @param max_display_worker_threads
+ *     The value to assign to the max_display_worker_threads member of the
+ *     guac_client prior to allocating the guac_display.
+ *
+ * @return
+ *     The number of worker threads created for the allocated guac_display.
+ */
+static int get_worker_thread_count(int max_display_worker_threads) {
+
+    guac_client* client = guac_client_alloc();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(client);
+
+    client->max_display_worker_threads = max_display_worker_threads;
+
+    guac_display* display = guac_display_alloc(client);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(display);
+
+    int count = display->worker_thread_count;
+
+    guac_display_free(display);
+    guac_client_free(client);
+
+    return count;
+
+}
+
+/**
+ * Test which verifies that the max_display_worker_threads member of
+ * guac_client limits the number of worker threads created for that client's
+ * guac_display, and that no limit is imposed by default.
+ */
+void test_display__max_worker_threads(void) {
+
+    /* At least one worker thread should be created by default (a
+     * newly-allocated guac_client imposes no limit) */
+    int default_count = get_worker_thread_count(0);
+    CU_ASSERT(default_count >= 1);
+
+    /* A configured limit should cap the number of worker threads */
+    CU_ASSERT_EQUAL(get_worker_thread_count(1), 1);
+
+    /* A limit that exceeds the default thread count should have no effect
+     * (the limit can only reduce the number of threads created, not
+     * increase it) */
+    CU_ASSERT_EQUAL(get_worker_thread_count(default_count + 100), default_count);
+
+    /* Negative values should be treated as if no limit were set */
+    CU_ASSERT_EQUAL(get_worker_thread_count(-1), default_count);
+
+    /* The limit is per-client: a client configured with a limit must not
+     * affect the displays of other clients */
+    CU_ASSERT_EQUAL(get_worker_thread_count(1), 1);
+    CU_ASSERT_EQUAL(get_worker_thread_count(0), default_count);
+
+}


### PR DESCRIPTION
Adds a per-connection limit on the number of encoder worker threads created for each guac_display, configurable via max_worker_threads in guacd.conf, -w on the command line, and MAX_WORKER_THREADS in the Docker image.

The limit is stored on guac_client (appended to the struct) and read by guac_display_alloc(), so it transports from guacd across the protocol-plugin boundary without changing any existing public signature. Default 0 preserves current behavior.

See GUACAMOLE-2316 for the motivation and the open question about whether the default should stay 0/unlimited or become a finite value.