### PR TITLE
GUACAMOLE-2319: Fix SFTP symlink dirs shown as files when root is not system root.

### DIFF
--- a/src/common-ssh/common-ssh/sftp.h
+++ b/src/common-ssh/common-ssh/sftp.h
@@ -99,9 +99,17 @@ typedef struct guac_common_ssh_sftp_ls_state {
     LIBSSH2_SFTP_HANDLE* directory;
 
     /**
-     * The absolute path of the directory being listed.
+     * The absolute path of the directory being listed, as exposed to the
+     * client via the Guacamole protocol stream name.
      */
     char directory_name[GUAC_COMMON_SSH_SFTP_MAX_PATH];
+
+    /**
+     * The real, server-side filesystem path of the directory being listed,
+     * including any configured SFTP root prefix. Used to resolve symlinks
+     * during listing when the SFTP root is not "/".
+     */
+    char directory_real_path[GUAC_COMMON_SSH_SFTP_MAX_PATH];
 
     /**
      * The current state of the JSON directory object being written.

--- a/src/common-ssh/sftp.c
+++ b/src/common-ssh/sftp.c
@@ -649,8 +649,12 @@ static int guac_common_ssh_sftp_ls_ack_handler(guac_user* user,
         }
 
         /* Stat explicitly if symbolic link (might point to directory) */
-        if (LIBSSH2_SFTP_S_ISLNK(attributes.permissions))
-            libssh2_sftp_stat(sftp, absolute_path, &attributes);
+        if (LIBSSH2_SFTP_S_ISLNK(attributes.permissions)) {
+            char real_path[GUAC_COMMON_SSH_SFTP_MAX_PATH];
+            if (guac_ssh_append_filename(real_path,
+                        list_state->directory_real_path, filename))
+                libssh2_sftp_stat(sftp, real_path, &attributes);
+        }
 
         /* Determine mimetype */
         const char* mimetype;
@@ -790,6 +794,9 @@ static int guac_common_ssh_sftp_get_handler(guac_user* user,
             guac_mem_free(list_state);
             return 0;
         }
+
+        guac_strlcpy(list_state->directory_real_path, fullpath,
+                sizeof(list_state->directory_real_path));
 
         /* Allocate stream for body */
         guac_stream* stream = guac_user_alloc_stream(user);


### PR DESCRIPTION
When SFTP is enabled and the configured root directory is the system root, symlinked directories are listed and navigated correctly. The issue only occurs when a custom SFTP root directory is configured that is not the system root. In that case, symlinked directories appear as files in the side panel instead of folders.