### PR TITLE
GUACAMOLE-2324: Add tight back to encodings & disable JPEG by default

### DIFF
--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -136,7 +136,7 @@ enum VNC_ARGS_IDX {
      * Space-separated list of encodings to use within the VNC session. If not
      * specified, this will be:
      *
-     *     "zrle ultra copyrect hextile zlib corre rre raw".
+     *     "tight zrle ultra copyrect hextile zlib corre rre raw".
      */
     IDX_ENCODINGS,
 
@@ -550,7 +550,7 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
     settings->encodings =
         guac_user_parse_args_string(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_ENCODINGS,
-                "zrle ultra copyrect hextile zlib corre rre raw");
+                "tight zrle ultra copyrect hextile zlib corre rre raw");
 
     /* Parse autoretry */
     settings->retries =

--- a/src/protocols/vnc/settings.c
+++ b/src/protocols/vnc/settings.c
@@ -104,6 +104,7 @@ const char* GUAC_VNC_CLIENT_ARGS[] = {
     "force-lossless",
     "compress-level",
     "quality-level",
+    "allow-jpeg",
     NULL
 };
 
@@ -450,6 +451,13 @@ enum VNC_ARGS_IDX {
      */
     IDX_QUALITY_LEVEL,
 
+    /**
+     * "true" if the VNC client library should be allowed to negotiate
+     * JPEG compression (used by the "tight" encoding), "false" or blank otherwise.
+     * This will hurt guacamole's internal PNG compression. Off by default.
+     */
+    IDX_ALLOW_JPEG,
+
     VNC_ARGS_COUNT
 };
 
@@ -533,6 +541,11 @@ guac_vnc_settings* guac_vnc_parse_args(guac_user* user,
     settings->quality_level =
         guac_user_parse_args_int(user, GUAC_VNC_CLIENT_ARGS, argv,
                 IDX_QUALITY_LEVEL, -1);
+
+    /* Whether JPEG (as used by the "tight" encoding) may be negotiated */
+    settings->allow_jpeg =
+        guac_user_parse_args_boolean(user, GUAC_VNC_CLIENT_ARGS, argv,
+                IDX_ALLOW_JPEG, false);
 
 #ifdef ENABLE_VNC_REPEATER
     /* Set repeater parameters if specified */

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -107,6 +107,13 @@ typedef struct guac_vnc_settings {
       */
     int quality_level;
 
+    /**
+     * Whether the VNC client library should be allowed to negotiate
+     * JPEG-compression (as used by the "tight" encoding). This will
+     * hurt guacamole's internal PNG compression. Off by default.
+     */
+    bool allow_jpeg;
+
 #ifdef ENABLE_VNC_REPEATER
     /**
      * The VNC host to connect to, if using a repeater.

--- a/src/protocols/vnc/vnc.c
+++ b/src/protocols/vnc/vnc.c
@@ -341,6 +341,8 @@ rfbClient* guac_vnc_get_client(guac_client* client) {
     if (vnc_settings->encodings)
         rfb_client->appData.encodingsString = strdup(vnc_settings->encodings);
 
+    rfb_client->appData.enableJPEG = vnc_settings->allow_jpeg;
+
     /* Connect */
     if (rfbInitClient(rfb_client, NULL, NULL))
         return rfb_client;


### PR DESCRIPTION
We recently encountered some issues with users not being able to use our guacamole setup to connect to their VNC server. Apparently, their server only supported “tight” encoding. Per [this message from 2016](https://www.mail-archive.com/user@guacamole.incubator.apache.org/msg00007.html), this has been removed from the default encodings string in guacamole to prevent connections with JPEG compression in between, which hurts guacamole’s own PNG compression.

In libvncclient the default encodings string (which is used if not explicitly specified by the user) still includes “tight”.

In our case the user could explicitly ask for “tight” encoding and it would work, albeit with bad performance because indeed in this case JPEG was used by their server, because guacamole advertises this by default (because it is libvncclient’s default to allow JPEG).

This PR adds tight back to the default encodings string, and disables JPEG advertisement by default.

In our own tests our user could connect again without explicitly selecting tight, and the performance was now good.